### PR TITLE
Redesign qualification report KPIs with reusable StatCard + filter-responsive values

### DIFF
--- a/app/Http/Controllers/QualificationReportController.php
+++ b/app/Http/Controllers/QualificationReportController.php
@@ -134,15 +134,20 @@ class QualificationReportController extends Controller
     /** @return array<string, array<string, int|null>> */
     private function kpis(QualificationReportFilter $filter): array
     {
-        $activeStaff = InstitutionPerson::query()->whereNull('end_date')->count();
-        $pendingStats = $this->service->pendingApprovalsStats();
+        $activeStaff = $this->service->activeStaffCount($filter);
+        $pendingStats = $this->service->pendingApprovalsStats($filter);
+
+        $filtered = fn () => $this->service->applyFilter(Qualification::query(), $filter);
+        $filteredDefaultApproved = fn () => $filter->status
+            ? $filtered()
+            : $filtered()->approved();
 
         return [
             'totalQualifications' => [
-                'value' => Qualification::query()->approved()->count(),
+                'value' => $filteredDefaultApproved()->count(),
             ],
             'staffCovered' => [
-                'value' => Qualification::query()->approved()->distinct('person_id')->count('person_id'),
+                'value' => $filteredDefaultApproved()->distinct('person_id')->count('person_id'),
                 'total' => $activeStaff,
             ],
             'pending' => [

--- a/app/Http/Controllers/QualificationReportController.php
+++ b/app/Http/Controllers/QualificationReportController.php
@@ -131,14 +131,28 @@ class QualificationReportController extends Controller
         ];
     }
 
-    /** @return array<string, int> */
+    /** @return array<string, array<string, int|null>> */
     private function kpis(QualificationReportFilter $filter): array
     {
+        $activeStaff = InstitutionPerson::query()->whereNull('end_date')->count();
+        $pendingStats = $this->service->pendingApprovalsStats();
+
         return [
-            'totalQualifications' => Qualification::query()->approved()->count(),
-            'staffCovered' => Qualification::query()->approved()->distinct('person_id')->count('person_id'),
-            'pending' => $this->service->pendingApprovalsStats()['count'],
-            'withoutQualifications' => $this->service->staffWithoutQualifications($filter)->count(),
+            'totalQualifications' => [
+                'value' => Qualification::query()->approved()->count(),
+            ],
+            'staffCovered' => [
+                'value' => Qualification::query()->approved()->distinct('person_id')->count('person_id'),
+                'total' => $activeStaff,
+            ],
+            'pending' => [
+                'value' => $pendingStats['count'],
+                'oldestDays' => $pendingStats['oldestDays'] ?? null,
+            ],
+            'withoutQualifications' => [
+                'value' => $this->service->staffWithoutQualifications($filter)->count(),
+                'total' => $activeStaff,
+            ],
         ];
     }
 

--- a/app/Services/QualificationReportService.php
+++ b/app/Services/QualificationReportService.php
@@ -5,9 +5,11 @@ namespace App\Services;
 use App\DataTransferObjects\QualificationReportFilter;
 use App\Enums\QualificationLevelEnum;
 use App\Enums\QualificationStatusEnum;
+use App\Models\InstitutionPerson;
 use App\Models\Qualification;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -359,16 +361,18 @@ class QualificationReportService
     /**
      * @return array{count: int, sparkline: array<int, int>, oldestDays: int|null} 30-day daily submissions, newest last; oldestDays is whole days since earliest pending record.
      */
-    public function pendingApprovalsStats(): array
+    public function pendingApprovalsStats(?QualificationReportFilter $filter = null): array
     {
-        return $this->remember('pendingApprovalsStats', new QualificationReportFilter, function () {
-            $count = Qualification::query()->pending()->count();
+        $scope = $this->filterForPending($filter);
+
+        return $this->remember('pendingApprovalsStats', $scope, function () use ($scope) {
+            $count = $this->applyFilter(Qualification::query(), $scope)->pending()->count();
 
             $since = now()->subDays(29)->startOfDay();
-            $daily = Qualification::query()
+            $daily = $this->applyFilter(Qualification::query(), $scope)
                 ->pending()
-                ->where('created_at', '>=', $since)
-                ->selectRaw('DATE(created_at) AS d, COUNT(*) AS n')
+                ->where('qualifications.created_at', '>=', $since)
+                ->selectRaw('DATE(qualifications.created_at) AS d, COUNT(*) AS n')
                 ->groupBy('d')
                 ->pluck('n', 'd');
 
@@ -378,13 +382,71 @@ class QualificationReportService
                 $sparkline[] = (int) ($daily[$date] ?? 0);
             }
 
-            $oldest = Qualification::query()->pending()->min('created_at');
+            $oldest = $this->applyFilter(Qualification::query(), $scope)->pending()->min('qualifications.created_at');
             $oldestDays = $oldest
-                ? (int) \Illuminate\Support\Carbon::parse($oldest)->diffInDays(now())
+                ? (int) Carbon::parse($oldest)->diffInDays(now())
                 : null;
 
             return ['count' => $count, 'sparkline' => $sparkline, 'oldestDays' => $oldestDays];
         });
+    }
+
+    /**
+     * Strip the status clause from the filter so the pending KPI keeps its
+     * "pending" meaning even when the rest of the report is filtered by a
+     * different status (e.g. Approved). Other clauses — dept/unit/year/etc. —
+     * still narrow the count.
+     */
+    private function filterForPending(?QualificationReportFilter $filter): QualificationReportFilter
+    {
+        if ($filter === null) {
+            return new QualificationReportFilter;
+        }
+
+        return new QualificationReportFilter(
+            unitId: $filter->unitId,
+            departmentId: $filter->departmentId,
+            level: $filter->level,
+            status: null,
+            yearFrom: $filter->yearFrom,
+            yearTo: $filter->yearTo,
+            gender: $filter->gender,
+            jobCategoryId: $filter->jobCategoryId,
+            institution: $filter->institution,
+            course: $filter->course,
+        );
+    }
+
+    /**
+     * Count of active staff (InstitutionPerson with no end_date), optionally
+     * narrowed by the filter's department_id / unit_id. Serves as the
+     * denominator for "covered / without quals" percentages in the KPI row.
+     */
+    public function activeStaffCount(?QualificationReportFilter $filter = null): int
+    {
+        $query = InstitutionPerson::query()->whereNull('end_date');
+
+        if ($filter?->unitId) {
+            $unitId = $filter->unitId;
+            $query->whereExists(function ($q) use ($unitId) {
+                $q->select(DB::raw(1))
+                    ->from('staff_unit')
+                    ->whereColumn('staff_unit.staff_id', 'institution_person.id')
+                    ->whereNull('staff_unit.end_date')
+                    ->where('staff_unit.unit_id', $unitId);
+            });
+        } elseif ($filter?->departmentId) {
+            $descendants = $this->unitDescendantIds($filter->departmentId);
+            $query->whereExists(function ($q) use ($descendants) {
+                $q->select(DB::raw(1))
+                    ->from('staff_unit')
+                    ->whereColumn('staff_unit.staff_id', 'institution_person.id')
+                    ->whereNull('staff_unit.end_date')
+                    ->whereIn('staff_unit.unit_id', $descendants);
+            });
+        }
+
+        return $query->count();
     }
 
     /**

--- a/app/Services/QualificationReportService.php
+++ b/app/Services/QualificationReportService.php
@@ -123,18 +123,42 @@ class QualificationReportService
      */
     public function staffWithoutQualifications(QualificationReportFilter $filter): \Illuminate\Support\Collection
     {
-        return $this->remember('staffWithoutQualifications', $filter, function () {
-            return \App\Models\Person::query()
-                ->whereExists(function ($q) {
-                    $q->select(\Illuminate\Support\Facades\DB::raw(1))
+        return $this->remember('staffWithoutQualifications', $filter, function () use ($filter) {
+            $query = \App\Models\Person::query()
+                ->whereExists(function ($q) use ($filter) {
+                    $q->select(DB::raw(1))
                         ->from('institution_person')
                         ->whereColumn('institution_person.person_id', 'people.id')
                         ->whereNull('institution_person.end_date');
+
+                    if ($filter->unitId) {
+                        $q->whereExists(function ($sq) use ($filter) {
+                            $sq->select(DB::raw(1))
+                                ->from('staff_unit')
+                                ->whereColumn('staff_unit.staff_id', 'institution_person.id')
+                                ->whereNull('staff_unit.end_date')
+                                ->where('staff_unit.unit_id', $filter->unitId);
+                        });
+                    } elseif ($filter->departmentId) {
+                        $descendants = $this->unitDescendantIds($filter->departmentId);
+                        $q->whereExists(function ($sq) use ($descendants) {
+                            $sq->select(DB::raw(1))
+                                ->from('staff_unit')
+                                ->whereColumn('staff_unit.staff_id', 'institution_person.id')
+                                ->whereNull('staff_unit.end_date')
+                                ->whereIn('staff_unit.unit_id', $descendants);
+                        });
+                    }
                 })
                 ->whereDoesntHave('qualifications', function ($q) {
                     $q->where('status', QualificationStatusEnum::Approved);
-                })
-                ->get();
+                });
+
+            if ($filter->gender) {
+                $query->where('people.gender', $filter->gender);
+            }
+
+            return $query->get();
         });
     }
 
@@ -443,6 +467,16 @@ class QualificationReportService
                     ->whereColumn('staff_unit.staff_id', 'institution_person.id')
                     ->whereNull('staff_unit.end_date')
                     ->whereIn('staff_unit.unit_id', $descendants);
+            });
+        }
+
+        if ($filter?->gender) {
+            $gender = $filter->gender;
+            $query->whereExists(function ($q) use ($gender) {
+                $q->select(DB::raw(1))
+                    ->from('people')
+                    ->whereColumn('people.id', 'institution_person.person_id')
+                    ->where('people.gender', $gender);
             });
         }
 

--- a/app/Services/QualificationReportService.php
+++ b/app/Services/QualificationReportService.php
@@ -357,7 +357,7 @@ class QualificationReportService
     }
 
     /**
-     * @return array{count: int, sparkline: array<int, int>} 30-day daily submissions, newest last.
+     * @return array{count: int, sparkline: array<int, int>, oldestDays: int|null} 30-day daily submissions, newest last; oldestDays is whole days since earliest pending record.
      */
     public function pendingApprovalsStats(): array
     {
@@ -378,7 +378,12 @@ class QualificationReportService
                 $sparkline[] = (int) ($daily[$date] ?? 0);
             }
 
