### PR TITLE
Remove unnecessary edit buttons from person show page

### DIFF
--- a/resources/js/Pages/Person/Summary.vue
+++ b/resources/js/Pages/Person/Summary.vue
@@ -44,7 +44,7 @@ const props = defineProps({
 						</div>
 					</dd>
 				</div>
-				<div class="flex-none self-end px-6 pt-4">
+				<!-- <div class="flex-none self-end px-6 pt-4">
 					<Link
 						v-if="permissions?.includes('view staff')"
 						:href="'/person/' + person.id"
@@ -52,7 +52,7 @@ const props = defineProps({
 					>
 						View
 					</Link>
-				</div>
+				</div> -->
 
 				<div
 					class="mt-4 flex w-full flex-none gap-x-4 px-6 pt-6 border-t border-gray-900/5 dark:border-gray-200/30"

--- a/resources/js/Pages/Person/partials/StaffDetails.vue
+++ b/resources/js/Pages/Person/partials/StaffDetails.vue
@@ -33,7 +33,7 @@ defineProps({
 					</dt>
 				</div>
 				<div class="flex-none self-end px-6 pt-4">
-					<Link
+					<!-- <Link
 						v-if="
 							permissions?.includes('update staff') ||
 							permissions?.includes('delete staff')
@@ -42,7 +42,7 @@ defineProps({
 						class="rounded-md bg-green-50 dark:bg-gray-400 px-2 py-1 text-xs font-medium text-green-600 dark:text-gray-50 ring-1 ring-inset ring-green-600/20 dark:ring-gray-500"
 					>
 						Edit
-					</Link>
+					</Link> -->
 				</div>
 				<div class="mt-4 w-full border-t pt-6 px-6 flex gap-5 justify-between">
 					<div


### PR DESCRIPTION
## Summary
- Removes unnecessary edit buttons from the Person show page (`Summary.vue` and `StaffDetails.vue` partial).

## Test plan
- [ ] Visit a person's show page and confirm the removed edit buttons no longer render
- [ ] Confirm remaining edit affordances still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)