### PR TITLE
fix: Resolve Vue console warnings across multiple pages

### DIFF
--- a/app/Http/Controllers/DataIntegrityController.php
+++ b/app/Http/Controllers/DataIntegrityController.php
@@ -162,7 +162,7 @@ class DataIntegrityController extends Controller
                     'description' => 'Active staff members who have no current unit assignment',
                     'count' => $staffWithoutUnitsCount,
                     'severity' => $staffWithoutUnitsCount > 0 ? 'error' : 'success',
-                    // 'route' => route('data-integrity.staff-without-units'),
+                    'route' => route('data-integrity.staff-without-units'),
                 ],
                 [
                     'id' => 'staff-without-ranks',

--- a/app/Http/Controllers/PromotionBatchController.php
+++ b/app/Http/Controllers/PromotionBatchController.php
@@ -206,7 +206,7 @@ class PromotionBatchController extends Controller
             'PromotionRank/Show',
             [
                 'promotions' => $staff,
-                'rank' => $request->rank,
+                'rank' => $rank->id,
                 'filters' => [
                     'search' => request()->search,
                     'year' => $year,

--- a/resources/js/Components/IntegrityCheckCard.vue
+++ b/resources/js/Components/IntegrityCheckCard.vue
@@ -25,7 +25,7 @@ const props = defineProps({
 		default: "success",
 		validator: (value) => ["success", "warning", "error"].includes(value),
 	},
-	route: {
+	href: {
 		type: String,
 		required: true,
 	},
@@ -61,7 +61,7 @@ const severityClasses = computed(() => {
 
 <template>
 	<Link
-		:href="route"
+		:href="href"
 		class="block rounded-lg border-2 p-6 transition-all hover:shadow-lg"
 		:class="[severityClasses.bg, severityClasses.border]"
 	>

--- a/resources/js/Components/Pagination.vue
+++ b/resources/js/Components/Pagination.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/24/outline";
-import { Link, router } from "@inertiajs/vue3";
+import { router } from "@inertiajs/vue3";
 const emit = defineEmits(["refreshData"]);
 const pageClicked = (link = null) => {
 	if (link) {
@@ -21,20 +21,28 @@ defineProps({
 		class="bg-white dark:bg-gray-800 px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6"
 	>
 		<div class="flex-1 flex justify-between sm:hidden">
-			<Link
-				:href="navigation.prev_page_url ?? 'null'"
-				preserve-scroll
-				class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 cursor-pointer"
+			<div
+				class="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white"
+				:class="
+					navigation.prev_page_url
+						? 'cursor-pointer hover:bg-gray-50'
+						: 'opacity-50 cursor-not-allowed'
+				"
+				@click="pageClicked(navigation.prev_page_url)"
 			>
 				Previous
-			</Link>
-			<Link
-				:href="navigation.next_page_url"
-				preserve-scroll
-				class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+			</div>
+			<div
+				class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white"
+				:class="
+					navigation.next_page_url
+						? 'cursor-pointer hover:bg-gray-50'
+						: 'opacity-50 cursor-not-allowed'
+				"
+				@click="pageClicked(navigation.next_page_url)"
 			>
 				Next
-			</Link>
+			</div>
 		</div>
 		<div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
 			<div>

--- a/resources/js/Pages/DataIntegrity/ExpiredActiveStatus.vue
+++ b/resources/js/Pages/DataIntegrity/ExpiredActiveStatus.vue
@@ -24,7 +24,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Expired Active Status",

--- a/resources/js/Pages/DataIntegrity/Index.vue
+++ b/resources/js/Pages/DataIntegrity/Index.vue
@@ -44,7 +44,7 @@ const breadcrumbLinks = [
 							:description="check.description"
 							:count="check.count"
 							:severity="check.severity"
-							:route="check.route"
+							:href="check.route"
 						/>
 					</div>
 				</div>

--- a/resources/js/Pages/DataIntegrity/InvalidDateRanges.vue
+++ b/resources/js/Pages/DataIntegrity/InvalidDateRanges.vue
@@ -28,7 +28,7 @@ const selectedStaff = ref(null);
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Invalid Date Ranges",

--- a/resources/js/Pages/DataIntegrity/MultipleRanks.vue
+++ b/resources/js/Pages/DataIntegrity/MultipleRanks.vue
@@ -28,7 +28,7 @@ const selectedStaff = ref(null);
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Multiple Active Ranks",

--- a/resources/js/Pages/DataIntegrity/MultipleUnitAssignments.vue
+++ b/resources/js/Pages/DataIntegrity/MultipleUnitAssignments.vue
@@ -18,7 +18,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Multiple Unit Assignments",

--- a/resources/js/Pages/DataIntegrity/PendingQualifications.vue
+++ b/resources/js/Pages/DataIntegrity/PendingQualifications.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Pending Qualifications",

--- a/resources/js/Pages/DataIntegrity/SeparatedButActive.vue
+++ b/resources/js/Pages/DataIntegrity/SeparatedButActive.vue
@@ -17,7 +17,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Separated but Active",

--- a/resources/js/Pages/DataIntegrity/StaffWithoutGender.vue
+++ b/resources/js/Pages/DataIntegrity/StaffWithoutGender.vue
@@ -14,7 +14,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Staff without Gender",

--- a/resources/js/Pages/DataIntegrity/StaffWithoutPictures.vue
+++ b/resources/js/Pages/DataIntegrity/StaffWithoutPictures.vue
@@ -23,7 +23,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Staff without Pictures",

--- a/resources/js/Pages/DataIntegrity/StaffWithoutRanks.vue
+++ b/resources/js/Pages/DataIntegrity/StaffWithoutRanks.vue
@@ -14,7 +14,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Staff without Ranks",

--- a/resources/js/Pages/DataIntegrity/StaffWithoutUnits.vue
+++ b/resources/js/Pages/DataIntegrity/StaffWithoutUnits.vue
@@ -14,7 +14,7 @@ const props = defineProps({
 const breadcrumbLinks = [
 	{
 		name: "Data Integrity",
-		href: route("data-integrity.index"),
+		url: route("data-integrity.index"),
 	},
 	{
 		name: "Staff without Units",

--- a/resources/js/Pages/Person/NewShow.vue
+++ b/resources/js/Pages/Person/NewShow.vue
@@ -17,11 +17,15 @@ import EditPersonForm from "@/Pages/Person/partials/EditPersonForm.vue";
 import RolesDetail from "./partials/RolesDetail.vue";
 
 let showEditForm = ref(false);
+let showPromotionForm = ref(false);
+let showTransferForm = ref(false);
 
 const page = usePage();
 const permissions = computed(() => page.props?.auth.permissions);
 
 let toggleEditForm = useToggle(showEditForm);
+let togglePromotionForm = useToggle(showPromotionForm);
+let toggleTransferForm = useToggle(showTransferForm);
 
 let props = defineProps({
 	person: { type: Object, required: true },
@@ -176,7 +180,7 @@ let BreadcrumbLinks = [
 							v-if="staff !== null && staff[0] !== null"
 							:promote="false"
 							:edit-promotion="false"
-							:promotions="staff[0].ranks"
+							:promotions="staff[0].ranks ?? []"
 							:staff="staff[0].staff_id"
 							:institution="staff[0].institution_id"
 							:show-promotion-form="showPromotionForm"
@@ -187,7 +191,7 @@ let BreadcrumbLinks = [
 							v-if="staff !== null && staff[0] !== null"
 							:transfer="false"
 							:edit-transfer="false"
-							:transfers="staff[0].units"
+							:transfers="staff[0].units ?? []"
 							:staff="staff[0].staff_id"
 							:staff-name="person.name"
 							:institution="staff[0].institution_id"

--- a/resources/js/Pages/PromotionRank/Show.vue
+++ b/resources/js/Pages/PromotionRank/Show.vue
@@ -13,14 +13,10 @@ const permissions = computed(() => page.props?.auth.permissions);
 let props = defineProps({
 	promotions: Object,
 	rank: {
-		type: String,
+		type: Number,
 		required: true,
 	},
 	filters: Object,
-	rank: {
-		type: String,
-		required: true,
-	},
 });
 
 let search = ref(props.filters.search);

--- a/resources/js/Pages/Role/partials/RolePermissions.vue
+++ b/resources/js/Pages/Role/partials/RolePermissions.vue
@@ -16,6 +16,8 @@ import {
 	MagnifyingGlassIcon,
 } from "@heroicons/vue/20/solid";
 
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits(["openRole"]);
 const props = defineProps({
 	permissions: {
@@ -100,7 +102,10 @@ const tableCols = computed(() => {
 </script>
 
 <template>
-	<section class="flex flex-col mt-6 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+	<section
+		v-bind="$attrs"
+		class="flex flex-col mt-6 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8"
+	>
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div class="mb-3 relative">
 				<div

--- a/resources/js/Pages/User/Show.vue
+++ b/resources/js/Pages/User/Show.vue
@@ -34,7 +34,6 @@ let breadcrumbLinks = [
 	{ name: "Dashboard", url: "/dashboard" },
 	{ name: "Users", url: "/user" },
 	{ name: props.user.name, url: null },
-	4, // { name: props.person.name, url: "/" },
 ];
 const page = usePage();
 const permissions = computed(() => {


### PR DESCRIPTION
## Summary
Sweeps out several long-standing Vue console warnings surfaced during everyday navigation. All fixes are minimal and preserve existing behavior; a couple also repair silent bugs (e.g. a pagination link navigating to `/null`, a next-promotions export receiving `[object Object]`).

## Warnings eliminated

- **Pagination (`Components/Pagination.vue`)** — mobile Prev/Next `<Link>` passed null/undefined `href` on first/last page. Replaced with the same `<div @click="pageClicked(...)">` pattern used by the desktop block, plus a disabled visual state. Also fixes a pre-existing broken link that navigated to `/null` on page 1.
- **`IntegrityCheckCard.vue`** — prop named `route` collided with Ziggy's global `route()` method (*"Methods property 'route' is already defined in Props"*). Renamed to `href`.
- **Data Integrity sub-pages (10 files)** — breadcrumb entries used `href:` but `BreadCrump.vue` reads `link.url`. Renamed to `url:` to match the rest of the codebase. Side-benefit: the Data Integrity breadcrumb link now actually works.
- **`DataIntegrityController.php`** — restored the `route` key for the `staff-without-units` check (was commented out), so its card renders with a valid href.
- **`Role/Show.vue` → `RolePermissions.vue`** — *"Extraneous non-props attributes (class) were passed ... could not be automatically inherited because component renders fragment"*. The component has two root elements (`<section>` + `<NewModal>`); added `defineOptions({ inheritAttrs: false })` and explicit `v-bind="$attrs"` on the `<section>`.
- **`User/Show.vue`** — stray `4,` entry in `breadcrumbLinks` pushed the current-user entry out of the terminal-text branch into a `<Link :href="null">`. Removed.
- **`Person/NewShow.vue`** — template bound `showPromotionForm` / `togglePromotionForm` / `showTransferForm` / `toggleTransferForm` but none were declared in `<script setup>`. Declared them matching the existing `showEditForm` / `useToggle` pattern. Also guarded `staff[0].ranks` / `staff[0].units` with `?? []` to satisfy required Array props on `PromotionHistory` / `TransferHistory`.
- **`next-promotions` show page** — backend passed `$request->rank` (resolves to the full `Job` model via route-model binding) to the frontend, which declared `rank` as `String` (and twice, duplicate key). Changed backend to `$rank->id`, frontend prop to `Number`, removed duplicate declaration. Also fixes the silent `?rank=[object Object]` that the export URL was building.

## Test plan
- [ ] `/data-integrity` — no `href` warnings on index; breadcrumb link back from any sub-page works.
- [ ] Unit / User / Role index pages with pagination — no `href` warning on first/last page; mobile Prev/Next disabled visual on boundaries.
- [ ] `/role/{role}` — no fragment/inheritance warning; `RolePermissions` still receives its `w-full xl:flex-1` classes.
- [ ] `/user/{user}` — breadcrumbs render correctly; no `href: null` warning.
- [ ] `/person/{person}` — no "accessed during render but is not defined" warning; no promotions/transfers Array warning even when staff has no rank/unit history.
- [ ] `/next-promotions/{rank}/{year?}` — no rank-prop warning; Export to Excel still works (URL contains a numeric `?rank=`).
- [ ] `php artisan test` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)