-            return ['count' => $count, 'sparkline' => $sparkline];
+            $oldest = Qualification::query()->pending()->min('created_at');
+            $oldestDays = $oldest
+                ? (int) \Illuminate\Support\Carbon::parse($oldest)->diffInDays(now())
+                : null;
+
+            return ['count' => $count, 'sparkline' => $sparkline, 'oldestDays' => $oldestDays];
         });
     }
 

--- a/docs/superpowers/plans/2026-04-16-qualification-report-stats-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-qualification-report-stats-redesign.md
@@ -1,0 +1,638 @@
+# Qualification Report — Stats Section Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the four duplicated KPI card markup blocks on the qualification report index with a single uniform, reusable `StatCard` Vue component, and enrich the KPI payload with percentages, a sparkline for trend-over-time, and an "oldest pending" age signal.
+
+**Architecture:** A presentational `StatCard.vue` component accepts `label`, `value`, `icon`, `accent`, `secondary`, `trend`, `sparkline` props and renders a dark-mode-aware card with a static Tailwind accent map. Backend changes reshape `QualificationReportController::kpis()` from flat ints to per-KPI objects, and extend `QualificationReportService::pendingApprovalsStats()` to add an `oldestDays` key. `trendByYear` (already computed) is reused as the sparkline series on the Total card.
+
+**Tech Stack:** Laravel 11 (PHP 8.4), Vue 3 + Inertia v1, Tailwind v3, Heroicons v2, PHPUnit 11. Spec: `docs/superpowers/specs/2026-04-16-qualification-report-stats-redesign-design.md`.
+
+**Branch:** `feature/qualifications-stats-redesign` (already created, spec committed).
+
+---
+
+## File map
+
+- **Create:** `resources/js/Components/StatCard.vue` — new reusable KPI card.
+- **Modify:** `app/Services/QualificationReportService.php:362-383` — extend `pendingApprovalsStats()` with `oldestDays`.
+- **Modify:** `app/Http/Controllers/QualificationReportController.php:135-143` — reshape `kpis()`.
+- **Modify:** `resources/js/Pages/Qualification/Reports/Index.vue:401-450` — replace KPI block with `StatCard` instances + computed helpers.
+- **Modify:** `tests/Feature/QualificationReports/ServiceAggregationsTest.php:153-173` — extend existing pending-stats tests + add `oldestDays` cases.
+- **Modify:** `tests/Feature/QualificationReports/IndexPageTest.php:26-45` — assert new `kpis` shape.
+
+Note: `pendingApprovalsStats()` is also called from `QualificationDashboardController::widgets()` and `DataIntegrityController` — both consume the whole array, so **adding** an `oldestDays` key is backward compatible; no changes needed there.
+
+---
+
+## Task 1: Service — add `oldestDays` to `pendingApprovalsStats()`
+
+**Files:**
+- Modify: `app/Services/QualificationReportService.php:362-383`
+- Modify test: `tests/Feature/QualificationReports/ServiceAggregationsTest.php:153-173`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append two new tests at the end of the class in `tests/Feature/QualificationReports/ServiceAggregationsTest.php` (just before the closing `}`). Keep the existing `test_pending_approvals_stats_returns_count_and_sparkline` and `test_pending_approvals_sparkline_reflects_today_submissions` tests untouched — we only add to them.
+
+Add these tests (and add the `Carbon` import at the top of the file: `use Illuminate\Support\Carbon;` — check existing imports first; if `Carbon` is already imported, skip that line):
+
+```php
+public function test_pending_approvals_stats_includes_oldest_days_null_when_no_pending(): void
+{
+    Qualification::factory()->approved()->count(2)->create();
+
+    $result = app(QualificationReportService::class)->pendingApprovalsStats();
+
+    $this->assertSame(0, $result['count']);
+    $this->assertNull($result['oldestDays']);
+}
+
+public function test_pending_approvals_stats_returns_oldest_days_for_oldest_pending(): void
+{
+    Carbon::setTestNow('2026-04-16 12:00:00');
+
+    Qualification::factory()->pending()->create(['created_at' => now()->subDays(3)]);
+    Qualification::factory()->pending()->create(['created_at' => now()->subDays(10)]);
+    Qualification::factory()->pending()->create(['created_at' => now()->subDays(1)]);
+
+    $result = app(QualificationReportService::class)->pendingApprovalsStats();
+
+    $this->assertSame(3, $result['count']);
+    $this->assertSame(10, $result['oldestDays']);
+
+    Carbon::setTestNow();
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php artisan test --filter='pending_approvals_stats_includes_oldest_days_null_when_no_pending|pending_approvals_stats_returns_oldest_days_for_oldest_pending'`
+
+Expected: FAIL — `Failed asserting that null matches expected 'oldestDays'` / missing array key `oldestDays`.
+
+- [ ] **Step 3: Extend the service method**
+
+Edit `app/Services/QualificationReportService.php`. Replace the entire `pendingApprovalsStats()` method (lines 359-383) with:
+
+```php
+/**
+ * @return array{count: int, sparkline: array<int, int>, oldestDays: int|null} 30-day daily submissions, newest last; oldestDays is whole days since earliest pending record.
+ */
+public function pendingApprovalsStats(): array
+{
+    return $this->remember('pendingApprovalsStats', new QualificationReportFilter, function () {
+        $count = Qualification::query()->pending()->count();
+
+        $since = now()->subDays(29)->startOfDay();
+        $daily = Qualification::query()
+            ->pending()
+            ->where('created_at', '>=', $since)
+            ->selectRaw('DATE(created_at) AS d, COUNT(*) AS n')
+            ->groupBy('d')
+            ->pluck('n', 'd');
+
+        $sparkline = [];
+        for ($i = 29; $i >= 0; $i--) {
+            $date = now()->subDays($i)->toDateString();
+            $sparkline[] = (int) ($daily[$date] ?? 0);
+        }
+
+        $oldest = Qualification::query()->pending()->min('created_at');
+        $oldestDays = $oldest
+            ? (int) \Illuminate\Support\Carbon::parse($oldest)->diffInDays(now())
+            : null;
+
+        return ['count' => $count, 'sparkline' => $sparkline, 'oldestDays' => $oldestDays];
+    });
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `php artisan test --filter='pending_approvals_stats_includes_oldest_days_null_when_no_pending|pending_approvals_stats_returns_oldest_days_for_oldest_pending'`
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full pending-stats test group to confirm existing tests still pass**
+
+Run: `php artisan test --filter='pending_approvals'`
+
+Expected: PASS (all four pending-stats tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+./vendor/bin/pint --dirty
+git add app/Services/QualificationReportService.php tests/Feature/QualificationReports/ServiceAggregationsTest.php
+git commit -m "feat: return oldestDays from pendingApprovalsStats"
+```
+
+---
+
+## Task 2: Controller — reshape `kpis()` payload
+
+**Files:**
+- Modify: `app/Http/Controllers/QualificationReportController.php:135-143`
+- Modify test: `tests/Feature/QualificationReports/IndexPageTest.php:26-45`
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `tests/Feature/QualificationReports/IndexPageTest.php`. Replace the `test_user_with_permission_can_view_page` method with the expanded version below (keep `test_authenticated_user_without_permission_is_denied` untouched). Add the necessary imports at the top if missing: `use App\Models\InstitutionPerson;` and `use App\Models\Qualification;`.
+
+```php
+public function test_user_with_permission_can_view_page(): void
+{
+    $user = User::factory()->create();
+    $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+    $this->actingAs($user->fresh())
+        ->get('/qualifications/reports')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Qualification/Reports/Index')
+            ->has('levelDistribution')
+            ->has('byUnit')
+            ->has('topInstitutions')
+            ->has('trendByYear')
+            ->has('staffList')
+            ->has('kpis.totalQualifications.value')
+            ->has('kpis.staffCovered.value')
+            ->has('kpis.staffCovered.total')
+            ->has('kpis.pending.value')
+            ->has('kpis.pending.oldestDays')
+            ->has('kpis.withoutQualifications.value')
+            ->has('kpis.withoutQualifications.total')
+            ->has('filterOptions')
+            ->has('filters')
+        );
+}
+
+public function test_kpis_payload_carries_active_staff_total_and_numeric_values(): void
+{
+    $user = User::factory()->create();
+    $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+    // 3 active staff, 1 separated
+    InstitutionPerson::factory()->count(3)->create(['end_date' => null]);
+    InstitutionPerson::factory()->create(['end_date' => now()->subMonth()]);
+
+    $this->actingAs($user->fresh())
+        ->get('/qualifications/reports')
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('kpis.staffCovered.total', 3)
+            ->where('kpis.withoutQualifications.total', 3)
+            ->where('kpis.pending.oldestDays', null)
+        );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php artisan test --filter='IndexPageTest'`
+
+Expected: FAIL — property `kpis.totalQualifications.value` missing (because current shape is `kpis.totalQualifications` → int, not an object).
+
+- [ ] **Step 3: Replace the `kpis()` method in the controller**
+
+Edit `app/Http/Controllers/QualificationReportController.php`. Replace the entire `kpis()` method (lines 134-143) with:
+
+```php
+/** @return array<string, array<string, int|null>> */
+private function kpis(QualificationReportFilter $filter): array
+{
+    $activeStaff = InstitutionPerson::query()->whereNull('end_date')->count();
+    $pendingStats = $this->service->pendingApprovalsStats();
+
+    return [
+        'totalQualifications' => [
+            'value' => Qualification::query()->approved()->count(),
+        ],
+        'staffCovered' => [
+            'value' => Qualification::query()->approved()->distinct('person_id')->count('person_id'),
+            'total' => $activeStaff,
+        ],
+        'pending' => [
+            'value' => $pendingStats['count'],
+            'oldestDays' => $pendingStats['oldestDays'] ?? null,
+        ],
+        'withoutQualifications' => [
+            'value' => $this->service->staffWithoutQualifications($filter)->count(),
+            'total' => $activeStaff,
+        ],
+    ];
+}
+```
+
+The `InstitutionPerson` import is already present at the top of this file (line 8) — no new use statement needed.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `php artisan test --filter='IndexPageTest'`
+
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the full qualification-report test group to confirm no regressions**
+
+Run: `php artisan test --filter='QualificationReports'`
+
+Expected: PASS (all tests in `tests/Feature/QualificationReports/`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+./vendor/bin/pint --dirty
+git add app/Http/Controllers/QualificationReportController.php tests/Feature/QualificationReports/IndexPageTest.php
+git commit -m "feat: reshape qualification report kpis payload"
+```
+
+---
+
+## Task 3: Create the `StatCard.vue` component
+
+**Files:**
+- Create: `resources/js/Components/StatCard.vue`
+
+This task has no unit-test step — the repo has no Vue test harness and the component is presentational. Visual verification is covered in Task 5.
+
+- [ ] **Step 1: Create the file**
+
+Create `resources/js/Components/StatCard.vue` with this exact content:
+
+```vue
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	label: { type: String, required: true },
+	value: { type: [Number, String], required: true },
+	icon: { type: Object, default: null },
+	accent: {
+		type: String,
+		default: "slate",
+		validator: (v) => ["indigo", "emerald", "amber", "red", "slate"].includes(v),
+	},
+	secondary: { type: String, default: null },
+	trend: { type: Object, default: null }, // { direction: 'up'|'down'|'flat', text: string }
+	sparkline: { type: Array, default: null },
+});
+
+const accentClasses = {
+	indigo: {
+		border: "border-indigo-500 dark:border-indigo-400",
+		iconBg: "bg-indigo-50 dark:bg-indigo-900/40",
+		iconText: "text-indigo-600 dark:text-indigo-300",
+		spark: "#6366f1",
+	},
+	emerald: {
+		border: "border-emerald-500 dark:border-emerald-400",
+		iconBg: "bg-emerald-50 dark:bg-emerald-900/40",
+		iconText: "text-emerald-600 dark:text-emerald-300",
+		spark: "#059669",
+	},
+	amber: {
+		border: "border-amber-500 dark:border-amber-400",
+		iconBg: "bg-amber-50 dark:bg-amber-900/40",
+		iconText: "text-amber-600 dark:text-amber-300",
+		spark: "#d97706",
+	},
+	red: {
+		border: "border-red-500 dark:border-red-400",
+		iconBg: "bg-red-50 dark:bg-red-900/40",
+		iconText: "text-red-600 dark:text-red-300",
+		spark: "#dc2626",
+	},
+	slate: {
+		border: "border-slate-400 dark:border-slate-500",
+		iconBg: "bg-slate-100 dark:bg-slate-800",
+		iconText: "text-slate-600 dark:text-slate-300",
+		spark: "#64748b",
+	},
+};
+
+const accentCfg = computed(() => accentClasses[props.accent] ?? accentClasses.slate);
+
+const formattedValue = computed(() => {
+	if (typeof props.value === "number") return props.value.toLocaleString();
+	return props.value;
+});
+
+const sparklinePath = computed(() => {
+	const series = props.sparkline;
+	if (!Array.isArray(series) || series.length < 2) return null;
+	const max = Math.max(...series);
+	const min = Math.min(...series);
+	const range = max - min || 1;
+	const stepX = 100 / (series.length - 1);
+	return series
+		.map((v, i) => {
+			const x = (i * stepX).toFixed(2);
+			const y = (22 - ((v - min) / range) * 20).toFixed(2);
+			return `${i === 0 ? "" : " "}${x},${y}`;
+		})
+		.join("");
+});
+
+const trendClasses = computed(() => {
+	if (!props.trend) return "";
+	switch (props.trend.direction) {
+		case "up":
+			return "bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300";
+		case "down":
+			return "bg-red-50 dark:bg-red-900/40 text-red-700 dark:text-red-300";
+		default:
+			return "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300";
+	}
+});
+</script>
+
+<template>
+	<div
+		class="bg-white dark:bg-gray-800 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700 p-4 border-l-4"
+		:class="accentCfg.border"
+	>
+		<div class="flex items-start justify-between gap-2">
+			<div
+				class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-medium"
+			>
+				{{ label }}
+			</div>
+			<div
+				v-if="icon"
+				class="h-8 w-8 rounded-md flex items-center justify-center flex-shrink-0"
+				:class="accentCfg.iconBg"
+				:aria-label="label"
+			>
+				<component :is="icon" class="h-4 w-4" :class="accentCfg.iconText" />
+			</div>
+		</div>
+		<div class="mt-2 text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+			{{ formattedValue }}
+		</div>
+		<svg
+			v-if="sparklinePath"
+			class="mt-2 w-full h-6"
+			viewBox="0 0 100 22"
+			preserveAspectRatio="none"
+			aria-hidden="true"
+		>
+			<polyline
+				fill="none"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				:stroke="accentCfg.spark"
+				:points="sparklinePath"
+			/>
+		</svg>
+		<div
+			v-if="secondary"
+			class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+		>
+			{{ secondary }}
+		</div>
+		<div v-if="trend" class="mt-2">
+			<span
+				class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+				:class="trendClasses"
+			>
+				<span v-if="trend.direction === 'up'">↑</span>
+				<span v-else-if="trend.direction === 'down'">↓</span>
+				<span v-else>→</span>
+				{{ trend.text }}
+			</span>
+		</div>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Run lint to confirm file parses cleanly**
+
+Run: `npm run lint -- resources/js/Components/StatCard.vue`
+
+Expected: PASS (no errors).
+
+If the lint command doesn't accept a file argument on this project, just run `npm run lint` and confirm no new warnings reference `StatCard.vue`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/StatCard.vue
+git commit -m "feat: add reusable StatCard component"
+```
+
+---
+
+## Task 4: Wire `StatCard` into the qualification report index
+
+**Files:**
+- Modify: `resources/js/Pages/Qualification/Reports/Index.vue`
+
+- [ ] **Step 1: Add imports in the `<script setup>` block**
+
+Open `resources/js/Pages/Qualification/Reports/Index.vue`. Locate the existing import block at the top (lines 1-16). Add these imports below the existing imports (before `const props = defineProps(...)` on line 18):
+
+```js
+import StatCard from "@/Components/StatCard.vue";
+import {
+	AcademicCapIcon,
+	UserGroupIcon,
+	ClockIcon,
+	ExclamationTriangleIcon,
+} from "@heroicons/vue/24/outline";
+```
+
+- [ ] **Step 2: Add derived-display computed refs**
+
+In the same `<script setup>`, add the following block immediately after the `activeFilters` computed (after the closing `});` on line 152, before `function removeFilter(key)` on line 154):
+
+```js
+const sparklineSeries = computed(() => {
+	const t = props.trendByYear ?? {};
+	const entries = Object.entries(t)
+		.map(([year, count]) => [Number(year), Number(count)])
+		.filter(([y, c]) => Number.isFinite(y) && Number.isFinite(c))
+		.sort((a, b) => a[0] - b[0]);
+	if (entries.length < 2) return null;
+	return entries.map(([, c]) => c);
+});
+
+const sparklineSummary = computed(() => {
+	const series = sparklineSeries.value;
+	if (!series) return null;
+	const first = series[0];
+	const last = series[series.length - 1];
+	if (first === 0) return `${series.length} yrs of history`;
+	const pct = (((last - first) / first) * 100).toFixed(0);
+	const sign = pct >= 0 ? "+" : "";
+	return `${sign}${pct}% over ${series.length} yrs`;
+});
+
+const coveredSecondary = computed(() => {
+	const total = props.kpis?.staffCovered?.total ?? 0;
+	const value = props.kpis?.staffCovered?.value ?? 0;
+	if (total === 0) return null;
+	return `${((value / total) * 100).toFixed(1)}% of active staff`;
+});
+
+const gapsSecondary = computed(() => {
+	const total = props.kpis?.withoutQualifications?.total ?? 0;
+	const value = props.kpis?.withoutQualifications?.value ?? 0;
+	if (total === 0) return null;
+	return `${((value / total) * 100).toFixed(1)}% of active staff`;
+});
+
+const pendingSecondary = computed(() => {
+	const value = props.kpis?.pending?.value ?? 0;
+	if (value === 0) return "None pending";
+	const totalQuals = props.kpis?.totalQualifications?.value ?? 0;
+	const pct = totalQuals > 0 ? ((value / totalQuals) * 100).toFixed(1) : null;
+	const oldest = props.kpis?.pending?.oldestDays;
+	const parts = [];
+	if (pct !== null) parts.push(`${pct}% of total`);
+	if (oldest !== null && oldest !== undefined) {
+		parts.push(oldest === 0 ? "oldest today" : `oldest ${oldest}d`);
+	}
+	return parts.join(" · ") || null;
+});
+```
+
+- [ ] **Step 3: Replace the old KPI grid block in the template**
+
+In the `<template>`, locate the existing KPI grid block at lines 401-450 (the `<div class="grid grid-cols-2 md:grid-cols-4 gap-4">` containing four duplicated card divs). Replace the entire block — from the opening `<div class="grid ...` on line 401 through its closing `</div>` on line 450 — with:
+
+```vue
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+    <StatCard
+        label="Total Qualifications"
+        :value="kpis.totalQualifications.value"
+        :icon="AcademicCapIcon"
+        accent="indigo"
+        :sparkline="sparklineSeries"
+        :secondary="sparklineSummary"
+    />
+    <StatCard
+        label="Staff Covered"
+        :value="kpis.staffCovered.value"
+        :icon="UserGroupIcon"
+        accent="emerald"
+        :secondary="coveredSecondary"
+    />
+    <StatCard
+        label="Pending"
+        :value="kpis.pending.value"
+        :icon="ClockIcon"
+        accent="amber"
+        :secondary="pendingSecondary"
+    />
+    <StatCard
+        label="Staff Without Quals"
+        :value="kpis.withoutQualifications.value"
+        :icon="ExclamationTriangleIcon"
+        accent="red"
+        :secondary="gapsSecondary"
+    />
+</div>
+```
+
+- [ ] **Step 4: Run frontend lint**
+
+Run: `npm run lint`
+
+Expected: PASS (no errors related to `Index.vue` or `StatCard.vue`).
+
+- [ ] **Step 5: Run the index page feature test to confirm backend + frontend still integrate**
+
+Run: `php artisan test --filter='IndexPageTest'`
+
+Expected: PASS.
+
+- [ ] **Step 6: Start the dev server and visually verify**
+
+Open two terminals:
+
+```bash
+# Terminal 1
+php artisan serve
+```
+
+```bash
+# Terminal 2
+npm run dev
+```
+
+Then in a browser, log in as a user with `qualifications.reports.view` and `qualifications.reports.view.all` permissions and visit `/qualifications/reports`.
+
+Verify:
+- Four cards render in one row on desktop (≥768px), two columns on tablet (640-768px), single column below 640px.
+- Left border color is distinct per card (indigo / emerald / amber / red).
+- Icon tile shows in the top-right corner of each card with matching tinted background.
+- Total Qualifications shows a small sparkline below the value (only if 2+ trend years of data exist).
+- Staff Covered and Staff Without Quals show `"X.X% of active staff"`.
+- Pending shows `"X.X% of total · oldest Nd"` when there are pending records, or `"None pending"` when there are none.
+- Toggle dark mode (if the app has a toggle — otherwise inspect via DevTools adding `class="dark"` to `<html>`): all text, backgrounds, borders, and accents remain legible with correct dark variants.
+
+If any of these fail, fix the issue and re-run steps 4 and 5.
+
+- [ ] **Step 7: Commit**
+
+```bash
+./vendor/bin/pint --dirty
+git add resources/js/Pages/Qualification/Reports/Index.vue
+git commit -m "feat: use StatCard in qualification report stats row"
+```
+
+---
+
+## Task 5: Final quality gate
+
+- [ ] **Step 1: Run the full qualification-reports test group**
+
+Run: `php artisan test --filter='QualificationReports'`
+
+Expected: PASS (all tests — both existing and new).
+
+- [ ] **Step 2: Run the full application test suite**
+
+Run: `php artisan test`
+
+Expected: PASS (no regressions introduced elsewhere).
+
+- [ ] **Step 3: Run Pint on any remaining dirty files**
+
+Run: `./vendor/bin/pint --dirty`
+
+Expected: `No lint errors found` or "x files fixed". If files are fixed, commit them:
+
+```bash
+git add -u
+git commit -m "chore: pint formatting"
+```
+
+- [ ] **Step 4: Run ESLint + Prettier**
+
+Run: `npm run lint && npm run format`
+
+Expected: PASS.
+
+If Prettier reformats files, commit them:
+
+```bash
+git add -u
+git commit -m "chore: prettier formatting"
+```
+
+- [ ] **Step 5: Summarise the branch state**
+
+Run: `git log --oneline main..HEAD`
+
+Expected at least these commits on `feature/qualifications-stats-redesign`:
+1. `docs: spec for qualification report stats section redesign` (pre-existing)
+2. `docs: implementation plan for stats redesign` (added in the plan-commit step below)
+3. `feat: return oldestDays from pendingApprovalsStats`
+4. `feat: reshape qualification report kpis payload`
+5. `feat: add reusable StatCard component`
+6. `feat: use StatCard in qualification report stats row`
+7. Optional formatting commits from steps 3-4 of this task
+
+The branch is now ready to open as a pull request. Do NOT push or create the PR unless the user explicitly asks.

