### PR TITLE
fix: SQLite-compatible index check in qualifications report migration

### DIFF
--- a/database/migrations/2026_04_14_000000_add_report_indexes_to_qualifications.php
+++ b/database/migrations/2026_04_14_000000_add_report_indexes_to_qualifications.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -28,20 +27,22 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('qualifications', function (Blueprint $table) {
-            $table->dropIndex('qualifications_level_status_index');
-            $table->dropIndex('qualifications_status_approved_at_index');
-            $table->dropIndex('qualifications_year_index');
-            $table->dropIndex('qualifications_institution_index');
+            foreach ([
+                'qualifications_level_status_index',
+                'qualifications_status_approved_at_index',
+                'qualifications_year_index',
+                'qualifications_institution_index',
+            ] as $index) {
+                if ($this->hasIndex('qualifications', $index)) {
+                    $table->dropIndex($index);
+                }
+            }
         });
     }
 
     private function hasIndex(string $table, string $index): bool
     {
-        $db = DB::getDatabaseName();
-
-        return DB::selectOne(
-            'SELECT COUNT(*) AS c FROM information_schema.statistics WHERE table_schema = ? AND table_name = ? AND index_name = ?',
-            [$db, $table, $index]
-        )->c > 0;
+        return collect(Schema::getIndexes($table))
+            ->contains(fn (array $existing) => $existing['name'] === $index);
     }
 };


### PR DESCRIPTION
## Summary
- The `2026_04_14_000000_add_report_indexes_to_qualifications` migration used a raw `information_schema.statistics` query (MySQL-only) to check index existence. CI runs on SQLite, so `migrate:fresh` blew up and **every** Unit + Feature test failed with `QueryException` (see run [24461871415](https://github.com/judedanbo/hr/actions/runs/24461871415)).
- Replaced with `Schema::getIndexes()`, which is driver-agnostic.
- Made `down()` idempotent by gating each `dropIndex` behind the same check.

## Test plan
- [x] `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test tests/Unit/PersonTest.php` — migrations complete; 26/29 pass (the 3 remaining failures are an unrelated pre-existing `monthname()` MySQL-ism in a search scope, not part of this fix).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)