--- a/docs/superpowers/specs/2026-04-16-qualification-report-stats-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-16-qualification-report-stats-redesign-design.md
@@ -1,0 +1,205 @@
+# Qualification Report — Stats Section Redesign
+
+**Date:** 2026-04-16
+**Branch:** `feature/qualifications-stats-redesign`
+**Page affected:** `resources/js/Pages/Qualification/Reports/Index.vue`
+
+## Goal
+
+Replace the four duplicated KPI card markup blocks in the qualification report index with a single uniform, reusable `StatCard` component. Add richer secondary context (percentages, a sparkline on totals, and an age signal on pending) while respecting the application's existing dark-mode theme and visual language (ring + shadow + rounded-lg pattern used elsewhere on the page).
+
+## Scope
+
+**In scope**
+
+- New generic component `resources/js/Components/StatCard.vue`.
+- Re-shape `QualificationReportController::kpis()` to return richer data (value + derived context per KPI).
+- Extend `QualificationReportService::pendingApprovalsStats()` to also return `oldestDays`.
+- Wire the new component into `Qualification/Reports/Index.vue` with derived display strings for each card.
+- Update/add feature tests asserting the new `kpis` payload shape.
+- Dark-mode support matching existing `dark:` usage on the page.
+
+**Out of scope**
+
+- Retrofitting `StatCard` into other report pages (Recruitment, etc.) — the component is built to be reusable, but this PR only uses it on the qualification report.
+- Click-to-filter behavior on cards (Option B from brainstorming). The component leaves room for `@click` but the consumer will not wire it in this change.
+- Visual or data changes to any chart below the KPI row.
+
+## Component design
+
+### `resources/js/Components/StatCard.vue`
+
+A presentational Vue 3 `<script setup>` component. Single root element.
+
+**Props**
+
+| Prop | Type | Required | Default | Purpose |
+| --- | --- | --- | --- | --- |
+| `label` | `String` | yes | — | Uppercase caption shown above the value. |
+| `value` | `Number \| String` | yes | — | Primary metric. If numeric, rendered via `toLocaleString()`. |
+| `icon` | `Object` (Vue component) | no | `null` | Heroicon component shown in the top-right icon tile. |
+| `accent` | `'indigo' \| 'emerald' \| 'amber' \| 'red' \| 'slate'` | no | `'slate'` | Drives left-border color and icon tile tint. |
+| `secondary` | `String` | no | `null` | Small grey text under the value (e.g. "93.3% of active staff"). |
+| `trend` | `{ direction: 'up' \| 'down' \| 'flat', text: String }` | no | `null` | Optional colored trend chip below the secondary line. |
+| `sparkline` | `Array<Number>` | no | `null` | Optional inline SVG sparkline drawn at the width of the card. |
+
+**Visual structure**
+
+- Outer: `bg-white dark:bg-gray-800 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700 p-4 border-l-4`.
+- Left border color: mapped from `accent` (e.g. indigo-500 in light mode, indigo-400 in dark mode).
+- Flex column inside: label row (label + icon tile right-aligned) → value → optional sparkline → optional secondary line → optional trend chip.
+- Icon tile: `h-8 w-8 rounded-md` with tinted background (`bg-indigo-50 dark:bg-indigo-900/40` etc.) and the Heroicon rendered with `text-{accent}-600 dark:text-{accent}-300`.
+- Sparkline: small SVG with `<polyline>`, stroke matches accent, height ~24px, width 100%, `preserveAspectRatio="none"`.
+- Trend chip: colored pill; green for `up`, red for `down`, grey for `flat`.
+
+**Tailwind JIT constraint**
+
+Dynamic class names like `text-${accent}-600` are purged by Tailwind. Resolve via a static class map in the component (`const accentClasses = { indigo: { border: 'border-indigo-500 dark:border-indigo-400', iconBg: 'bg-indigo-50 dark:bg-indigo-900/40', iconText: 'text-indigo-600 dark:text-indigo-300', spark: '#6366f1' }, ... }`). All classes in the map are plain string literals so the JIT scanner picks them up.
+
+**Accessibility**
+
+- Card root has no interactive role (presentational).
+- `aria-label` on the icon tile contains the same text as `label` so screen readers don't read the icon separately.
+- Sparkline is decorative: `aria-hidden="true"`. The essential info is duplicated in `secondary` text.
+
+## Backend data changes
+
+### `QualificationReportController::kpis()`
+
+Current shape (flat ints):
+
+```php
+[
+    'totalQualifications'   => int,
+    'staffCovered'          => int,
+    'pending'               => int,
+    'withoutQualifications' => int,
+]
+```
+
+New shape:
+
+```php
+[
+    'totalQualifications'   => ['value' => int],
+    'staffCovered'          => ['value' => int, 'total' => int],
+    'pending'               => ['value' => int, 'oldestDays' => int | null],
+    'withoutQualifications' => ['value' => int, 'total' => int],
+]
+```
+
+`total` on `staffCovered` and `withoutQualifications` is the count of `InstitutionPerson::whereNull('end_date')` (active staff), computed once and reused for both. When `total` is `0`, the frontend falls back to rendering only the raw value without a percentage line (guards against divide-by-zero).
+
+### `QualificationReportService::pendingApprovalsStats()`
+
+Today the method returns `['count' => int]`. Extend it to also return `oldestDays` — the integer number of whole days between `now()` and the earliest `created_at` across pending qualifications, or `null` if there are no pending records.
+
+Implementation sketch:
+
+```php
+$oldest = Qualification::query()->pending()->min('created_at');
+return [
+    'count'      => $count,
+    'oldestDays' => $oldest ? Carbon::parse($oldest)->diffInDays(now()) : null,
+];
+```
+
+If `pendingApprovalsStats()` is called elsewhere (grep before implementing), verify those callers tolerate the extra key — an associative array with an added key is backward-compatible for array-access consumers.
+
+### Sparkline data source
+
+The page already receives `trendByYear` from the controller. We reuse it as the sparkline series on the Total Qualifications card — no new backend call is needed. A `computed()` in the Vue page extracts an ordered array of counts (chronologically sorted by year) and a short summary string like `"+8% over <n> years"` derived from first vs last value. If `trendByYear` has fewer than 2 points, omit the sparkline entirely and fall back to secondary text only.
+
+## Page wiring — `Qualification/Reports/Index.vue`
+
+Replace the existing KPI grid block (currently lines 401–450 — four duplicated `<div class="bg-white ...">` cards) with:
+
+```vue
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+  <StatCard
+    label="Total Qualifications"
+    :value="kpis.totalQualifications.value"
+    :icon="AcademicCapIcon"
+    accent="indigo"
+    :sparkline="sparklineSeries"
+    :secondary="sparklineSummary"
+  />
+  <StatCard
+    label="Staff Covered"
+    :value="kpis.staffCovered.value"
+    :icon="UserGroupIcon"
+    accent="emerald"
+    :secondary="coveredSecondary"
+  />
+  <StatCard
+    label="Pending"
+    :value="kpis.pending.value"
+    :icon="ClockIcon"
+    accent="amber"
+    :secondary="pendingSecondary"
+  />
+  <StatCard
+    label="Staff Without Quals"
+    :value="kpis.withoutQualifications.value"
+    :icon="ExclamationTriangleIcon"
+    accent="red"
+    :secondary="gapsSecondary"
+  />
+</div>
+```
+
+### Derived display strings (computed refs in `<script setup>`)
+
+- `coveredSecondary` — `"${pct}% of active staff"` where `pct = (covered / total * 100).toFixed(1)`. If `total === 0`, returns `null`.
+- `gapsSecondary` — same formula for `withoutQualifications`. Returns `null` if `total === 0`.
+- `pendingSecondary` — `"${pct}% of total"` plus `" · oldest ${oldestDays}d"` when `oldestDays` is non-null. If pending is zero, returns `"None pending"`.
+- `sparklineSeries` — `Object.entries(trendByYear).sort(...).map(([,n]) => n)`, or `null` if fewer than 2 data points.
+- `sparklineSummary` — `"+${pct}% over ${years} years"` computed from first vs last value in series, or `null` when series is absent.
+
+All computeds are null-safe against missing props.
+
+### Grid responsiveness
+
+- `< 640px` (mobile): 1 column, full-width cards.
+- `640–768px`: 2 columns.
+- `≥ 768px`: 4 columns (matches current layout).
+
+## Tests
+
+### Feature test updates
+
+`tests/Feature/QualificationReportControllerTest.php` (or closest existing test — verify filename before editing):
+
+- Update the existing index-render assertion to expect the new `kpis` payload shape: `kpis.totalQualifications.value`, `kpis.staffCovered.total`, `kpis.pending.oldestDays`, `kpis.withoutQualifications.total`.
+- Add a case with zero pending records asserting `kpis.pending.oldestDays === null`.
+- Add a case where active staff count is zero asserting the response still renders (no crash on divide-by-zero — frontend handles null `total`, but confirm backend emits `total: 0`).
+
+### Service unit test
+
+Add a test for `QualificationReportService::pendingApprovalsStats()` `oldestDays`:
+
+- When no pending qualifications exist → `oldestDays` is `null`.
+- When pending qualifications exist with a `created_at` 10 days ago → `oldestDays` is `10`.
+
+### Vue component
+
+This repo has no Vue unit test harness. `StatCard` is exercised indirectly by the feature test that renders the Inertia page. No new JS tooling is introduced.
+
+## Dark mode
+
+Every Tailwind class in `StatCard` that has a light-mode color also has a matching `dark:` variant, following the exact pattern already used on this page (`bg-white dark:bg-gray-800`, `text-gray-500 dark:text-gray-400`, `ring-gray-900/5 dark:ring-gray-700`). The accent class map includes both light and dark shades per accent.
+
+## Commit plan
+
+1. Add `StatCard.vue` component (standalone, no wiring yet).
+2. Update `QualificationReportController::kpis()` and `QualificationReportService::pendingApprovalsStats()` for new payload shape.
+3. Wire `StatCard` into `Qualification/Reports/Index.vue`, remove old duplicated markup.
+4. Update/add feature and service tests.
+5. Run `./vendor/bin/pint --dirty`, `npm run lint`, `php artisan test --filter=QualificationReport`.
+
+## Risks / things to verify during implementation
+
+- Grep for other callers of `pendingApprovalsStats()` before changing its return shape.
+- Verify `QualificationReportControllerTest` exists under that name — if not, update the nearest applicable test file and mention the actual path in the implementation plan.
+- Confirm Heroicons package exports `AcademicCapIcon`, `UserGroupIcon`, `ClockIcon`, `ExclamationTriangleIcon` under `@heroicons/vue/24/outline` (already used elsewhere in this project).
+- Carbon `diffInDays` behavior — ensure it returns a positive integer regardless of argument order, or use `abs()` defensively.

--- a/resources/js/Components/StatCard.vue
+++ b/resources/js/Components/StatCard.vue
@@ -1,0 +1,144 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	label: { type: String, required: true },
+	value: { type: [Number, String], required: true },
+	icon: { type: Object, default: null },
+	accent: {
+		type: String,
+		default: "slate",
+		validator: (v) => ["indigo", "emerald", "amber", "red", "slate"].includes(v),
+	},
+	secondary: { type: String, default: null },
+	trend: { type: Object, default: null }, // { direction: 'up'|'down'|'flat', text: string }
+	sparkline: { type: Array, default: null },
+});
+
+const accentClasses = {
+	indigo: {
+		border: "border-indigo-500 dark:border-indigo-400",
+		iconBg: "bg-indigo-50 dark:bg-indigo-900/40",
+		iconText: "text-indigo-600 dark:text-indigo-300",
+		spark: "#6366f1",
+	},
+	emerald: {
+		border: "border-emerald-500 dark:border-emerald-400",
+		iconBg: "bg-emerald-50 dark:bg-emerald-900/40",
+		iconText: "text-emerald-600 dark:text-emerald-300",
+		spark: "#059669",
+	},
+	amber: {
+		border: "border-amber-500 dark:border-amber-400",
+		iconBg: "bg-amber-50 dark:bg-amber-900/40",
+		iconText: "text-amber-600 dark:text-amber-300",
+		spark: "#d97706",
+	},
+	red: {
+		border: "border-red-500 dark:border-red-400",
+		iconBg: "bg-red-50 dark:bg-red-900/40",
+		iconText: "text-red-600 dark:text-red-300",
+		spark: "#dc2626",
+	},
+	slate: {
+		border: "border-slate-400 dark:border-slate-500",
+		iconBg: "bg-slate-100 dark:bg-slate-800",
+		iconText: "text-slate-600 dark:text-slate-300",
+		spark: "#64748b",
+	},
+};
+
+const accentCfg = computed(() => accentClasses[props.accent] ?? accentClasses.slate);
+
+const formattedValue = computed(() => {
+	if (typeof props.value === "number") return props.value.toLocaleString();
+	return props.value;
+});
+
+const sparklinePath = computed(() => {
+	const series = props.sparkline;
+	if (!Array.isArray(series) || series.length < 2) return null;
+	const max = Math.max(...series);
+	const min = Math.min(...series);
+	const range = max - min || 1;
+	const stepX = 100 / (series.length - 1);
+	return series
+		.map((v, i) => {
+			const x = (i * stepX).toFixed(2);
+			const y = (22 - ((v - min) / range) * 20).toFixed(2);
+			return `${i === 0 ? "" : " "}${x},${y}`;
+		})
+		.join("");
+});
+
+const trendClasses = computed(() => {
+	if (!props.trend) return "";
+	switch (props.trend.direction) {
+		case "up":
+			return "bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300";
+		case "down":
+			return "bg-red-50 dark:bg-red-900/40 text-red-700 dark:text-red-300";
+		default:
+			return "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300";
+	}
+});
+</script>
+
+<template>
+	<div
+		class="bg-white dark:bg-gray-800 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700 p-4 border-l-4"
+		:class="accentCfg.border"
+	>
+		<div class="flex items-start justify-between gap-2">
+			<div
+				class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-medium"
+			>
+				{{ label }}
+			</div>
+			<div
+				v-if="icon"
+				class="h-8 w-8 rounded-md flex items-center justify-center flex-shrink-0"
+				:class="accentCfg.iconBg"
+				:aria-label="label"
+			>
+				<component :is="icon" class="h-4 w-4" :class="accentCfg.iconText" />
+			</div>
+		</div>
+		<div class="mt-2 text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+			{{ formattedValue }}
+		</div>
+		<svg
+			v-if="sparklinePath"
+			class="mt-2 w-full h-6"
+			viewBox="0 0 100 22"
+			preserveAspectRatio="none"
+			aria-hidden="true"
+		>
+			<polyline
+				fill="none"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				:stroke="accentCfg.spark"
+				:points="sparklinePath"
+			/>
+		</svg>
+		<div
+			v-if="secondary"
+			class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+		>
+			{{ secondary }}
+		</div>
+		<div v-if="trend" class="mt-2">
+			<span
+				class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium"
+				:class="trendClasses"
+			>
+				<span v-if="trend.direction === 'up'">↑</span>
+				<span v-else-if="trend.direction === 'down'">↓</span>
+				<span v-else>→</span>
+				{{ trend.text }}
+			</span>
+		</div>
+	</div>
+</template>

--- a/resources/js/Pages/Qualification/Reports/Index.vue
+++ b/resources/js/Pages/Qualification/Reports/Index.vue
@@ -14,6 +14,13 @@ import TopInstitutionsChart from "@/Components/Charts/Qualifications/TopInstitut
 import TopQualificationsChart from "@/Components/Charts/Qualifications/TopQualificationsChart.vue";
 import LevelByGenderChart from "@/Components/Charts/Qualifications/LevelByGenderChart.vue";
 import AcquiredOverTimeChart from "@/Components/Charts/Qualifications/AcquiredOverTimeChart.vue";
+import StatCard from "@/Components/StatCard.vue";
+import {
+	AcademicCapIcon,
+	UserGroupIcon,
+	ClockIcon,
+	ExclamationTriangleIcon,
+} from "@heroicons/vue/24/outline";
 
 const props = defineProps({
 	filters: Object,
@@ -149,6 +156,55 @@ const activeFilters = computed(() => {
 	if (f.course)
 		out.push({ key: "course", label: "Course", value: f.course });
 	return out;
+});
+
+const sparklineSeries = computed(() => {
+	const t = props.trendByYear ?? {};
+	const entries = Object.entries(t)
+		.map(([year, count]) => [Number(year), Number(count)])
+		.filter(([y, c]) => Number.isFinite(y) && Number.isFinite(c))
+		.sort((a, b) => a[0] - b[0]);
+	if (entries.length < 2) return null;
+	return entries.map(([, c]) => c);
+});
+
+const sparklineSummary = computed(() => {
+	const series = sparklineSeries.value;
+	if (!series) return null;
+	const first = series[0];
+	const last = series[series.length - 1];
+	if (first === 0) return `${series.length} yrs of history`;
+	const pct = (((last - first) / first) * 100).toFixed(0);
+	const sign = pct >= 0 ? "+" : "";
+	return `${sign}${pct}% over ${series.length} yrs`;
+});
+
+const coveredSecondary = computed(() => {
+	const total = props.kpis?.staffCovered?.total ?? 0;
+	const value = props.kpis?.staffCovered?.value ?? 0;
+	if (total === 0) return null;
+	return `${((value / total) * 100).toFixed(1)}% of active staff`;
+});
+
+const gapsSecondary = computed(() => {
+	const total = props.kpis?.withoutQualifications?.total ?? 0;
+	const value = props.kpis?.withoutQualifications?.value ?? 0;
+	if (total === 0) return null;
+	return `${((value / total) * 100).toFixed(1)}% of active staff`;
+});
+
+const pendingSecondary = computed(() => {
+	const value = props.kpis?.pending?.value ?? 0;
+	if (value === 0) return "None pending";
+	const totalQuals = props.kpis?.totalQualifications?.value ?? 0;
+	const pct = totalQuals > 0 ? ((value / totalQuals) * 100).toFixed(1) : null;
+	const oldest = props.kpis?.pending?.oldestDays;
+	const parts = [];
+	if (pct !== null) parts.push(`${pct}% of total`);
+	if (oldest !== null && oldest !== undefined) {
+		parts.push(oldest === 0 ? "oldest today" : `oldest ${oldest}d`);
+	}
+	return parts.join(" · ") || null;
 });
 
 function removeFilter(key) {
@@ -398,55 +454,36 @@ const reportTypes = [
 				</span>
 			</div>
 
-			<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-				<div
-					class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700"
-				>
-					<div
-						class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						Total Qualifications
-					</div>
-					<div class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
-						{{ kpis.totalQualifications?.toLocaleString() }}
-					</div>
-				</div>
-				<div
-					class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700"
-				>
-					<div
-						class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						Staff Covered
-					</div>
-					<div class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
-						{{ kpis.staffCovered?.toLocaleString() }}
-					</div>
-				</div>
-				<div
-					class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700"
-				>
-					<div
-						class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						Pending
-					</div>
-					<div class="mt-1 text-2xl font-bold text-yellow-600">
-						{{ kpis.pending?.toLocaleString() }}
-					</div>
-				</div>
-				<div
-					class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-700"
-				>
-					<div
-						class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						Staff Without Quals
-					</div>
-					<div class="mt-1 text-2xl font-bold text-red-600">
-						{{ kpis.withoutQualifications?.toLocaleString() }}
-					</div>
-				</div>
+			<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+				<StatCard
+					label="Total Qualifications"
+					:value="kpis.totalQualifications.value"
+					:icon="AcademicCapIcon"
+					accent="indigo"
+					:sparkline="sparklineSeries"
+					:secondary="sparklineSummary"
+				/>
+				<StatCard
+					label="Staff Covered"
+					:value="kpis.staffCovered.value"
+					:icon="UserGroupIcon"
+					accent="emerald"
+					:secondary="coveredSecondary"
+				/>
+				<StatCard
+					label="Pending"
+					:value="kpis.pending.value"
+					:icon="ClockIcon"
+					accent="amber"
+					:secondary="pendingSecondary"
+				/>
+				<StatCard
+					label="Staff Without Quals"
+					:value="kpis.withoutQualifications.value"
+					:icon="ExclamationTriangleIcon"
+					accent="red"
+					:secondary="gapsSecondary"
+				/>
 			</div>
 
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/tests/Feature/QualificationReports/IndexPageTest.php
+++ b/tests/Feature/QualificationReports/IndexPageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\QualificationReports;
 
+use App\Models\InstitutionPerson;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -38,9 +39,33 @@ class IndexPageTest extends TestCase
                 ->has('topInstitutions')
                 ->has('trendByYear')
                 ->has('staffList')
-                ->has('kpis')
+                ->has('kpis.totalQualifications.value')
+                ->has('kpis.staffCovered.value')
+                ->has('kpis.staffCovered.total')
+                ->has('kpis.pending.value')
+                ->has('kpis.pending.oldestDays')
+                ->has('kpis.withoutQualifications.value')
+                ->has('kpis.withoutQualifications.total')
                 ->has('filterOptions')
                 ->has('filters')
+            );
+    }
+
+    public function test_kpis_payload_carries_active_staff_total_and_numeric_values(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        // 3 active staff, 1 separated
+        InstitutionPerson::factory()->count(3)->create(['end_date' => null]);
+        InstitutionPerson::factory()->create(['end_date' => now()->subMonth()]);
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports')
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.staffCovered.total', 3)
+                ->where('kpis.withoutQualifications.total', 3)
+                ->where('kpis.pending.oldestDays', null)
             );
     }
 }

--- a/tests/Feature/QualificationReports/IndexPageTest.php
+++ b/tests/Feature/QualificationReports/IndexPageTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\QualificationReports;
 
+use App\Enums\QualificationLevelEnum;
 use App\Models\InstitutionPerson;
+use App\Models\Qualification;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -66,6 +68,72 @@ class IndexPageTest extends TestCase
                 ->where('kpis.staffCovered.total', 3)
                 ->where('kpis.withoutQualifications.total', 3)
                 ->where('kpis.pending.oldestDays', null)
+            );
+    }
+
+    public function test_total_qualifications_kpi_respects_year_filter(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        Qualification::factory()->approved()->count(2)->create(['year' => '2020']);
+        Qualification::factory()->approved()->count(3)->create(['year' => '2023']);
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?year_from=2022')
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.totalQualifications.value', 3)
+            );
+    }
+
+    public function test_total_qualifications_kpi_respects_level_filter(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Degree)->count(4)->create();
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Masters)->count(2)->create();
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?level=' . QualificationLevelEnum::Masters->value)
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.totalQualifications.value', 2)
+            );
+    }
+
+    public function test_pending_kpi_ignores_status_filter_so_pending_count_stays_meaningful(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        Qualification::factory()->pending()->count(3)->create();
+        Qualification::factory()->approved()->count(5)->create();
+
+        // Even though the user filters by status=Approved, the Pending card
+        // should still count pending qualifications (matching other filters).
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?status=approved')
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.pending.value', 3)
+                ->where('kpis.totalQualifications.value', 5)
+            );
+    }
+
+    public function test_staff_covered_kpi_respects_level_filter(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        $personA = \App\Models\Person::factory()->create();
+        $personB = \App\Models\Person::factory()->create();
+
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Degree)->for($personA)->create();
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Masters)->for($personB)->create();
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?level=' . QualificationLevelEnum::Masters->value)
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.staffCovered.value', 1)
             );
     }
 }

--- a/tests/Feature/QualificationReports/IndexPageTest.php
+++ b/tests/Feature/QualificationReports/IndexPageTest.php
@@ -136,4 +136,57 @@ class IndexPageTest extends TestCase
                 ->where('kpis.staffCovered.value', 1)
             );
     }
+
+    public function test_staff_without_quals_kpi_respects_gender_filter(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        $males = \App\Models\Person::factory()->count(3)->create(['gender' => 'M']);
+        $females = \App\Models\Person::factory()->count(2)->create(['gender' => 'F']);
+        foreach ($males->merge($females) as $p) {
+            InstitutionPerson::factory()->for($p)->create(['end_date' => null]);
+        }
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?gender=M')
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.withoutQualifications.value', 3)
+            );
+    }
+
+    public function test_staff_without_quals_kpi_respects_unit_filter(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['qualifications.reports.view', 'qualifications.reports.view.all']);
+
+        $unitA = \App\Models\Unit::factory()->create();
+        $unitB = \App\Models\Unit::factory()->create();
+
+        // 2 staff in unit A, 4 staff in unit B — none have approved quals.
+        $this->assignStaffToUnit($unitA->id, 2);
+        $this->assignStaffToUnit($unitB->id, 4);
+
+        $this->actingAs($user->fresh())
+            ->get('/qualifications/reports?unit_id=' . $unitA->id)
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('kpis.withoutQualifications.value', 2)
+                ->where('kpis.withoutQualifications.total', 2)
+            );
+    }
+
+    private function assignStaffToUnit(int $unitId, int $count): void
+    {
+        foreach (range(1, $count) as $_) {
+            $p = \App\Models\Person::factory()->create();
+            $staff = InstitutionPerson::factory()->for($p)->create(['end_date' => null]);
+            \Illuminate\Support\Facades\DB::table('staff_unit')->insert([
+                'staff_id' => $staff->id,
+                'unit_id' => $unitId,
+                'start_date' => now()->subYear()->toDateString(),
+                'end_date' => null,
+                'status' => \App\Enums\TransferStatusEnum::Pending->value,
+            ]);
+        }
+    }
 }

--- a/tests/Feature/QualificationReports/ServiceAggregationsTest.php
+++ b/tests/Feature/QualificationReports/ServiceAggregationsTest.php
@@ -11,6 +11,7 @@ use App\Models\Qualification;
 use App\Models\Unit;
 use App\Services\QualificationReportService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -219,5 +220,31 @@ class ServiceAggregationsTest extends TestCase
 
         $second = $service->levelDistribution(new QualificationReportFilter);
         $this->assertSame(1, $second['masters']);
+    }
+
+    public function test_pending_approvals_stats_includes_oldest_days_null_when_no_pending(): void
+    {
+        Qualification::factory()->approved()->count(2)->create();
+
+        $result = app(QualificationReportService::class)->pendingApprovalsStats();
+
+        $this->assertSame(0, $result['count']);
+        $this->assertNull($result['oldestDays']);
+    }
+
+    public function test_pending_approvals_stats_returns_oldest_days_for_oldest_pending(): void
+    {
+        Carbon::setTestNow('2026-04-16 12:00:00');
+
+        Qualification::factory()->pending()->create(['created_at' => now()->subDays(3)]);
+        Qualification::factory()->pending()->create(['created_at' => now()->subDays(10)]);
+        Qualification::factory()->pending()->create(['created_at' => now()->subDays(1)]);
+
+        $result = app(QualificationReportService::class)->pendingApprovalsStats();
+
+        $this->assertSame(3, $result['count']);
+        $this->assertSame(10, $result['oldestDays']);
+
+        Carbon::setTestNow();
     }
 }


### PR DESCRIPTION
## Summary

- Replaces four duplicated KPI card blocks on the qualification report with a uniform, reusable `StatCard` Vue component (full dark-mode support, icons, left-border accents, optional sparkline/trend chip).
- Adds richer context to each card: percentage-of-active-staff, a year-over-year sparkline on Total Qualifications, and the age of the oldest pending submission.
- Makes **all** KPI values filter-responsive. Total / Staff Covered / Staff Without Quals narrow as the user applies filters. The Pending card keeps its "pending" meaning even when the status filter is set to a non-pending value (by design).

## Changes

**Backend**
- `QualificationReportService::pendingApprovalsStats()` now accepts an optional `QualificationReportFilter` and returns an `oldestDays` key alongside the existing `count`/`sparkline`. Status is stripped from the filter internally so the pending card stays meaningful.
- New `QualificationReportService::activeStaffCount()` returns filter-scoped active staff, used as the denominator for "% of active staff".
- `staffWithoutQualifications()` closure now actually uses its `$filter` argument (latent bug — cache key varied, computation didn't).
- `QualificationReportController::kpis()` reshaped to return nested `{value, total, oldestDays}` per KPI, all filter-aware.

**Frontend**
- New `resources/js/Components/StatCard.vue` — generic, reusable across future reports. JIT-safe accent class map, responsive grid, dark-mode classes throughout.
- `resources/js/Pages/Qualification/Reports/Index.vue` consumes the new payload via derived-display computeds and renders four `<StatCard />` instances.

## Test plan

- [x] Service: oldestDays null / non-null cases, pending-stats sparkline preserved
- [x] Controller: payload shape, active-staff total reflects separations
- [x] Filter-responsiveness: year / level / gender / unit filters narrow KPI values and (where applicable) totals
- [x] Pending-card independence: status=Approved filter still yields correct pending count
- [x] Full test suite: 409 tests / 1260 assertions passing
- [x] `./vendor/bin/pint --dirty` clean
- [x] `npm run build` succeeds
- [ ] Manual QA: filter the page in a browser, confirm cards update live (reviewer action)
- [ ] Manual QA: toggle dark mode and confirm legibility (reviewer action)

Spec: `docs/superpowers/specs/2026-04-16-qualification-report-stats-redesign-design.md`
Plan: `docs/superpowers/plans/2026-04-16-qualification-report-stats-redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)