### PR TITLE
feat: staff My Profile page + photo admin approval

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -170,6 +170,12 @@ class ContactController extends Controller
             }
         }
 
+        if ($contact->isProtectedOrgEmail()) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'contact' => 'This Audit Service email address cannot be deleted.',
+            ]);
+        }
+
         $this->logSuccess('deleted a contact', $contact);
 
         $contact->delete();

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -155,6 +155,21 @@ class ContactController extends Controller
     {
         $this->authorize('delete', $contact);
 
+        if ($contact->contact_type === ContactTypeEnum::PHONE) {
+            $remaining = Contact::query()
+                ->where('person_id', $contact->person_id)
+                ->where('contact_type', ContactTypeEnum::PHONE)
+                ->whereNull('valid_end')
+                ->where('id', '!=', $contact->id)
+                ->count();
+
+            if ($remaining === 0) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'contact' => 'You must keep at least one active phone number.',
+                ]);
+            }
+        }
+
         $this->logSuccess('deleted a contact', $contact);
 
         $contact->delete();

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -24,7 +24,7 @@ class ContactController extends Controller
 
         $contacts = Contact::query()
             ->with('person')
-            ->when($request->contact_type, fn($q, $type) => $q->where('contact_type', $type))
+            ->when($request->contact_type, fn ($q, $type) => $q->where('contact_type', $type))
             ->when($request->search, function ($q, $search) {
                 $q->where('contact', 'like', "%{$search}%")
                     ->orWhereHas('person', function ($query) use ($search) {
@@ -35,7 +35,7 @@ class ContactController extends Controller
             ->latest()
             ->paginate(20)
             ->withQueryString()
-            ->through(fn(Contact $contact) => [
+            ->through(fn (Contact $contact) => [
                 'id' => $contact->id,
                 'contact_type' => $contact->contact_type?->value,
                 'contact_type_label' => $contact->contact_type?->label(),
@@ -48,7 +48,7 @@ class ContactController extends Controller
             ]);
 
         // Get contact types for filters
-        $contactTypes = collect(ContactTypeEnum::cases())->map(fn($type) => [
+        $contactTypes = collect(ContactTypeEnum::cases())->map(fn ($type) => [
             'value' => $type->value,
             'label' => $type->label(),
         ]);
@@ -65,7 +65,7 @@ class ContactController extends Controller
      */
     public function create(): Response
     {
-        $contactTypes = collect(ContactTypeEnum::cases())->map(fn($type) => [
+        $contactTypes = collect(ContactTypeEnum::cases())->map(fn ($type) => [
             'value' => $type->value,
             'label' => $type->label(),
         ]);
@@ -117,7 +117,7 @@ class ContactController extends Controller
      */
     public function edit(Contact $contact)
     {
-        $contactTypes = collect(ContactTypeEnum::cases())->map(fn($type) => [
+        $contactTypes = collect(ContactTypeEnum::cases())->map(fn ($type) => [
             'value' => $type->value,
             'label' => $type->label(),
         ]);
@@ -139,6 +139,8 @@ class ContactController extends Controller
      */
     public function update(UpdateContactRequest $request, Contact $contact)
     {
+        $this->authorize('update', $contact);
+
         $contact->update($request->validated());
 
         $this->logSuccess('updated a contact', $contact);
@@ -151,6 +153,8 @@ class ContactController extends Controller
      */
     public function destroy(Contact $contact)
     {
+        $this->authorize('delete', $contact);
+
         $this->logSuccess('deleted a contact', $contact);
 
         $contact->delete();

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -141,6 +141,12 @@ class ContactController extends Controller
     {
         $this->authorize('update', $contact);
 
+        if ($contact->isProtectedOrgEmail()) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'contact' => 'This Audit Service email address cannot be edited.',
+            ]);
+        }
+
         $contact->update($request->validated());
 
         $this->logSuccess('updated a contact', $contact);

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -92,11 +92,8 @@ class DashboardController extends Controller
 
     private function redirectToStaffLanding(User $user): RedirectResponse
     {
-        if ($user->person) {
-            return redirect()->route(
-                'staff.show',
-                [$user->person->institution->first()->staff->id]
-            );
+        if ($user->person_id) {
+            return redirect()->route('my-profile.show');
         }
 
         return redirect()->route('staff.index');

--- a/app/Http/Controllers/InstitutionPersonController.php
+++ b/app/Http/Controllers/InstitutionPersonController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\UpdateStaffPositionRequest;
 use App\Http\Requests\UpdateStaffRequest;
 use App\Models\InstitutionPerson;
 use App\Models\Position;
+use App\Services\StaffProfileProvider;
 use App\Transformers\Staff\StaffDetailTransformer;
 use App\Transformers\Staff\StaffListTransformer;
 use Carbon\Carbon;
@@ -26,7 +27,8 @@ class InstitutionPersonController extends Controller
         protected StaffManagementServiceInterface $staffManagementService,
         protected PromotionServiceInterface $promotionService,
         protected StaffDetailTransformer $detailTransformer,
-        protected StaffListTransformer $listTransformer
+        protected StaffListTransformer $listTransformer,
+        protected StaffProfileProvider $staffProfileProvider,
     ) {}
 
     /**
@@ -173,12 +175,12 @@ class InstitutionPersonController extends Controller
             }
         }
 
-        $staff = \App\Models\InstitutionPerson::query()->active()->whereId($staffId)->first();
+        $staff = InstitutionPerson::query()->active()->whereId($staffId)->first();
         if (! $staff) {
             return redirect()->route('person.show', ['person' => $staffId])->with('error', 'Staff not found');
         }
 
-        $payload = app(\App\Services\StaffProfileProvider::class)->forPerson($staff->person_id);
+        $payload = $this->staffProfileProvider->forPerson($staff->person_id);
 
         return Inertia::render('Staff/NewShow', array_merge($payload, [
             'user' => [

--- a/app/Http/Controllers/InstitutionPersonController.php
+++ b/app/Http/Controllers/InstitutionPersonController.php
@@ -166,238 +166,28 @@ class InstitutionPersonController extends Controller
         if (request()->user()->cannot('view staff')) {
             return redirect()->route('dashboard')->with('error', 'You do not have permission to view staff details');
         }
+
         if (request()->user()->isStaff()) {
             if (request()->user()->person->institution->first()->staff->id != $staffId) {
                 return redirect()->route('dashboard')->with('error', 'You do not have permission to view details of this staff');
             }
         }
-        $staff = InstitutionPerson::query()
-            ->with(
-                [
-                    'person' => function ($query) {
-                        $query->with([
-                            'address' => function ($query) {
-                                $query->whereNull('valid_end');
-                            },
-                            'contacts',
-                            'identities' => function ($query) {
-                                $query->withTrashed();
-                            },
-                            'qualifications',
-                        ]);
-                    },
-                    // 'units.institution',
-                    // 'units.parent',
-                    'units' => function ($query) {
-                        $query->with(['institution', 'parent']);
-                    },
-                    'ranks',
-                    'dependents.person',
-                    'statuses',
-                    'notes.documents',
-                    'positions' => function ($query) {
-                        $query->withTrashed();
-                    },
-                ]
-            )
-            ->active()
-            ->whereId($staffId)
-            ->first();
+
+        $staff = \App\Models\InstitutionPerson::query()->active()->whereId($staffId)->first();
         if (! $staff) {
             return redirect()->route('person.show', ['person' => $staffId])->with('error', 'Staff not found');
         }
 
-        // dd($request->session()->all());
-        // request()->session()->reflash();
-        return Inertia::render('Staff/NewShow', [
+        $payload = app(\App\Services\StaffProfileProvider::class)->forPerson($staff->person_id);
+
+        return Inertia::render('Staff/NewShow', array_merge($payload, [
             'user' => [
                 'id' => auth()->user()->id,
                 'name' => auth()->user()->name,
                 'email' => auth()->user()->email,
                 'person_id' => auth()->user()->person_id,
             ],
-            'person' => [
-                'id' => $staff->person->id,
-                'name' => $staff->person->full_name,
-                'maiden_name' => $staff->person->maiden_name,
-                'dob-value' => $staff->person->date_of_birth,
-                'dob' => $staff->person->date_of_birth?->format('d M Y'),
-                'age' => $staff->person->age . ' years old',
-                'gender' => $staff->person->gender?->label(),
-                'ssn' => $staff->person->social_security_number,
-                'initials' => $staff->person->initials,
-                'nationality' => $staff->person->nationality?->nationality(),
-                'religion' => $staff->person->religion,
-                'marital_status' => $staff->person->marital_status?->label(),
-                'image' => $staff->person->image ? '/storage/' . $staff->person->image : null,
-                'identities' => $staff->person->identities->count() > 0 ? $staff->person->identities->map(fn ($id) => [
-                    'id' => $id->id,
-                    'id_type' => $id->id_type,
-                    'id_type_display' => $id->id_type->label(),
-                    'id_number' => $id->id_number,
-                ]) : null,
-            ],
-            'qualifications' => \App\Models\Qualification::query()
-                ->where('person_id', $staff->person->id)
-                ->visibleTo(auth()->user(), $staff->person->id)
-                ->with('documents')
-                ->get()
-                ->map(fn ($qualification) => [
-                    'id' => $qualification->id,
-                    'person_id' => $qualification->person_id,
-                    'course' => $qualification->course,
-                    'institution' => $qualification->institution,
-                    'qualification' => $qualification->qualification,
-                    'qualification_number' => $qualification->qualification_number,
-                    'level' => $qualification->level ? \App\Enums\QualificationLevelEnum::tryFrom($qualification->level)?->label() ?? $qualification->level : null,
-                    'year' => $qualification->year,
-                    'status' => $qualification->status?->label(),
-                    'status_color' => $qualification->status?->color(),
-                    'can_edit' => $qualification->canBeEditedBy(auth()->user()),
-                    'can_delete' => $qualification->canBeDeletedBy(auth()->user()),
-                    'documents' => $qualification->documents->count() > 0 ? $qualification->documents->map(fn ($document) => [
-                        'document_type' => $document->document_type,
-                        'document_title' => $document->document_title,
-                        'document_status' => $document->document_status,
-                        'document_number' => $document->document_number,
-                        'file_name' => $document->file_name,
-                        'file_type' => $document->file_type,
-                    ]) : null,
-                ]),
-            'contacts' => $staff->person->contacts->count() > 0 ? $staff->person->contacts->map(fn ($contact) => [
-                'id' => $contact->id,
-                'contact' => $contact->contact,
-                'contact_type' => $contact->contact_type,
-                'contact_type_dis' => $contact->contact_type->label(),
-                'valid_end' => $contact->valid_end,
-            ]) : null,
-
-            'address' => $staff->person->address->count() > 0 ? [
-                'id' => $staff->person->address->first()->id,
-                'address_line_1' => $staff->person->address->first()->address_line_1,
-                'address_line_2' => $staff->person->address->first()->address_line_2,
-                'city' => $staff->person->address->first()->city,
-                'region' => $staff->person->address->first()->region,
-                'country' => $staff->person->address->first()->country,
-                'post_code' => $staff->person->address->first()->post_code,
-                'valid_end' => $staff->person->address->first()->valid_end,
-            ] : null,
-            'staff' => [
-                'staff_id' => $staff->id,
-                'institution_id' => $staff->institution_id,
-                'staff_number' => $staff->staff_number,
-                'file_number' => $staff->file_number,
-                'old_staff_number' => $staff->old_staff_number,
-                'hire_date' => $staff->hire_date?->format('d M Y'),
-                'hire_date_display' => $staff->hire_date?->diffForHumans(),
-                'retirement_date' => $staff->retirement_date_formatted,
-                'retirement_date_display' => $staff->retirement_date_diff,
-                'start_date' => $staff->start_date?->format('d M Y'),
-                'statuses' => $staff->statuses?->map(fn ($status) => [
-                    'id' => $status->id,
-                    'status' => $status->status,
-                    'status_display' => $status->status?->name,
-                    'description' => $status->description,
-                    'start_date' => $status->start_date?->format('Y-m-d'),
-                    'start_date_display' => $status->start_date?->format('d M Y'),
-                    'end_date' => $status->end_date?->format('Y-m-d'),
-                    'end_date_display' => $status->end_date?->format('d M Y'),
-                ]),
-                'staff_type' => $staff->type?->map(fn ($type) => [
-                    'id' => $type->id,
-                    'type' => $type->staff_type,
-                    'type_label' => $type->staff_type->label(),
-                    'start_date' => $type->start_date?->format('Y-m-d'),
-                    'start_date_display' => $type->start_date?->format('d M Y'),
-                    'end_date' => $type->end_date?->format('Y-m-d'),
-                    'end_date_display' => $type->end_date?->format('d M Y'),
-                ]),
-                'positions' => $staff->positions?->map(fn ($position) => [
-                    'id' => $position->id,
-                    'name' => $position->name,
-                    'start_date' => $position->pivot->start_date,
-                    'end_date' => $position->pivot->end_date,
-                    'start_date_display' => $position->pivot->start_date ? Carbon::parse($position->pivot->start_date)->format('d M Y') : null,
-                    'end_date_display' => $position->pivot->end_date ? Carbon::parse($position->pivot->end_date)->format('d M Y') : null,
-                ]),
-                'ranks' => $staff->ranks->map(fn ($rank) => [
-                    'id' => $rank->id,
-                    'name' => $rank->name,
-                    'staff_name' => $staff->person->full_name,
-                    'staff_id' => $rank->pivot->staff_id,
-                    'rank_id' => $rank->pivot->job_id,
-                    'start_date' => $rank->pivot->start_date?->format('d M Y'),
-                    'start_date_unix' => $rank->pivot->start_date?->format('Y-m-d'),
-                    'end_date' => $rank->pivot->end_date?->format('d M Y'),
-                    'end_date_unix' => $rank->pivot->end_date?->format('Y-m-d'),
-                    'remarks' => $rank->pivot->remarks,
-                    'distance' => $rank->pivot->start_date?->diffForHumans(),
-                ]),
-                'notes' => $staff->notes->count() > 0 ? $staff->notes->map(fn ($note) => [
-                    'id' => $note->id,
-                    'note' => $note->note,
-                    'note_date' => $note->note_date->diffForHumans(),
-                    'note_date_time' => $note->note_date,
-                    'note_type' => $note->note_type,
-                    'created_by' => $note->created_by,
-                    'url' => $note->documents->count() > 0 ? $note->documents->map(fn ($doc) => [
-                        'document_type' => $doc->document_type,
-                        'document_title' => $doc->document_title,
-                        // 'document_status' => $doc->document_status,
-                        // 'document_number' => $doc->document_number,
-                        'file_name' => $doc->file_name,
-                        'file_type' => $doc->file_type,
-                    ]) : null,
-
-                ]) : null,
-                'units' => $staff->units->map(fn ($unit) => [
-                    // 'unit' => $unit,
-                    'unit_id' => $unit->id,
-                    'unit_name' => $unit->name,
-                    'status' => $unit->pivot->status?->label(),
-                    'status_color' => $unit->pivot->status?->color(),
-                    'department' => $unit->parent?->name,
-                    'department_short_name' => $unit->parent?->short_name,
-                    'staff_id' => $unit->pivot->staff_id,
-                    'start_date' => $unit->pivot->start_date?->format('d M Y'),
-                    'start_date_unix' => $unit->pivot->start_date?->format('Y-m-d'),
-                    'end_date' => $unit->pivot->end_date?->format('d M Y'),
-                    'end_date_unix' => $unit->pivot->end_date?->format('Y-m-d'),
-                    'distance' => $unit->pivot->start_date?->diffForHumans(),
-                    'remarks' => $unit->pivot->remarks,
-                    'old_data' => $unit->pivot->old_data,
-                ]),
-                'dependents' => $staff->dependents ? $staff->dependents->map(fn ($dep) => [
-                    'id' => $dep->id,
-                    'person_id' => $dep->person_id,
-                    'initials' => $dep->person->initials,
-                    'title' => $dep->person->title,
-                    'name' => $dep->person->full_name,
-                    'surname' => $dep->person->surname,
-                    'first_name' => $dep->person->first_name,
-                    'other_names' => $dep->person->other_names,
-                    'maiden_name' => $dep->person->maiden_name,
-                    'nationality' => $dep->person->nationality?->label(),
-                    'nationality_form' => $dep->person->nationality,
-                    'marital_status' => $dep->person->marital_status,
-                    'image' => $dep->person->image ? '/storage/' . $dep->person->image : null,
-                    'religion' => $dep->person->religion,
-                    'gender' => $dep->person->gender?->label(),
-                    'gender_form' => $dep->person->gender,
-                    'date_of_birth' => $dep->person->date_of_birth?->format('Y-m-d'),
-                    'age' => $dep->person->age . ' years old',
-                    'relation' => $dep->relation,
-                    'staff_id' => $staff->id,
-                    // $staff->person->image ? '/' . $staff->person->image :  null,
-                    'image' => $dep->person->image ? '/storage/' . $dep->person->image : null,
-                    'contacts' => $dep->person->contacts->map(fn ($contact) => [
-                        'id' => $contact->id,
-                        'type' => $contact->contact_type?->label(),
-                        'contact' => $contact->contact,
-                    ]),
-                ]) : null,
-            ],
-        ]);
+        ]));
     }
 
     public function promote(Request $request, InstitutionPerson $staff)

--- a/app/Http/Controllers/MyProfileController.php
+++ b/app/Http/Controllers/MyProfileController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\StaffProfileProvider;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MyProfileController extends Controller
+{
+    public function __construct(protected StaffProfileProvider $provider) {}
+
+    public function show(Request $request): Response
+    {
+        $personId = $request->user()->person_id;
+        abort_unless($personId, 403, 'Your account is not linked to a staff record.');
+
+        $payload = $this->provider->forPerson($personId);
+        abort_if($payload === null, 404, 'Staff record not found.');
+
+        return Inertia::render('MyProfile/Index', $payload);
+    }
+}

--- a/app/Http/Controllers/PersonAvatarController.php
+++ b/app/Http/Controllers/PersonAvatarController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Models\Person;
 use App\Models\User;
+use App\Notifications\PhotoPendingApprovalNotification;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,19 +39,29 @@ class PersonAvatarController extends Controller
             ],
         ]);
 
-        $avatar = Storage::disk('public')->put('avatars', $request->image);
+        // Delete any existing pending file to avoid storage bloat.
+        if ($person->pending_image) {
+            Storage::disk('public')->delete($person->pending_image);
+        }
+
+        $pendingAvatar = Storage::disk('public')->put('avatars', $request->image);
 
         $person->update([
-            'image' => $avatar,
+            'pending_image' => $pendingAvatar,
+            'pending_image_at' => now(),
         ]);
+
+        // Notify all approvers.
+        $approvers = \App\Models\User::permission('approve staff photo')->get();
+        Notification::send($approvers, new PhotoPendingApprovalNotification($person));
 
         activity()
             ->performedOn($person)
             ->causedBy($request->user())
-            ->event('updated avatar')
-            ->log('Updated avatar');
+            ->event('uploaded pending avatar')
+            ->log('Uploaded photo pending approval');
 
-        return back()->with('success', 'Image uploaded successfully');
+        return back()->with('success', 'Photo uploaded and pending admin approval');
     }
 
     public function delete(Request $request, Person $person)

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -5,9 +5,11 @@ namespace App\Http\Controllers;
 use App\Enums\ContactTypeEnum;
 use App\Http\Requests\StoreIdentityRequest;
 use App\Http\Requests\UpdatePersonRequest;
+use App\Models\Address;
 use App\Models\Contact;
 use App\Models\Person;
 use Exception;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rules\Enum;
@@ -330,6 +332,29 @@ class PersonController extends Controller
         $person->identities()->where('id', $identity)->forceDelete();
 
         return redirect()->back();
+    }
+
+    public function updateAddress(Request $request, Person $person, Address $address): RedirectResponse
+    {
+        abort_unless(
+            $address->addressable_type === $person->getMorphClass() && $address->addressable_id === $person->id,
+            404
+        );
+
+        $this->authorize('update', $address);
+
+        $attribute = $request->validate([
+            'address_line_1' => ['required'],
+            'address_line_2' => ['nullable'],
+            'city' => ['required'],
+            'region' => ['nullable'],
+            'country' => ['required'],
+            'post_code' => ['nullable'],
+        ]);
+
+        $address->update($attribute);
+
+        return redirect()->back()->with('success', 'Address updated successfully.');
     }
 
     public function deleteAddress(Person $person, $address)

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -312,6 +312,12 @@ class PersonController extends Controller
             }
         }
 
+        if ($contactModel->isProtectedOrgEmail()) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'contact' => 'This Audit Service email address cannot be deleted.',
+            ]);
+        }
+
         $person->contacts()->where('id', $contact)->forceDelete();
 
         return redirect()->back();

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -261,6 +261,12 @@ class PersonController extends Controller
 
     public function addContact(Request $request, Person $person)
     {
+        abort_unless(
+            $request->user()->person_id === $person->id
+                || $request->user()->can('update staff'),
+            403,
+        );
+
         $attribute = $request->validate([
             'contact_type' => [new Enum(ContactTypeEnum::class)],
             'contact' => 'required|min:7|max:100',
@@ -272,17 +278,23 @@ class PersonController extends Controller
 
     public function updateContact(Request $request, $person, $contact)
     {
+        $contactModel = Contact::findOrFail($contact);
+        $this->authorize('update', $contactModel);
+
         $attribute = $request->validate([
             'contact_type' => [new Enum(ContactTypeEnum::class)],
             'contact' => 'required|min:7|max:30',
         ]);
-        $contact = Contact::find($contact)->update($attribute);
+        $contactModel->update($attribute);
 
         return redirect()->back()->with('success', 'Contact updated');
     }
 
-    public function deleteContact(Person $person, $contact)
+    public function deleteContact(Request $request, Person $person, $contact)
     {
+        $contactModel = Contact::findOrFail($contact);
+        $this->authorize('delete', $contactModel);
+
         $person->contacts()->where('id', $contact)->forceDelete();
 
         return redirect()->back();

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -297,6 +297,21 @@ class PersonController extends Controller
         $contactModel = Contact::findOrFail($contact);
         $this->authorize('delete', $contactModel);
 
+        if ($contactModel->contact_type === ContactTypeEnum::PHONE) {
+            $remaining = Contact::query()
+                ->where('person_id', $contactModel->person_id)
+                ->where('contact_type', ContactTypeEnum::PHONE)
+                ->whereNull('valid_end')
+                ->where('id', '!=', $contactModel->id)
+                ->count();
+
+            if ($remaining === 0) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'contact' => 'You must keep at least one active phone number.',
+                ]);
+            }
+        }
+
         $person->contacts()->where('id', $contact)->forceDelete();
 
         return redirect()->back();

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\ContactTypeEnum;
+use App\Http\Requests\StoreAddressRequest;
 use App\Http\Requests\StoreIdentityRequest;
 use App\Http\Requests\UpdatePersonRequest;
 use App\Models\Address;
@@ -11,6 +12,7 @@ use App\Models\Person;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rules\Enum;
 use Inertia\Inertia;
@@ -300,26 +302,13 @@ class PersonController extends Controller
         return redirect()->back();
     }
 
-    public function addAddress(Request $request, Person $person)
+    public function addAddress(StoreAddressRequest $request, Person $person): RedirectResponse
     {
-        $attribute = $request->validate([
-            'address_line_1' => ['required'],
-            'address_line_2' => ['nullable'],
-            'city' => ['required'],
-            'region' => ['nullable'],
-            'country' => ['required'],
-            'post_code' => ['nullable'],
-        ]);
-
         $person->address()->where('valid_end', null)->update([
-            'valid_end' => now(),
+            'valid_end' => now()->toDateString(),
         ]);
 
-        // $staff->ranks()->wherePivot('end_date', null)->update([
-        //     'end_date' => Carbon::parse($request->start_date)->subDay(),
-        // ]);
-
-        $person->address()->create($attribute);
+        $person->address()->create($request->validated());
 
         return redirect()->back();
     }
@@ -355,18 +344,44 @@ class PersonController extends Controller
 
         $this->authorize('update', $address);
 
-        $attribute = $request->validate([
-            'address_line_1' => ['required'],
-            'address_line_2' => ['nullable'],
-            'city' => ['required'],
-            'region' => ['nullable'],
-            'country' => ['required'],
-            'post_code' => ['nullable'],
-        ]);
+        $attribute = $request->validate(
+            [
+                'address_line_1' => 'required|string|max:255',
+                'address_line_2' => 'nullable|string|max:255',
+                'city' => 'required|string|max:100',
+                'region' => 'nullable|string|max:100',
+                'country' => 'required|string|max:100',
+                'post_code' => 'nullable|string|max:20',
+            ],
+            [
+                'address_line_1.required' => 'Address line 1 is required.',
+                'city.required' => 'City is required.',
+                'country.required' => 'Country is required.',
+            ]
+        );
 
         $address->update($attribute);
 
         return redirect()->back()->with('success', 'Address updated successfully.');
+    }
+
+    public function changeAddress(StoreAddressRequest $request, Person $person): RedirectResponse
+    {
+        abort_unless(
+            $request->user()->person_id === $person->id
+                || $request->user()->can('update staff'),
+            403,
+        );
+
+        DB::transaction(function () use ($person, $request) {
+            $person->address()
+                ->whereNull('valid_end')
+                ->update(['valid_end' => now()->toDateString()]);
+
+            $person->address()->create($request->validated());
+        });
+
+        return redirect()->back()->with('success', 'Address updated. Previous address kept in history.');
     }
 
     public function deleteAddress(Person $person, $address)

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -283,6 +283,12 @@ class PersonController extends Controller
         $contactModel = Contact::findOrFail($contact);
         $this->authorize('update', $contactModel);
 
+        if ($contactModel->isProtectedOrgEmail()) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'contact' => 'This Audit Service email address cannot be edited.',
+            ]);
+        }
+
         $attribute = $request->validate([
             'contact_type' => [new Enum(ContactTypeEnum::class)],
             'contact' => 'required|min:7|max:30',

--- a/app/Http/Controllers/PhotoApprovalController.php
+++ b/app/Http/Controllers/PhotoApprovalController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Person;
+use App\Notifications\PhotoApprovedNotification;
+use App\Notifications\PhotoRejectedNotification;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+class PhotoApprovalController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        abort_unless($request->user()->can('approve staff photo'), HttpResponse::HTTP_FORBIDDEN);
+
+        $pending = Person::query()
+            ->whereNotNull('pending_image')
+            ->get()
+            ->map(fn (Person $person) => [
+                'id' => $person->id,
+                'name' => $person->full_name,
+                'current_image' => $person->image ? '/storage/' . $person->image : null,
+                'pending_image' => '/storage/' . $person->pending_image,
+                'pending_image_at' => $person->pending_image_at?->diffForHumans(),
+            ])
+            ->all();
+
+        return Inertia::render('PhotoApprovals/Index', [
+            'pending' => $pending,
+        ]);
+    }
+
+    public function approve(Request $request, Person $person): RedirectResponse
+    {
+        abort_unless($request->user()->can('approve staff photo'), HttpResponse::HTTP_FORBIDDEN);
+        abort_if($person->pending_image === null, HttpResponse::HTTP_UNPROCESSABLE_ENTITY, 'No pending photo to approve.');
+
+        // Delete the previously approved file if one exists.
+        if ($person->image) {
+            Storage::disk('public')->delete($person->image);
+        }
+
+        $person->update([
+            'image' => $person->pending_image,
+            'pending_image' => null,
+            'pending_image_at' => null,
+            'image_approved_by' => $request->user()->id,
+            'image_approved_at' => now(),
+        ]);
+
+        // Notify the staff member whose photo was approved.
+        $staffUser = $person->user;
+        if ($staffUser) {
+            $staffUser->notify(new PhotoApprovedNotification($person));
+        }
+
+        return back()->with('success', 'Photo approved successfully.');
+    }
+
+    public function reject(Request $request, Person $person): RedirectResponse
+    {
+        abort_unless($request->user()->can('approve staff photo'), HttpResponse::HTTP_FORBIDDEN);
+        abort_if($person->pending_image === null, HttpResponse::HTTP_UNPROCESSABLE_ENTITY, 'No pending photo to reject.');
+
+        Storage::disk('public')->delete($person->pending_image);
+
+        $person->update([
+            'pending_image' => null,
+            'pending_image_at' => null,
+        ]);
+
+        // Notify the staff member whose photo was rejected.
+        $staffUser = $person->user;
+        if ($staffUser) {
+            $staffUser->notify(new PhotoRejectedNotification($person));
+        }
+
+        return back()->with('success', 'Photo rejected and removed.');
+    }
+}

--- a/app/Http/Controllers/QualificationController.php
+++ b/app/Http/Controllers/QualificationController.php
@@ -92,15 +92,16 @@ class QualificationController extends Controller
             );
 
             if ($request->hasFile('file_name')) {
-                $path = Storage::disk('qualifications-documents')->put('/', $request->file('file_name'));
-                $qualification->documents()->create([
-                    'document_type' => $request->input('document_type'),
-                    'document_title' => $request->input('document_title')
-                        ?? pathinfo($request->file('file_name')->getClientOriginalName(), PATHINFO_FILENAME),
-                    'document_status' => 'P',
-                    'file_name' => $path,
-                    'file_type' => $request->file('file_name')->getMimeType(),
-                ]);
+                foreach ((array) $request->file('file_name') as $file) {
+                    $path = Storage::disk('qualifications-documents')->put('/', $file);
+                    $qualification->documents()->create([
+                        'document_type' => $request->input('document_type'),
+                        'document_title' => pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME),
+                        'document_status' => 'P',
+                        'file_name' => $path,
+                        'file_type' => $file->getMimeType(),
+                    ]);
+                }
             }
 
             return $qualification;

--- a/app/Http/Controllers/QualificationController.php
+++ b/app/Http/Controllers/QualificationController.php
@@ -92,11 +92,14 @@ class QualificationController extends Controller
             );
 
             if ($request->hasFile('file_name')) {
-                foreach ((array) $request->file('file_name') as $file) {
+                $types = (array) $request->input('document_type', []);
+                $titles = (array) $request->input('document_title', []);
+
+                foreach ($request->file('file_name') as $i => $file) {
                     $path = Storage::disk('qualifications-documents')->put('/', $file);
                     $qualification->documents()->create([
-                        'document_type' => $request->input('document_type'),
-                        'document_title' => pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME),
+                        'document_type' => $types[$i] ?? null,
+                        'document_title' => $titles[$i] ?? pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME),
                         'document_status' => 'P',
                         'file_name' => $path,
                         'file_type' => $file->getMimeType(),

--- a/app/Http/Controllers/QualificationController.php
+++ b/app/Http/Controllers/QualificationController.php
@@ -10,7 +10,9 @@ use App\Models\Qualification;
 use App\Models\User;
 use App\Notifications\QualificationPendingApprovalNotification;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 
 class QualificationController extends Controller
@@ -84,7 +86,25 @@ class QualificationController extends Controller
         $data = $request->validated();
         $data['status'] = QualificationStatusEnum::Pending;
 
-        $qualification = Qualification::create($data);
+        $qualification = DB::transaction(function () use ($request, $data) {
+            $qualification = Qualification::create(
+                collect($data)->except(['document_type', 'document_title', 'file_name'])->all()
+            );
+
+            if ($request->hasFile('file_name')) {
+                $path = Storage::disk('qualifications-documents')->put('/', $request->file('file_name'));
+                $qualification->documents()->create([
+                    'document_type' => $request->input('document_type'),
+                    'document_title' => $request->input('document_title')
+                        ?? pathinfo($request->file('file_name')->getClientOriginalName(), PATHINFO_FILENAME),
+                    'document_status' => 'P',
+                    'file_name' => $path,
+                    'file_type' => $request->file('file_name')->getMimeType(),
+                ]);
+            }
+
+            return $qualification;
+        });
 
         // Send notification to all users with approve permission
         $qualification->load('person');

--- a/app/Http/Controllers/QualificationDocumentController.php
+++ b/app/Http/Controllers/QualificationDocumentController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\UpdateQualificationDocumentRequest;
+use App\Models\Document;
 use App\Models\Qualification;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class QualificationDocumentController extends Controller
@@ -44,5 +46,28 @@ class QualificationDocumentController extends Controller
         $qualification->documents()->delete();
 
         return back()->with('success', 'Qualification Document has been deleted.');
+    }
+
+    public function destroy(Request $request, Qualification $qualification, Document $document): mixed
+    {
+        abort_unless(
+            $document->documentable_id === $qualification->id
+                && $document->documentable_type === Qualification::class,
+            404,
+        );
+
+        abort_unless(
+            $qualification->canBeEditedBy($request->user())
+                || $request->user()?->can('approve staff qualification'),
+            403,
+        );
+
+        if ($document->file_name && Storage::disk('qualifications-documents')->exists($document->file_name)) {
+            Storage::disk('qualifications-documents')->delete($document->file_name);
+        }
+
+        $document->delete();
+
+        return back()->with('success', 'Document removed.');
     }
 }

--- a/app/Http/Controllers/QualificationDocumentController.php
+++ b/app/Http/Controllers/QualificationDocumentController.php
@@ -2,14 +2,53 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\DocumentTypeEnum;
 use App\Http\Requests\UpdateQualificationDocumentRequest;
 use App\Models\Document;
 use App\Models\Qualification;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rules\Enum;
 
 class QualificationDocumentController extends Controller
 {
+    public function store(Request $request, Qualification $qualification): mixed
+    {
+        abort_unless(
+            $qualification->canBeEditedBy($request->user())
+                || $request->user()?->can('approve staff qualification'),
+            403,
+        );
+
+        $validated = $request->validate([
+            'file_name' => 'required|array|min:1',
+            'file_name.*' => 'required|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'document_type' => 'required|array|min:1',
+            'document_type.*' => ['required', new Enum(DocumentTypeEnum::class)],
+            'document_title' => 'required|array|min:1',
+            'document_title.*' => 'required|string|max:100',
+        ]);
+
+        DB::transaction(function () use ($qualification, $request, $validated) {
+            $types = $validated['document_type'];
+            $titles = $validated['document_title'];
+
+            foreach ($request->file('file_name') as $i => $file) {
+                $path = Storage::disk('qualifications-documents')->put('/', $file);
+                $qualification->documents()->create([
+                    'document_type' => $types[$i] ?? null,
+                    'document_title' => $titles[$i] ?? null,
+                    'document_status' => 'P',
+                    'file_name' => $path,
+                    'file_type' => $file->getMimeType(),
+                ]);
+            }
+        });
+
+        return back()->with('success', 'Documents attached.');
+    }
+
     public function update(UpdateQualificationDocumentRequest $request, Qualification $qualification)
     {
         // return $request->validated();

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use App\Models\Person;
-use App\Models\Qualification;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Tightenco\Ziggy\Ziggy;
@@ -16,6 +15,15 @@ class HandleInertiaRequests extends Middleware
      * @var string
      */
     protected $rootView = 'app';
+
+    /**
+     * Per-request memoized result of {@see profileFactsForCurrentUser()}.
+     * Laravel resolves middleware fresh per request, so this stays
+     * request-scoped without leaking across users.
+     *
+     * @var array{has_photo: bool, qualifications_count: int}|null|false
+     */
+    private array|false|null $profileFactsCache = false;
 
     /**
      * Determine the current asset version.
@@ -48,8 +56,8 @@ class HandleInertiaRequests extends Middleware
                 'viewMode' => fn () => $request->session()->get('view_mode'),
                 'isMultiRoleStaff' => fn () => $request->user()?->isMultiRoleStaff() ?? false,
                 'viewModeLabel' => fn () => $this->resolveViewModeLabel($request->user()),
-                'has_photo' => fn () => $this->hasPhotoForCurrentUser($request),
-                'qualifications_count' => fn () => $this->qualificationsCountForCurrentUser($request),
+                'has_photo' => fn () => $this->profileFactsForCurrentUser($request)['has_photo'] ?? null,
+                'qualifications_count' => fn () => $this->profileFactsForCurrentUser($request)['qualifications_count'] ?? null,
             ],
             // 'permissions' => fn() => $request->user()?->getAllPermissions()->pluck('name'),
             'ziggy' => function () use ($request) {
@@ -75,28 +83,40 @@ class HandleInertiaRequests extends Middleware
         return $user->canAccessAdminDashboard() ? 'Admin' : 'Other';
     }
 
-    private function hasPhotoForCurrentUser(Request $request): ?bool
+    /**
+     * Return the authenticated user's photo-presence and qualification-count
+     * facts as a single associative array, or null when the request has no
+     * authenticated user linked to a Person. The result is memoized for the
+     * life of this request; the underlying query is one eager-loaded count.
+     *
+     * @return array{has_photo: bool, qualifications_count: int}|null
+     */
+    private function profileFactsForCurrentUser(Request $request): ?array
     {
-        $user = $request->user();
-        if (! $user || ! $user->person_id) {
-            return null;
+        if ($this->profileFactsCache !== false) {
+            return $this->profileFactsCache;
         }
 
-        return (bool) Person::query()
+        $user = $request->user();
+        if (! $user || ! $user->person_id) {
+            return $this->profileFactsCache = null;
+        }
+
+        $person = Person::query()
             ->whereKey($user->person_id)
-            ->whereNotNull('image')
-            ->exists();
-    }
+            ->withCount('qualifications')
+            ->first(['id', 'image']);
 
-    private function qualificationsCountForCurrentUser(Request $request): ?int
-    {
-        $user = $request->user();
-        if (! $user || ! $user->person_id) {
-            return null;
+        if (! $person) {
+            return $this->profileFactsCache = [
+                'has_photo' => false,
+                'qualifications_count' => 0,
+            ];
         }
 
-        return Qualification::query()
-            ->where('person_id', $user->person_id)
-            ->count();
+        return $this->profileFactsCache = [
+            'has_photo' => (bool) $person->image,
+            'qualifications_count' => (int) $person->qualifications_count,
+        ];
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Person;
+use App\Models\Qualification;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Tightenco\Ziggy\Ziggy;
@@ -34,13 +36,20 @@ class HandleInertiaRequests extends Middleware
     {
         return array_merge(parent::share($request), [
             'auth' => [
-                'user' => fn () => $request->user()?->only('id', 'name', 'email'),
+                'user' => fn () => $request->user()
+                    ? array_merge(
+                        $request->user()->only('id', 'name', 'email'),
+                        ['person_id' => $request->user()->person_id],
+                    )
+                    : null,
                 'roles' => fn () => $request->user()?->getRoleNames(),
                 // 'is_admin' => fn() => $request->user()?->isAdmin(),
                 'permissions' => fn () => $request->user()?->getAllPermissions()->pluck('name'),
                 'viewMode' => fn () => $request->session()->get('view_mode'),
                 'isMultiRoleStaff' => fn () => $request->user()?->isMultiRoleStaff() ?? false,
                 'viewModeLabel' => fn () => $this->resolveViewModeLabel($request->user()),
+                'has_photo' => fn () => $this->hasPhotoForCurrentUser($request),
+                'qualifications_count' => fn () => $this->qualificationsCountForCurrentUser($request),
             ],
             // 'permissions' => fn() => $request->user()?->getAllPermissions()->pluck('name'),
             'ziggy' => function () use ($request) {
@@ -64,5 +73,30 @@ class HandleInertiaRequests extends Middleware
         }
 
         return $user->canAccessAdminDashboard() ? 'Admin' : 'Other';
+    }
+
+    private function hasPhotoForCurrentUser(Request $request): ?bool
+    {
+        $user = $request->user();
+        if (! $user || ! $user->person_id) {
+            return null;
+        }
+
+        return (bool) Person::query()
+            ->whereKey($user->person_id)
+            ->whereNotNull('image')
+            ->exists();
+    }
+
+    private function qualificationsCountForCurrentUser(Request $request): ?int
+    {
+        $user = $request->user();
+        if (! $user || ! $user->person_id) {
+            return null;
+        }
+
+        return Qualification::query()
+            ->where('person_id', $user->person_id)
+            ->count();
     }
 }

--- a/app/Http/Requests/StoreAddressRequest.php
+++ b/app/Http/Requests/StoreAddressRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAddressRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // Authorization handled in the controller
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'address_line_1' => 'required|string|max:255',
+            'address_line_2' => 'nullable|string|max:255',
+            'city' => 'required|string|max:100',
+            'region' => 'nullable|string|max:100',
+            'country' => 'required|string|max:100',
+            'post_code' => 'nullable|string|max:20',
+        ];
+    }
+
+    /**
+     * Get custom error messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'address_line_1.required' => 'Address line 1 is required.',
+            'address_line_1.max' => 'Address line 1 cannot exceed 255 characters.',
+            'city.required' => 'City is required.',
+            'city.max' => 'City cannot exceed 100 characters.',
+            'country.required' => 'Country is required.',
+            'country.max' => 'Country cannot exceed 100 characters.',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreQualificationRequest.php
+++ b/app/Http/Requests/StoreQualificationRequest.php
@@ -28,7 +28,7 @@ class StoreQualificationRequest extends FormRequest
      *
      * @return array<string, mixed>
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             'person_id' => 'required|integer|exists:people,id',
@@ -39,6 +39,11 @@ class StoreQualificationRequest extends FormRequest
             'level' => 'string|max:50|nullable',
             'pk' => 'string|max:6|nullable',
             'year' => 'string|max:4|nullable',
+
+            // Optional inline document — only validated when a file is uploaded.
+            'document_type' => ['required_with:file_name', 'string', 'nullable', new \Illuminate\Validation\Rules\Enum(\App\Enums\DocumentTypeEnum::class)],
+            'document_title' => 'nullable|string|max:100',
+            'file_name' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
         ];
     }
 }

--- a/app/Http/Requests/StoreQualificationRequest.php
+++ b/app/Http/Requests/StoreQualificationRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\DocumentTypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
 
 class StoreQualificationRequest extends FormRequest
 {
@@ -40,10 +42,13 @@ class StoreQualificationRequest extends FormRequest
             'pk' => 'string|max:6|nullable',
             'year' => 'string|max:4|nullable',
 
-            // Optional inline documents — only validated when files are uploaded.
-            'document_type' => ['required_with:file_name', 'nullable', new \Illuminate\Validation\Rules\Enum(\App\Enums\DocumentTypeEnum::class)],
+            // Per-file parallel arrays — all three are required together when any file is uploaded.
             'file_name' => 'nullable|array',
             'file_name.*' => 'file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'document_type' => 'nullable|array|required_with:file_name',
+            'document_type.*' => ['required', new Enum(DocumentTypeEnum::class)],
+            'document_title' => 'nullable|array|required_with:file_name',
+            'document_title.*' => 'required|string|max:100',
         ];
     }
 }

--- a/app/Http/Requests/StoreQualificationRequest.php
+++ b/app/Http/Requests/StoreQualificationRequest.php
@@ -40,10 +40,10 @@ class StoreQualificationRequest extends FormRequest
             'pk' => 'string|max:6|nullable',
             'year' => 'string|max:4|nullable',
 
-            // Optional inline document — only validated when a file is uploaded.
-            'document_type' => ['required_with:file_name', 'string', 'nullable', new \Illuminate\Validation\Rules\Enum(\App\Enums\DocumentTypeEnum::class)],
-            'document_title' => 'nullable|string|max:100',
-            'file_name' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            // Optional inline documents — only validated when files are uploaded.
+            'document_type' => ['required_with:file_name', 'nullable', new \Illuminate\Validation\Rules\Enum(\App\Enums\DocumentTypeEnum::class)],
+            'file_name' => 'nullable|array',
+            'file_name.*' => 'file|mimes:pdf,jpg,jpeg,png|max:2048',
         ];
     }
 }

--- a/app/Http/Requests/UpdateContactRequest.php
+++ b/app/Http/Requests/UpdateContactRequest.php
@@ -13,7 +13,8 @@ class UpdateContactRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true; // Authorization handled by route middleware
+        // Authorization enforced by ContactPolicy via $this->authorize() in the controller.
+        return true;
     }
 
     /**

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Address extends Model
 {
-    use HasFactory, SoftDeletes, LogAllTraits;
+    use HasFactory, LogAllTraits, SoftDeletes;
 
     protected $fillable = [
         'address_line_1',
@@ -18,6 +18,7 @@ class Address extends Model
         'region',
         'country',
         'post_code',
+        'valid_end',
     ];
 
     public function addressable()

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -32,4 +32,24 @@ class Contact extends Model
     {
         return $this->belongsTo(Person::class);
     }
+
+    /**
+     * Returns true when this contact is an Audit Service organisational email
+     * (domain exactly equals audit.gov.gh, case-insensitive).
+     * These addresses must not be deletable by end users.
+     */
+    public function isProtectedOrgEmail(): bool
+    {
+        if ($this->contact_type !== ContactTypeEnum::EMAIL) {
+            return false;
+        }
+        $email = strtolower((string) $this->contact);
+        $atPos = strrpos($email, '@');
+        if ($atPos === false) {
+            return false;
+        }
+        $domain = substr($email, $atPos + 1);
+
+        return $domain === 'audit.gov.gh';
+    }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -33,18 +33,26 @@ class Person extends Model
         'country_of_birth',
         'nationality',
         'image',
+        'pending_image',
+        'pending_image_at',
+        'image_approved_by',
+        'image_approved_at',
         'ethnicity',
         'religion',
         'about',
-
     ];
 
-    protected $casts = [
-        'gender' => GenderEnum::class,
-        'date_of_birth' => 'date',
-        'marital_status' => MaritalStatusEnum::class,
-        'nationality' => CountryEnum::class,
-    ];
+    protected function casts(): array
+    {
+        return [
+            'gender' => GenderEnum::class,
+            'date_of_birth' => 'date',
+            'marital_status' => MaritalStatusEnum::class,
+            'nationality' => CountryEnum::class,
+            'pending_image_at' => 'datetime',
+            'image_approved_at' => 'datetime',
+        ];
+    }
 
     // / get full name of person
     public function getFullNameAttribute(): string

--- a/app/Notifications/PhotoApprovedNotification.php
+++ b/app/Notifications/PhotoApprovedNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Person;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PhotoApprovedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Person $person
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your Profile Photo Has Been Approved')
+            ->greeting('Hello ' . $notifiable->name . ',')
+            ->line('Your profile photo has been approved and is now live across the HR system.')
+            ->action('View My Profile', url('/my-profile'))
+            ->line('Thank you for keeping your profile up to date.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'person_id' => $this->person->id,
+            'person_name' => $this->person->full_name,
+            'message' => 'Your profile photo has been approved',
+        ];
+    }
+}

--- a/app/Notifications/PhotoPendingApprovalNotification.php
+++ b/app/Notifications/PhotoPendingApprovalNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Person;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PhotoPendingApprovalNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Person $person
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New Profile Photo Pending Approval')
+            ->greeting('Hello ' . $notifiable->name . ',')
+            ->line('A staff member has submitted a new profile photo that requires your approval.')
+            ->line('**Staff:** ' . $this->person->full_name)
+            ->action('Review Photo Approvals', url('/staff-photo-approvals'))
+            ->line('Please review and approve or reject this photo submission.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'person_id' => $this->person->id,
+            'person_name' => $this->person->full_name,
+            'message' => 'New profile photo pending approval',
+        ];
+    }
+}

--- a/app/Notifications/PhotoRejectedNotification.php
+++ b/app/Notifications/PhotoRejectedNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Person;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PhotoRejectedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Person $person
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your Profile Photo Submission Was Rejected')
+            ->greeting('Hello ' . $notifiable->name . ',')
+            ->line('Your profile photo submission has been reviewed and was not approved.')
+            ->line('You are welcome to submit a new photo at any time.')
+            ->action('Update My Profile', url('/my-profile'))
+            ->line('Please ensure your photo meets the requirements before resubmitting.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'person_id' => $this->person->id,
+            'person_name' => $this->person->full_name,
+            'message' => 'Your profile photo submission was rejected',
+        ];
+    }
+}

--- a/app/Policies/AddressPolicy.php
+++ b/app/Policies/AddressPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Address;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AddressPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view staff') || $user->can('view all staff');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Address $address): bool
+    {
+        return $user->can('view staff') || $this->ownsAddress($user, $address);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('update staff') || $user->can('create staff');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Address $address): bool
+    {
+        return $user->can('update staff') || $this->ownsAddress($user, $address);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Address $address): bool
+    {
+        return $user->can('update staff') || $this->ownsAddress($user, $address);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Address $address): bool
+    {
+        return $user->can('restore staff');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Address $address): bool
+    {
+        return $user->can('destroy staff');
+    }
+
+    /**
+     * Check if the address belongs to the user's person record.
+     * Address uses a morph relationship (addressable_id / addressable_type).
+     */
+    private function ownsAddress(User $user, Address $address): bool
+    {
+        return $address->addressable_type === (new Person)->getMorphClass()
+            && $address->addressable_id === $user->person_id;
+    }
+}

--- a/app/Services/StaffProfileProvider.php
+++ b/app/Services/StaffProfileProvider.php
@@ -67,6 +67,8 @@ final class StaffProfileProvider
             'religion' => $staff->person->religion,
             'marital_status' => $staff->person->marital_status?->label(),
             'image' => $staff->person->image ? '/storage/' . $staff->person->image : null,
+            'pending_image' => $staff->person->pending_image ? '/storage/' . $staff->person->pending_image : null,
+            'pending_image_at' => $staff->person->pending_image_at?->diffForHumans(),
             'identities' => $staff->person->identities->map(fn ($id) => [
                 'id' => $id->id,
                 'id_type' => $id->id_type,

--- a/app/Services/StaffProfileProvider.php
+++ b/app/Services/StaffProfileProvider.php
@@ -13,7 +13,7 @@ final class StaffProfileProvider
      * Build the profile payload consumed by both the admin Staff/NewShow page
      * and the self-service MyProfile page.
      *
-     * @return array{person: array, qualifications: array, contacts: array|null, address: array|null, staff: array}|null
+     * @return array{person: array, qualifications: array, contacts: array, address: array|null, staff: array}|null
      */
     public function forPerson(int $personId): ?array
     {
@@ -67,14 +67,12 @@ final class StaffProfileProvider
             'religion' => $staff->person->religion,
             'marital_status' => $staff->person->marital_status?->label(),
             'image' => $staff->person->image ? '/storage/' . $staff->person->image : null,
-            'identities' => $staff->person->identities->count() > 0
-                ? $staff->person->identities->map(fn ($id) => [
-                    'id' => $id->id,
-                    'id_type' => $id->id_type,
-                    'id_type_display' => $id->id_type->label(),
-                    'id_number' => $id->id_number,
-                ])->all()
-                : null,
+            'identities' => $staff->person->identities->map(fn ($id) => [
+                'id' => $id->id,
+                'id_type' => $id->id_type,
+                'id_type_display' => $id->id_type->label(),
+                'id_number' => $id->id_number,
+            ])->all(),
         ];
     }
 
@@ -110,12 +108,8 @@ final class StaffProfileProvider
             ->all();
     }
 
-    private function mapContacts(InstitutionPerson $staff): ?array
+    private function mapContacts(InstitutionPerson $staff): array
     {
-        if ($staff->person->contacts->count() === 0) {
-            return null;
-        }
-
         return $staff->person->contacts->map(fn ($c) => [
             'id' => $c->id,
             'contact' => $c->contact,

--- a/app/Services/StaffProfileProvider.php
+++ b/app/Services/StaffProfileProvider.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\QualificationLevelEnum;
+use App\Models\InstitutionPerson;
+use App\Models\Qualification;
+use Carbon\Carbon;
+
+final class StaffProfileProvider
+{
+    /**
+     * Build the profile payload consumed by both the admin Staff/NewShow page
+     * and the self-service MyProfile page.
+     *
+     * @return array{person: array, qualifications: array, contacts: array|null, address: array|null, staff: array}|null
+     */
+    public function forPerson(int $personId): ?array
+    {
+        $staff = InstitutionPerson::query()
+            ->with([
+                'person' => function ($query) {
+                    $query->with([
+                        'address' => fn ($q) => $q->whereNull('valid_end'),
+                        'contacts',
+                        'identities' => fn ($q) => $q->withTrashed(),
+                        'qualifications',
+                    ]);
+                },
+                'units' => fn ($query) => $query->with(['institution', 'parent']),
+                'ranks',
+                'dependents.person',
+                'statuses',
+                'notes.documents',
+                'positions' => fn ($query) => $query->withTrashed(),
+            ])
+            ->active()
+            ->where('person_id', $personId)
+            ->first();
+
+        if (! $staff) {
+            return null;
+        }
+
+        return [
+            'person' => $this->mapPerson($staff),
+            'qualifications' => $this->mapQualifications($staff->person->id),
+            'contacts' => $this->mapContacts($staff),
+            'address' => $this->mapAddress($staff),
+            'staff' => $this->mapStaff($staff),
+        ];
+    }
+
+    private function mapPerson(InstitutionPerson $staff): array
+    {
+        return [
+            'id' => $staff->person->id,
+            'name' => $staff->person->full_name,
+            'maiden_name' => $staff->person->maiden_name,
+            'dob-value' => $staff->person->date_of_birth,
+            'dob' => $staff->person->date_of_birth?->format('d M Y'),
+            'age' => $staff->person->age . ' years old',
+            'gender' => $staff->person->gender?->label(),
+            'ssn' => $staff->person->social_security_number,
+            'initials' => $staff->person->initials,
+            'nationality' => $staff->person->nationality?->nationality(),
+            'religion' => $staff->person->religion,
+            'marital_status' => $staff->person->marital_status?->label(),
+            'image' => $staff->person->image ? '/storage/' . $staff->person->image : null,
+            'identities' => $staff->person->identities->count() > 0
+                ? $staff->person->identities->map(fn ($id) => [
+                    'id' => $id->id,
+                    'id_type' => $id->id_type,
+                    'id_type_display' => $id->id_type->label(),
+                    'id_number' => $id->id_number,
+                ])->all()
+                : null,
+        ];
+    }
+
+    private function mapQualifications(int $personId): array
+    {
+        return Qualification::query()
+            ->where('person_id', $personId)
+            ->visibleTo(auth()->user(), $personId)
+            ->with('documents')
+            ->get()
+            ->map(fn ($q) => [
+                'id' => $q->id,
+                'person_id' => $q->person_id,
+                'course' => $q->course,
+                'institution' => $q->institution,
+                'qualification' => $q->qualification,
+                'qualification_number' => $q->qualification_number,
+                'level' => $q->level ? QualificationLevelEnum::tryFrom($q->level)?->label() ?? $q->level : null,
+                'year' => $q->year,
+                'status' => $q->status?->label(),
+                'status_color' => $q->status?->color(),
+                'can_edit' => $q->canBeEditedBy(auth()->user()),
+                'can_delete' => $q->canBeDeletedBy(auth()->user()),
+                'documents' => $q->documents->count() > 0 ? $q->documents->map(fn ($d) => [
+                    'document_type' => $d->document_type,
+                    'document_title' => $d->document_title,
+                    'document_status' => $d->document_status,
+                    'document_number' => $d->document_number,
+                    'file_name' => $d->file_name,
+                    'file_type' => $d->file_type,
+                ])->all() : null,
+            ])
+            ->all();
+    }
+
+    private function mapContacts(InstitutionPerson $staff): ?array
+    {
+        if ($staff->person->contacts->count() === 0) {
+            return null;
+        }
+
+        return $staff->person->contacts->map(fn ($c) => [
+            'id' => $c->id,
+            'contact' => $c->contact,
+            'contact_type' => $c->contact_type,
+            'contact_type_dis' => $c->contact_type->label(),
+            'valid_end' => $c->valid_end,
+        ])->all();
+    }
+
+    private function mapAddress(InstitutionPerson $staff): ?array
+    {
+        $address = $staff->person->address->first();
+        if (! $address) {
+            return null;
+        }
+
+        return [
+            'id' => $address->id,
+            'address_line_1' => $address->address_line_1,
+            'address_line_2' => $address->address_line_2,
+            'city' => $address->city,
+            'region' => $address->region,
+            'country' => $address->country,
+            'post_code' => $address->post_code,
+            'valid_end' => $address->valid_end,
+        ];
+    }
+
+    private function mapStaff(InstitutionPerson $staff): array
+    {
+        return [
+            'staff_id' => $staff->id,
+            'institution_id' => $staff->institution_id,
+            'staff_number' => $staff->staff_number,
+            'file_number' => $staff->file_number,
+            'old_staff_number' => $staff->old_staff_number,
+            'hire_date' => $staff->hire_date?->format('d M Y'),
+            'hire_date_display' => $staff->hire_date?->diffForHumans(),
+            'retirement_date' => $staff->retirement_date_formatted,
+            'retirement_date_display' => $staff->retirement_date_diff,
+            'start_date' => $staff->start_date?->format('d M Y'),
+            'statuses' => $staff->statuses?->map(fn ($s) => [
+                'id' => $s->id,
+                'status' => $s->status,
+                'status_display' => $s->status?->name,
+                'description' => $s->description,
+                'start_date' => $s->start_date?->format('Y-m-d'),
+                'start_date_display' => $s->start_date?->format('d M Y'),
+                'end_date' => $s->end_date?->format('Y-m-d'),
+                'end_date_display' => $s->end_date?->format('d M Y'),
+            ])->all(),
+            'staff_type' => $staff->type?->map(fn ($t) => [
+                'id' => $t->id,
+                'type' => $t->staff_type,
+                'type_label' => $t->staff_type->label(),
+                'start_date' => $t->start_date?->format('Y-m-d'),
+                'start_date_display' => $t->start_date?->format('d M Y'),
+                'end_date' => $t->end_date?->format('Y-m-d'),
+                'end_date_display' => $t->end_date?->format('d M Y'),
+            ])->all(),
+            'positions' => $staff->positions?->map(fn ($p) => [
+                'id' => $p->id,
+                'name' => $p->name,
+                'start_date' => $p->pivot->start_date,
+                'end_date' => $p->pivot->end_date,
+                'start_date_display' => $p->pivot->start_date ? Carbon::parse($p->pivot->start_date)->format('d M Y') : null,
+                'end_date_display' => $p->pivot->end_date ? Carbon::parse($p->pivot->end_date)->format('d M Y') : null,
+            ])->all(),
+            'ranks' => $staff->ranks->map(fn ($r) => [
+                'id' => $r->id,
+                'name' => $r->name,
+                'staff_name' => $staff->person->full_name,
+                'staff_id' => $r->pivot->staff_id,
+                'rank_id' => $r->pivot->job_id,
+                'start_date' => $r->pivot->start_date?->format('d M Y'),
+                'start_date_unix' => $r->pivot->start_date?->format('Y-m-d'),
+                'end_date' => $r->pivot->end_date?->format('d M Y'),
+                'end_date_unix' => $r->pivot->end_date?->format('Y-m-d'),
+                'remarks' => $r->pivot->remarks,
+                'distance' => $r->pivot->start_date?->diffForHumans(),
+            ])->all(),
+            'notes' => $staff->notes->count() > 0 ? $staff->notes->map(fn ($n) => [
+                'id' => $n->id,
+                'note' => $n->note,
+                'note_date' => $n->note_date->diffForHumans(),
+                'note_date_time' => $n->note_date,
+                'note_type' => $n->note_type,
+                'created_by' => $n->created_by,
+                'url' => $n->documents->count() > 0 ? $n->documents->map(fn ($d) => [
+                    'document_type' => $d->document_type,
+                    'document_title' => $d->document_title,
+                    'file_name' => $d->file_name,
+                    'file_type' => $d->file_type,
+                ])->all() : null,
+            ])->all() : null,
+            'units' => $staff->units->map(fn ($u) => [
+                'unit_id' => $u->id,
+                'unit_name' => $u->name,
+                'status' => $u->pivot->status?->label(),
+                'status_color' => $u->pivot->status?->color(),
+                'department' => $u->parent?->name,
+                'department_short_name' => $u->parent?->short_name,
+                'staff_id' => $u->pivot->staff_id,
+                'start_date' => $u->pivot->start_date?->format('d M Y'),
+                'start_date_unix' => $u->pivot->start_date?->format('Y-m-d'),
+                'end_date' => $u->pivot->end_date?->format('d M Y'),
+                'end_date_unix' => $u->pivot->end_date?->format('Y-m-d'),
+                'distance' => $u->pivot->start_date?->diffForHumans(),
+                'remarks' => $u->pivot->remarks,
+                'old_data' => $u->pivot->old_data,
+            ])->all(),
+            'dependents' => $staff->dependents ? $staff->dependents->map(fn ($d) => [
+                'id' => $d->id,
+                'person_id' => $d->person_id,
+                'initials' => $d->person->initials,
+                'title' => $d->person->title,
+                'name' => $d->person->full_name,
+                'surname' => $d->person->surname,
+                'first_name' => $d->person->first_name,
+                'other_names' => $d->person->other_names,
+                'maiden_name' => $d->person->maiden_name,
+                'nationality' => $d->person->nationality?->label(),
+                'nationality_form' => $d->person->nationality,
+                'marital_status' => $d->person->marital_status,
+                'image' => $d->person->image ? '/storage/' . $d->person->image : null,
+                'religion' => $d->person->religion,
+                'gender' => $d->person->gender?->label(),
+                'gender_form' => $d->person->gender,
+                'date_of_birth' => $d->person->date_of_birth?->format('Y-m-d'),
+                'age' => $d->person->age . ' years old',
+                'relation' => $d->relation,
+                'staff_id' => $staff->id,
+                'contacts' => $d->person->contacts->map(fn ($c) => [
+                    'id' => $c->id,
+                    'type' => $c->contact_type?->label(),
+                    'contact' => $c->contact,
+                ])->all(),
+            ])->all() : null,
+        ];
+    }
+}

--- a/app/Services/StaffProfileProvider.php
+++ b/app/Services/StaffProfileProvider.php
@@ -97,6 +97,7 @@ final class StaffProfileProvider
                 'can_edit' => $q->canBeEditedBy(auth()->user()),
                 'can_delete' => $q->canBeDeletedBy(auth()->user()),
                 'documents' => $q->documents->count() > 0 ? $q->documents->map(fn ($d) => [
+                    'id' => $d->id,
                     'document_type' => $d->document_type,
                     'document_title' => $d->document_title,
                     'document_status' => $d->document_status,

--- a/database/migrations/2026_04_17_174921_add_pending_photo_columns_to_people_table.php
+++ b/database/migrations/2026_04_17_174921_add_pending_photo_columns_to_people_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->string('pending_image')->nullable()->after('image');
+            $table->timestamp('pending_image_at')->nullable()->after('pending_image');
+            $table->foreignId('image_approved_by')->nullable()->constrained('users')->nullOnDelete()->after('pending_image_at');
+            $table->timestamp('image_approved_at')->nullable()->after('image_approved_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('people', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('image_approved_by');
+            $table->dropColumn(['pending_image', 'pending_image_at', 'image_approved_at']);
+        });
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -53,6 +53,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'qualifications.reports.view',
             'qualifications.reports.export',
             'qualifications.reports.view.all',
+            'approve staff photo',
         ],
 
         'aag-admin' => [
@@ -80,6 +81,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'qualifications.reports.view',
             'qualifications.reports.export',
             'qualifications.reports.view.all',
+            'approve staff photo',
         ],
 
         'personel-user' => [

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -127,8 +127,10 @@ class RolesAndPermissionsSeeder extends Seeder
             'view staff',
             'upload avatar',
             'edit avatar',
-            'create staff qualification',
             'view staff qualification',
+            'create staff qualification',
+            'edit staff qualification',
+            'delete staff qualification',
             'update contacts',
         ],
     ];

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -129,6 +129,7 @@ class RolesAndPermissionsSeeder extends Seeder
             'edit avatar',
             'create staff qualification',
             'view staff qualification',
+            'update contacts',
         ],
     ];
 

--- a/docs/superpowers/plans/2026-04-17-staff-my-profile-redesign.md
+++ b/docs/superpowers/plans/2026-04-17-staff-my-profile-redesign.md
@@ -1,0 +1,2030 @@
+# Staff "My Profile" Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a new staff-facing `/my-profile` page that puts photo upload and qualification management front and center for first-time self-service users, while keeping the existing admin `Staff/NewShow.vue` unchanged.
+
+**Architecture:** A new `StaffProfileProvider` service extracts the eager-load-and-map payload currently inlined in `InstitutionPersonController@show` so it can be reused by a new `MyProfileController`. The controller renders `Pages/MyProfile/Index.vue`, composed of focused components under `Components/MyProfile/` that reuse existing modals (`AddQualification`, `EditContactForm`, etc.) and the existing `PersonAvatarController` endpoints. Three new fields on `HandleInertiaRequests` (`person_id`, `has_photo`, `qualifications_count`) power a dismissible completion banner for multi-role users, and `DashboardController::redirectToStaffLanding` is updated to land staff-only users on `/my-profile` instead of the admin staff show.
+
+**Tech Stack:** Laravel 11, Inertia.js v1, Vue 3 + Tailwind 3, PHPUnit 11, Spatie Permission, HeadlessUI, FormKit, existing project image-upload/qualification/contact flows.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-staff-my-profile-redesign-design.md`
+
+**Branch:** `feature/staff-my-profile-redesign`
+
+---
+
+## Task 1: Extract `StaffProfileProvider` service (refactor-safe, TDD)
+
+**Files:**
+- Create: `app/Services/StaffProfileProvider.php`
+- Modify: `app/Http/Controllers/InstitutionPersonController.php` (lines ~174–400 of `show()`)
+- Create: `tests/Unit/Services/StaffProfileProviderTest.php`
+
+- [ ] **Step 1: Add a characterization test for the existing admin payload shape**
+
+Create `tests/Unit/Services/StaffProfileProviderTest.php`:
+
+```php
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\InstitutionPerson;
+use App\Services\StaffProfileProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffProfileProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_null_when_no_active_institution_person_exists(): void
+    {
+        $provider = new StaffProfileProvider;
+
+        $this->assertNull($provider->forPerson(999_999));
+    }
+
+    public function test_returns_payload_with_expected_top_level_keys(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertIsArray($payload);
+        $this->assertSame(
+            ['person', 'qualifications', 'contacts', 'address', 'staff'],
+            array_keys($payload),
+        );
+    }
+
+    public function test_person_block_contains_expected_fields(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertArrayHasKey('id', $payload['person']);
+        $this->assertArrayHasKey('name', $payload['person']);
+        $this->assertArrayHasKey('initials', $payload['person']);
+        $this->assertArrayHasKey('image', $payload['person']);
+        $this->assertArrayHasKey('identities', $payload['person']);
+    }
+
+    public function test_staff_block_contains_expected_employment_fields(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertArrayHasKey('staff_id', $payload['staff']);
+        $this->assertArrayHasKey('staff_number', $payload['staff']);
+        $this->assertArrayHasKey('file_number', $payload['staff']);
+        $this->assertArrayHasKey('hire_date', $payload['staff']);
+        $this->assertArrayHasKey('ranks', $payload['staff']);
+        $this->assertArrayHasKey('units', $payload['staff']);
+        $this->assertArrayHasKey('dependents', $payload['staff']);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect class-not-found**
+
+Run: `php artisan test --filter=StaffProfileProviderTest`
+Expected: FAIL — `Class "App\Services\StaffProfileProvider" not found`
+
+- [ ] **Step 3: Create the service by moving the eager-load + map from the controller**
+
+Create `app/Services/StaffProfileProvider.php`:
+
+```php
+<?php
+
+namespace App\Services;
+
+use App\Enums\QualificationLevelEnum;
+use App\Models\InstitutionPerson;
+use App\Models\Qualification;
+use Carbon\Carbon;
+
+final class StaffProfileProvider
+{
+    /**
+     * Build the profile payload consumed by both the admin Staff/NewShow page
+     * and the self-service MyProfile page.
+     *
+     * @return array{person: array, qualifications: array, contacts: array|null, address: array|null, staff: array}|null
+     */
+    public function forPerson(int $personId): ?array
+    {
+        $staff = InstitutionPerson::query()
+            ->with([
+                'person' => function ($query) {
+                    $query->with([
+                        'address' => fn ($q) => $q->whereNull('valid_end'),
+                        'contacts',
+                        'identities' => fn ($q) => $q->withTrashed(),
+                        'qualifications',
+                    ]);
+                },
+                'units' => fn ($query) => $query->with(['institution', 'parent']),
+                'ranks',
+                'dependents.person',
+                'statuses',
+                'notes.documents',
+                'positions' => fn ($query) => $query->withTrashed(),
+            ])
+            ->active()
+            ->where('person_id', $personId)
+            ->first();
+
+        if (! $staff) {
+            return null;
+        }
+
+        return [
+            'person' => $this->mapPerson($staff),
+            'qualifications' => $this->mapQualifications($staff->person->id),
+            'contacts' => $this->mapContacts($staff),
+            'address' => $this->mapAddress($staff),
+            'staff' => $this->mapStaff($staff),
+        ];
+    }
+
+    private function mapPerson(InstitutionPerson $staff): array
+    {
+        return [
+            'id' => $staff->person->id,
+            'name' => $staff->person->full_name,
+            'maiden_name' => $staff->person->maiden_name,
+            'dob-value' => $staff->person->date_of_birth,
+            'dob' => $staff->person->date_of_birth?->format('d M Y'),
+            'age' => $staff->person->age.' years old',
+            'gender' => $staff->person->gender?->label(),
+            'ssn' => $staff->person->social_security_number,
+            'initials' => $staff->person->initials,
+            'nationality' => $staff->person->nationality?->nationality(),
+            'religion' => $staff->person->religion,
+            'marital_status' => $staff->person->marital_status?->label(),
+            'image' => $staff->person->image ? '/storage/'.$staff->person->image : null,
+            'identities' => $staff->person->identities->count() > 0
+                ? $staff->person->identities->map(fn ($id) => [
+                    'id' => $id->id,
+                    'id_type' => $id->id_type,
+                    'id_type_display' => $id->id_type->label(),
+                    'id_number' => $id->id_number,
+                ])->all()
+                : null,
+        ];
+    }
+
+    private function mapQualifications(int $personId): array
+    {
+        return Qualification::query()
+            ->where('person_id', $personId)
+            ->visibleTo(auth()->user(), $personId)
+            ->with('documents')
+            ->get()
+            ->map(fn ($q) => [
+                'id' => $q->id,
+                'person_id' => $q->person_id,
+                'course' => $q->course,
+                'institution' => $q->institution,
+                'qualification' => $q->qualification,
+                'qualification_number' => $q->qualification_number,
+                'level' => $q->level ? QualificationLevelEnum::tryFrom($q->level)?->label() ?? $q->level : null,
+                'year' => $q->year,
+                'status' => $q->status?->label(),
+                'status_color' => $q->status?->color(),
+                'can_edit' => $q->canBeEditedBy(auth()->user()),
+                'can_delete' => $q->canBeDeletedBy(auth()->user()),
+                'documents' => $q->documents->count() > 0 ? $q->documents->map(fn ($d) => [
+                    'document_type' => $d->document_type,
+                    'document_title' => $d->document_title,
+                    'document_status' => $d->document_status,
+                    'document_number' => $d->document_number,
+                    'file_name' => $d->file_name,
+                    'file_type' => $d->file_type,
+                ])->all() : null,
+            ])
+            ->all();
+    }
+
+    private function mapContacts(InstitutionPerson $staff): ?array
+    {
+        if ($staff->person->contacts->count() === 0) {
+            return null;
+        }
+
+        return $staff->person->contacts->map(fn ($c) => [
+            'id' => $c->id,
+            'contact' => $c->contact,
+            'contact_type' => $c->contact_type,
+            'contact_type_dis' => $c->contact_type->label(),
+            'valid_end' => $c->valid_end,
+        ])->all();
+    }
+
+    private function mapAddress(InstitutionPerson $staff): ?array
+    {
+        $address = $staff->person->address->first();
+        if (! $address) {
+            return null;
+        }
+
+        return [
+            'id' => $address->id,
+            'address_line_1' => $address->address_line_1,
+            'address_line_2' => $address->address_line_2,
+            'city' => $address->city,
+            'region' => $address->region,
+            'country' => $address->country,
+            'post_code' => $address->post_code,
+            'valid_end' => $address->valid_end,
+        ];
+    }
+
+    private function mapStaff(InstitutionPerson $staff): array
+    {
+        return [
+            'staff_id' => $staff->id,
+            'institution_id' => $staff->institution_id,
+            'staff_number' => $staff->staff_number,
+            'file_number' => $staff->file_number,
+            'old_staff_number' => $staff->old_staff_number,
+            'hire_date' => $staff->hire_date?->format('d M Y'),
+            'hire_date_display' => $staff->hire_date?->diffForHumans(),
+            'retirement_date' => $staff->retirement_date_formatted,
+            'retirement_date_display' => $staff->retirement_date_diff,
+            'start_date' => $staff->start_date?->format('d M Y'),
+            'statuses' => $staff->statuses?->map(fn ($s) => [
+                'id' => $s->id,
+                'status' => $s->status,
+                'status_display' => $s->status?->name,
+                'description' => $s->description,
+                'start_date' => $s->start_date?->format('Y-m-d'),
+                'start_date_display' => $s->start_date?->format('d M Y'),
+                'end_date' => $s->end_date?->format('Y-m-d'),
+                'end_date_display' => $s->end_date?->format('d M Y'),
+            ])->all(),
+            'staff_type' => $staff->type?->map(fn ($t) => [
+                'id' => $t->id,
+                'type' => $t->staff_type,
+                'type_label' => $t->staff_type->label(),
+                'start_date' => $t->start_date?->format('Y-m-d'),
+                'start_date_display' => $t->start_date?->format('d M Y'),
+                'end_date' => $t->end_date?->format('Y-m-d'),
+                'end_date_display' => $t->end_date?->format('d M Y'),
+            ])->all(),
+            'positions' => $staff->positions?->map(fn ($p) => [
+                'id' => $p->id,
+                'name' => $p->name,
+                'start_date' => $p->pivot->start_date,
+                'end_date' => $p->pivot->end_date,
+                'start_date_display' => $p->pivot->start_date ? Carbon::parse($p->pivot->start_date)->format('d M Y') : null,
+                'end_date_display' => $p->pivot->end_date ? Carbon::parse($p->pivot->end_date)->format('d M Y') : null,
+            ])->all(),
+            'ranks' => $staff->ranks->map(fn ($r) => [
+                'id' => $r->id,
+                'name' => $r->name,
+                'staff_name' => $staff->person->full_name,
+                'staff_id' => $r->pivot->staff_id,
+                'rank_id' => $r->pivot->job_id,
+                'start_date' => $r->pivot->start_date?->format('d M Y'),
+                'start_date_unix' => $r->pivot->start_date?->format('Y-m-d'),
+                'end_date' => $r->pivot->end_date?->format('d M Y'),
+                'end_date_unix' => $r->pivot->end_date?->format('Y-m-d'),
+                'remarks' => $r->pivot->remarks,
+                'distance' => $r->pivot->start_date?->diffForHumans(),
+            ])->all(),
+            'notes' => $staff->notes->count() > 0 ? $staff->notes->map(fn ($n) => [
+                'id' => $n->id,
+                'note' => $n->note,
+                'note_date' => $n->note_date->diffForHumans(),
+                'note_date_time' => $n->note_date,
+                'note_type' => $n->note_type,
+                'created_by' => $n->created_by,
+                'url' => $n->documents->count() > 0 ? $n->documents->map(fn ($d) => [
+                    'document_type' => $d->document_type,
+                    'document_title' => $d->document_title,
+                    'file_name' => $d->file_name,
+                    'file_type' => $d->file_type,
+                ])->all() : null,
+            ])->all() : null,
+            'units' => $staff->units->map(fn ($u) => [
+                'unit_id' => $u->id,
+                'unit_name' => $u->name,
+                'status' => $u->pivot->status?->label(),
+                'status_color' => $u->pivot->status?->color(),
+                'department' => $u->parent?->name,
+                'department_short_name' => $u->parent?->short_name,
+                'staff_id' => $u->pivot->staff_id,
+                'start_date' => $u->pivot->start_date?->format('d M Y'),
+                'start_date_unix' => $u->pivot->start_date?->format('Y-m-d'),
+                'end_date' => $u->pivot->end_date?->format('d M Y'),
+                'end_date_unix' => $u->pivot->end_date?->format('Y-m-d'),
+                'distance' => $u->pivot->start_date?->diffForHumans(),
+                'remarks' => $u->pivot->remarks,
+                'old_data' => $u->pivot->old_data,
+            ])->all(),
+            'dependents' => $staff->dependents ? $staff->dependents->map(fn ($d) => [
+                'id' => $d->id,
+                'person_id' => $d->person_id,
+                'initials' => $d->person->initials,
+                'title' => $d->person->title,
+                'name' => $d->person->full_name,
+                'surname' => $d->person->surname,
+                'first_name' => $d->person->first_name,
+                'other_names' => $d->person->other_names,
+                'maiden_name' => $d->person->maiden_name,
+                'nationality' => $d->person->nationality?->label(),
+                'nationality_form' => $d->person->nationality,
+                'marital_status' => $d->person->marital_status,
+                'image' => $d->person->image ? '/storage/'.$d->person->image : null,
+                'religion' => $d->person->religion,
+                'gender' => $d->person->gender?->label(),
+                'gender_form' => $d->person->gender,
+                'date_of_birth' => $d->person->date_of_birth?->format('Y-m-d'),
+                'age' => $d->person->age.' years old',
+                'relation' => $d->relation,
+                'staff_id' => $staff->id,
+                'contacts' => $d->person->contacts->map(fn ($c) => [
+                    'id' => $c->id,
+                    'type' => $c->contact_type?->label(),
+                    'contact' => $c->contact,
+                ])->all(),
+            ])->all() : null,
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `php artisan test --filter=StaffProfileProviderTest`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Refactor `InstitutionPersonController@show` to delegate to the service**
+
+In `app/Http/Controllers/InstitutionPersonController.php`, replace the body of `show($staffId)` so the eager-load-and-map is delegated. Keep the `view staff` gate and the staff-ownership guard at the top exactly as they are today.
+
+Replace lines 164–401 with:
+
+```php
+public function show($staffId)
+{
+    if (request()->user()->cannot('view staff')) {
+        return redirect()->route('dashboard')->with('error', 'You do not have permission to view staff details');
+    }
+
+    if (request()->user()->isStaff()) {
+        if (request()->user()->person->institution->first()->staff->id != $staffId) {
+            return redirect()->route('dashboard')->with('error', 'You do not have permission to view details of this staff');
+        }
+    }
+
+    $staff = \App\Models\InstitutionPerson::query()->active()->whereId($staffId)->first();
+    if (! $staff) {
+        return redirect()->route('person.show', ['person' => $staffId])->with('error', 'Staff not found');
+    }
+
+    $payload = app(\App\Services\StaffProfileProvider::class)->forPerson($staff->person_id);
+
+    return \Inertia\Inertia::render('Staff/NewShow', array_merge($payload, [
+        'user' => [
+            'id' => auth()->user()->id,
+            'name' => auth()->user()->name,
+            'email' => auth()->user()->email,
+            'person_id' => auth()->user()->person_id,
+        ],
+    ]));
+}
+```
+
+- [ ] **Step 6: Run the existing admin staff show tests — expect continued pass**
+
+Run: `php artisan test --filter=InstitutionPerson`
+Expected: all existing tests pass. If a test calls specific transformers (`$this->detailTransformer`), it's not in scope here — the transformers are still injected in the constructor but the show method no longer uses them. Do not remove them; they are used in other methods (`index` uses `listTransformer`).
+
+Run the full suite as a safety net:
+Run: `php artisan test`
+Expected: no new failures introduced by this refactor.
+
+- [ ] **Step 7: Format and commit**
+
+Run: `./vendor/bin/pint --dirty`
+
+```bash
+git add app/Services/StaffProfileProvider.php app/Http/Controllers/InstitutionPersonController.php tests/Unit/Services/StaffProfileProviderTest.php
+git commit -m "refactor: extract StaffProfileProvider service from InstitutionPersonController"
+```
+
+---
+
+## Task 2: Create `MyProfileController` and the `/my-profile` route (TDD)
+
+**Files:**
+- Create: `app/Http/Controllers/MyProfileController.php`
+- Modify: `routes/web.php`
+- Create: `tests/Feature/MyProfile/MyProfileShowTest.php`
+
+- [ ] **Step 1: Create the failing feature test**
+
+Create `tests/Feature/MyProfile/MyProfileShowTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('my-profile.show'))->assertRedirect(route('login'));
+    }
+
+    public function test_authenticated_user_without_person_id_gets_403(): void
+    {
+        $user = User::factory()->create(['person_id' => null]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertForbidden();
+    }
+
+    public function test_authenticated_staff_user_sees_their_profile(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('MyProfile/Index')
+                ->has('person')
+                ->has('staff')
+                ->has('qualifications')
+                ->where('person.id', $staff->person_id)
+            );
+    }
+
+    public function test_user_with_no_active_staff_record_sees_404(): void
+    {
+        $user = User::factory()->create(['person_id' => 9_999_999]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertNotFound();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect route-not-defined**
+
+Run: `php artisan test --filter=MyProfileShowTest`
+Expected: FAIL — route `[my-profile.show] not defined` or similar.
+
+- [ ] **Step 3: Create the controller**
+
+Create `app/Http/Controllers/MyProfileController.php`:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\StaffProfileProvider;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MyProfileController extends Controller
+{
+    public function __construct(protected StaffProfileProvider $provider) {}
+
+    public function show(Request $request): Response
+    {
+        $personId = $request->user()->person_id;
+        abort_unless($personId, 403, 'Your account is not linked to a staff record.');
+
+        $payload = $this->provider->forPerson($personId);
+        abort_if($payload === null, 404, 'Staff record not found.');
+
+        return Inertia::render('MyProfile/Index', $payload);
+    }
+}
+```
+
+- [ ] **Step 4: Register the route**
+
+In `routes/web.php`, add below the existing `person/{person}/avatar` block (around line 162):
+
+```php
+Route::middleware(['auth', 'password_changed'])
+    ->get('/my-profile', [\App\Http\Controllers\MyProfileController::class, 'show'])
+    ->name('my-profile.show');
+```
+
+- [ ] **Step 5: Run the test — expect pass**
+
+Run: `php artisan test --filter=MyProfileShowTest`
+Expected: PASS (4 tests). If `assertInertia` fails because the Vue page does not exist yet, that is resolved in Task 4; for now the controller + route test should pass because `Inertia::render` does not require the component file to exist at request time.
+
+- [ ] **Step 6: Format and commit**
+
+Run: `./vendor/bin/pint --dirty`
+
+```bash
+git add app/Http/Controllers/MyProfileController.php routes/web.php tests/Feature/MyProfile/MyProfileShowTest.php
+git commit -m "feat: add MyProfileController and /my-profile route"
+```
+
+---
+
+## Task 3: Share `person_id`, `has_photo`, `qualifications_count` via Inertia (TDD)
+
+**Files:**
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php`
+- Create: `tests/Feature/MyProfile/SharedPropsTest.php`
+
+- [ ] **Step 1: Create the failing test**
+
+Create `tests/Feature/MyProfile/SharedPropsTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\Qualification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SharedPropsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_auth_props_include_person_id_has_photo_and_qualifications_count(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.user.person_id', $staff->person_id)
+                ->where('auth.has_photo', false)
+                ->where('auth.qualifications_count', 0)
+            );
+    }
+
+    public function test_has_photo_flips_true_when_person_image_is_set(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->person->update(['image' => 'avatars/example.jpg']);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn ($page) => $page->where('auth.has_photo', true));
+    }
+
+    public function test_qualifications_count_reflects_stored_qualifications(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        Qualification::factory()->count(3)->create(['person_id' => $staff->person_id]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn ($page) => $page->where('auth.qualifications_count', 3));
+    }
+
+    public function test_props_are_null_for_users_without_person_id(): void
+    {
+        $user = User::factory()->create(['person_id' => null]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.has_photo', null)
+                ->where('auth.qualifications_count', null)
+            );
+    }
+}
+```
+
+> **Note:** `route('dashboard')` redirects. Use `followingRedirects()` only if the final page does not render Inertia (it does, so `assertInertia` works after `get()` against whatever destination the redirect lands on). If the tests fail because of redirect behaviour, swap `get(route('dashboard'))` for `get(route('my-profile.show'))` once Task 2 is in place — same shared props evaluate identically.
+
+- [ ] **Step 2: Run the test — expect fail**
+
+Run: `php artisan test --filter=SharedPropsTest`
+Expected: FAIL — keys missing from `auth`.
+
+- [ ] **Step 3: Extend `HandleInertiaRequests::share`**
+
+Modify `app/Http/Middleware/HandleInertiaRequests.php`. Replace the `auth` block inside `share()` with:
+
+```php
+'auth' => [
+    'user' => fn () => $request->user()
+        ? array_merge(
+            $request->user()->only('id', 'name', 'email'),
+            ['person_id' => $request->user()->person_id],
+        )
+        : null,
+    'roles' => fn () => $request->user()?->getRoleNames(),
+    'permissions' => fn () => $request->user()?->getAllPermissions()->pluck('name'),
+    'viewMode' => fn () => $request->session()->get('view_mode'),
+    'isMultiRoleStaff' => fn () => $request->user()?->isMultiRoleStaff() ?? false,
+    'viewModeLabel' => fn () => $this->resolveViewModeLabel($request->user()),
+    'has_photo' => fn () => $this->hasPhotoForCurrentUser($request),
+    'qualifications_count' => fn () => $this->qualificationsCountForCurrentUser($request),
+],
+```
+
+Then add these two private helpers to the class:
+
+```php
+private function hasPhotoForCurrentUser(Request $request): ?bool
+{
+    $user = $request->user();
+    if (! $user || ! $user->person_id) {
+        return null;
+    }
+
+    return (bool) \App\Models\Person::query()
+        ->whereKey($user->person_id)
+        ->whereNotNull('image')
+        ->exists();
+}
+
+private function qualificationsCountForCurrentUser(Request $request): ?int
+{
+    $user = $request->user();
+    if (! $user || ! $user->person_id) {
+        return null;
+    }
+
+    return \App\Models\Qualification::query()
+        ->where('person_id', $user->person_id)
+        ->count();
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `php artisan test --filter=SharedPropsTest`
+Expected: PASS (4 tests). If any test still fails because `route('dashboard')` redirects to a non-Inertia destination, change that specific test's URL to `route('my-profile.show')` (Task 2 already provides it).
+
+- [ ] **Step 5: Format and commit**
+
+Run: `./vendor/bin/pint --dirty`
+
+```bash
+git add app/Http/Middleware/HandleInertiaRequests.php tests/Feature/MyProfile/SharedPropsTest.php
+git commit -m "feat: share person_id, has_photo and qualifications_count via Inertia"
+```
+
+---
+
+## Task 4: Redirect staff-only users to `/my-profile` on dashboard hit (TDD)
+
+**Files:**
+- Modify: `app/Http/Controllers/DashboardController.php`
+- Create: `tests/Feature/MyProfile/StaffLandingRedirectTest.php`
+
+- [ ] **Step 1: Create the failing test**
+
+Create `tests/Feature/MyProfile/StaffLandingRedirectTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class StaffLandingRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::findOrCreate('staff');
+    }
+
+    public function test_staff_only_user_is_redirected_to_my_profile(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('staff');
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertRedirect(route('my-profile.show'));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect fail**
+
+Run: `php artisan test --filter=StaffLandingRedirectTest`
+Expected: FAIL — redirects to `staff.show/{id}` instead.
+
+- [ ] **Step 3: Update `redirectToStaffLanding`**
+
+In `app/Http/Controllers/DashboardController.php`, replace `redirectToStaffLanding`:
+
+```php
+private function redirectToStaffLanding(User $user): RedirectResponse
+{
+    if ($user->person_id) {
+        return redirect()->route('my-profile.show');
+    }
+
+    return redirect()->route('staff.index');
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `php artisan test --filter=StaffLandingRedirectTest`
+Expected: PASS.
+
+- [ ] **Step 5: Run the existing multi-role dashboard tests — expect continued pass**
+
+Run: `php artisan test --filter=MultiRole`
+Expected: existing tests pass (they exercise `isMultiRoleStaff` and view_mode paths, which don't touch this helper).
+
+- [ ] **Step 6: Format and commit**
+
+Run: `./vendor/bin/pint --dirty`
+
+```bash
+git add app/Http/Controllers/DashboardController.php tests/Feature/MyProfile/StaffLandingRedirectTest.php
+git commit -m "feat: land staff-only users on /my-profile instead of admin staff show"
+```
+
+---
+
+## Task 5: Create the `MyProfile/Index.vue` page shell
+
+**Files:**
+- Create: `resources/js/Pages/MyProfile/Index.vue`
+
+- [ ] **Step 1: Create the page**
+
+Create `resources/js/Pages/MyProfile/Index.vue`:
+
+```vue
+<script setup>
+import { Head } from "@inertiajs/vue3";
+import MainLayout from "@/Layouts/NewAuthenticated.vue";
+import IdentityStrip from "@/Components/MyProfile/IdentityStrip.vue";
+import PhotoCard from "@/Components/MyProfile/PhotoCard.vue";
+import QualificationsCard from "@/Components/MyProfile/QualificationsCard.vue";
+import ContactCard from "@/Components/MyProfile/ContactCard.vue";
+import ReadOnlyKvCard from "@/Components/MyProfile/ReadOnlyKvCard.vue";
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	staff: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
+});
+
+const employmentRows = computed(() => {
+	const currentRank = props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0];
+	const currentUnit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	return [
+		{ key: "Rank", value: currentRank?.name ?? "—" },
+		{ key: "Unit", value: currentUnit?.unit_name ?? "—" },
+		{ key: "Joined", value: props.staff.hire_date ?? "—" },
+	];
+});
+
+const dependentRows = computed(() => {
+	const deps = props.staff.dependents ?? [];
+	const spouse = deps.find((d) => (d.relation ?? "").toLowerCase() === "spouse");
+	const childrenCount = deps.filter((d) => (d.relation ?? "").toLowerCase() === "child").length;
+	return [
+		{ key: "Spouse", value: spouse?.name ?? "—" },
+		{ key: "Children", value: String(childrenCount) },
+	];
+});
+</script>
+
+<template>
+	<Head title="My Profile" />
+	<MainLayout>
+		<main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+			<IdentityStrip
+				:person="person"
+				:staff="staff"
+				:qualifications="qualifications"
+				:contacts="contacts"
+			/>
+
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-5">
+				<PhotoCard :person="person" />
+				<QualificationsCard
+					:qualifications="qualifications"
+					:person="{ id: person.id, name: person.name }"
+				/>
+			</div>
+
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-3 gap-4">
+				<ContactCard
+					:person-id="person.id"
+					:contacts="contacts"
+					:address="address"
+				/>
+				<ReadOnlyKvCard
+					title="Employment"
+					lock-label="HR-managed"
+					:rows="employmentRows"
+				/>
+				<ReadOnlyKvCard
+					title="Dependents"
+					lock-label="View only"
+					:rows="dependentRows"
+					footer="Need changes? Contact HR."
+				/>
+			</div>
+		</main>
+	</MainLayout>
+</template>
+```
+
+- [ ] **Step 2: Commit the shell (child components are stubbed out in following tasks)**
+
+```bash
+git add resources/js/Pages/MyProfile/Index.vue
+git commit -m "feat: scaffold MyProfile Index page shell"
+```
+
+---
+
+## Task 6: Build `IdentityStrip.vue` and `ProfileProgress.vue`
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/ProfileProgress.vue`
+- Create: `resources/js/Components/MyProfile/IdentityStrip.vue`
+
+- [ ] **Step 1: Create `ProfileProgress.vue`**
+
+Create `resources/js/Components/MyProfile/ProfileProgress.vue`:
+
+```vue
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+});
+
+const checkpoints = computed(() => {
+	const hasPhoto = Boolean(props.person?.image);
+	const hasQualification = props.qualifications.length > 0;
+	const emails = (props.contacts ?? []).filter(
+		(c) => String(c.contact_type).toLowerCase() === "email" && !c.valid_end,
+	);
+	const phones = (props.contacts ?? []).filter(
+		(c) => String(c.contact_type).toLowerCase() === "phone" && !c.valid_end,
+	);
+	const hasContacts = emails.length > 0 && phones.length > 0;
+	return [hasPhoto, hasQualification, hasContacts];
+});
+
+const percent = computed(
+	() => Math.round((checkpoints.value.filter(Boolean).length / 3) * 100),
+);
+const isComplete = computed(() => percent.value === 100);
+</script>
+
+<template>
+	<div
+		:class="[
+			'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold',
+			isComplete
+				? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+				: 'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+		]"
+	>
+		<div
+			:class="[
+				'w-20 h-1.5 rounded-full overflow-hidden',
+				isComplete ? 'bg-emerald-200 dark:bg-emerald-800' : 'bg-amber-200 dark:bg-amber-800',
+			]"
+		>
+			<div
+				:class="[
+					'h-full transition-all',
+					isComplete ? 'bg-emerald-600' : 'bg-amber-500',
+				]"
+				:style="{ width: `${percent}%` }"
+			></div>
+		</div>
+		<span v-if="isComplete">✓ Profile complete</span>
+		<span v-else>{{ percent }}% complete</span>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Create `IdentityStrip.vue`**
+
+Create `resources/js/Components/MyProfile/IdentityStrip.vue`:
+
+```vue
+<script setup>
+import ProfileProgress from "@/Components/MyProfile/ProfileProgress.vue";
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	staff: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+});
+
+const currentRank = computed(
+	() => props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0],
+);
+const currentDepartment = computed(() => {
+	const unit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	return unit?.department ?? unit?.unit_name ?? null;
+});
+</script>
+
+<template>
+	<div
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm flex flex-col sm:flex-row items-center sm:items-stretch gap-4 sm:gap-5"
+	>
+		<div class="flex-shrink-0">
+			<img
+				v-if="person.image"
+				:src="person.image"
+				alt=""
+				class="w-[72px] h-[72px] rounded-full object-cover border-2 border-white dark:border-gray-700 shadow"
+			/>
+			<div
+				v-else
+				class="w-[72px] h-[72px] rounded-full bg-gradient-to-br from-gray-400 to-gray-600 dark:from-gray-500 dark:to-gray-700 flex items-center justify-center text-white font-bold text-2xl"
+			>
+				{{ person.initials }}
+			</div>
+		</div>
+		<div class="flex-1 min-w-0 text-center sm:text-left">
+			<h1
+				class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+			>
+				{{ person.name }}
+			</h1>
+			<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+				<span v-if="currentRank">{{ currentRank.name }}</span>
+				<span v-if="currentRank && currentDepartment"> · </span>
+				<span v-if="currentDepartment">{{ currentDepartment }}</span>
+				<span v-if="staff.staff_number"> · Staff #{{ staff.staff_number }}</span>
+			</p>
+		</div>
+		<div class="flex items-center justify-center sm:justify-end">
+			<ProfileProgress
+				:person="person"
+				:qualifications="qualifications"
+				:contacts="contacts"
+			/>
+		</div>
+	</div>
+</template>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/MyProfile/ProfileProgress.vue resources/js/Components/MyProfile/IdentityStrip.vue
+git commit -m "feat: add IdentityStrip and ProfileProgress components"
+```
+
+---
+
+## Task 7: Build `PhotoCard.vue` with empty / filled / uploading / error states
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/PhotoCard.vue`
+- Create: `tests/Feature/MyProfile/MyProfilePhotoUploadTest.php`
+
+- [ ] **Step 1: Create the failing feature test**
+
+Create `tests/Feature/MyProfile/MyProfilePhotoUploadTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MyProfilePhotoUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_staff_can_upload_own_photo(): void
+    {
+        Storage::fake('public');
+        $staff = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $staff->person_id]), [
+                'image' => UploadedFile::fake()->image('me.jpg', 400, 400)->size(500),
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNotNull($staff->person->fresh()->image);
+    }
+
+    public function test_staff_cannot_upload_photo_for_another_person(): void
+    {
+        Storage::fake('public');
+        $me = InstitutionPerson::factory()->create();
+        $someone = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $me->person_id]);
+
+        $response = $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $someone->person_id]), [
+                'image' => UploadedFile::fake()->image('me.jpg'),
+            ]);
+
+        $response->assertForbidden();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — confirm current behaviour**
+
+Run: `php artisan test --filter=MyProfilePhotoUploadTest`
+Expected: the first test passes (confirms the existing endpoint accepts uploads); the second test **may fail** if the existing `PersonAvatarController` does not already enforce ownership. If it fails, open `app/Http/Controllers/PersonAvatarController.php::update`, add `abort_unless($request->user()->person_id === $person->id, 403);` at the top, and re-run. Commit that guard as part of this task.
+
+- [ ] **Step 3: Create `PhotoCard.vue`**
+
+Create `resources/js/Components/MyProfile/PhotoCard.vue`:
+
+```vue
+<script setup>
+import { ref, computed } from "vue";
+import { router } from "@inertiajs/vue3";
+import NewModal from "@/Components/NewModal.vue";
+import DeleteAvatar from "@/Pages/Staff/DeleteAvatar.vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+});
+
+const isUploading = ref(false);
+const errorMessage = ref("");
+const isDragging = ref(false);
+const fileInput = ref(null);
+const showDeleteModal = ref(false);
+
+const accepted = ["image/jpeg", "image/png"];
+const maxBytes = 2 * 1024 * 1024;
+
+const statusLabel = computed(() => (props.person.image ? "✓ Set" : "Not set"));
+const statusClass = computed(() =>
+	props.person.image
+		? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+		: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+);
+
+function openPicker() {
+	fileInput.value?.click();
+}
+
+function onFileChange(event) {
+	const file = event.target.files?.[0];
+	if (file) {
+		submit(file);
+	}
+}
+
+function onDrop(event) {
+	event.preventDefault();
+	isDragging.value = false;
+	const file = event.dataTransfer.files?.[0];
+	if (file) {
+		submit(file);
+	}
+}
+
+function submit(file) {
+	errorMessage.value = "";
+	if (!accepted.includes(file.type)) {
+		errorMessage.value = "Please choose a JPG or PNG image.";
+		return;
+	}
+	if (file.size > maxBytes) {
+		errorMessage.value = "Image must be 2 MB or smaller.";
+		return;
+	}
+
+	const formData = new FormData();
+	formData.append("image", file);
+
+	isUploading.value = true;
+	router.post(route("person.avatar.update", { person: props.person.id }), formData, {
+		forceFormData: true,
+		preserveScroll: true,
+		onSuccess: () => {
+			router.reload({ only: ["person"] });
+		},
+		onError: (errors) => {
+			errorMessage.value = errors.image ?? "Upload failed — please try again.";
+		},
+		onFinish: () => {
+			isUploading.value = false;
+		},
+	});
+}
+
+function confirmRemove() {
+	showDeleteModal.value = true;
+}
+
+function remove() {
+	router.delete(route("person.avatar.delete", { person: props.person.id }), {
+		preserveScroll: true,
+		onSuccess: () => {
+			showDeleteModal.value = false;
+			router.reload({ only: ["person"] });
+		},
+	});
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
+	>
+		<header class="flex justify-between items-start mb-4">
+			<div>
+				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">Your photo</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					{{
+						person.image
+							? "Visible across the HR system."
+							: "Help colleagues recognise you. Used across the system."
+					}}
+				</p>
+			</div>
+			<span
+				class="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+				:class="statusClass"
+			>{{ statusLabel }}</span>
+		</header>
+
+		<!-- FILLED -->
+		<div v-if="person.image && !isUploading" class="flex gap-4 items-center">
+			<img
+				:src="person.image"
+				alt="Profile photo"
+				class="w-[120px] h-[120px] rounded-xl object-cover border-[3px] border-white dark:border-gray-700 shadow"
+			/>
+			<div class="flex-1">
+				<div class="flex flex-wrap gap-2">
+					<button
+						type="button"
+						class="inline-flex items-center rounded-lg bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border border-emerald-200 dark:border-emerald-700 px-3 py-1.5 text-xs font-semibold hover:bg-emerald-100"
+						@click="openPicker"
+					>Change photo</button>
+					<button
+						type="button"
+						class="inline-flex items-center rounded-lg bg-white dark:bg-gray-900 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-700 px-3 py-1.5 text-xs font-semibold hover:bg-red-50 dark:hover:bg-red-900/30"
+						@click="confirmRemove"
+					>Remove</button>
+				</div>
+				<p v-if="errorMessage" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+			</div>
+		</div>
+
+		<!-- EMPTY / ERROR / UPLOADING -->
+		<div v-else>
+			<div
+				:class="[
+					'rounded-xl border-2 border-dashed px-6 py-9 text-center transition-colors cursor-pointer',
+					isDragging
+						? 'border-emerald-600 bg-emerald-50 dark:bg-emerald-900/30'
+						: 'border-emerald-500 bg-emerald-50/60 hover:bg-emerald-50 dark:bg-emerald-900/20 dark:hover:bg-emerald-900/30',
+					isUploading ? 'opacity-60 pointer-events-none' : '',
+				]"
+				@dragover.prevent="isDragging = true"
+				@dragleave.prevent="isDragging = false"
+				@drop="onDrop"
+				@click="openPicker"
+			>
+				<div class="text-4xl">📷</div>
+				<p class="mt-2 text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+					{{ isUploading ? "Uploading..." : "Drop your photo here" }}
+				</p>
+				<p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
+					JPG or PNG, up to 2 MB · square crop works best
+				</p>
+				<p class="text-[11px] text-gray-500 mt-3 mb-2">or</p>
+				<button
+					type="button"
+					class="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700"
+					@click.stop="openPicker"
+				>Choose a file</button>
+			</div>
+			<p v-if="errorMessage" class="mt-3 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+		</div>
+
+		<input
+			ref="fileInput"
+			type="file"
+			class="hidden"
+			accept="image/jpeg,image/png"
+			@change="onFileChange"
+		/>
+
+		<NewModal :show="showDeleteModal" @close="showDeleteModal = false">
+			<DeleteAvatar
+				@delete-confirmed="remove"
+				@close="showDeleteModal = false"
+			/>
+		</NewModal>
+	</section>
+</template>
+```
+
+- [ ] **Step 4: Run the tests again**
+
+Run: `php artisan test --filter=MyProfilePhotoUploadTest`
+Expected: PASS (2 tests). If the ownership guard was added in Step 2, ensure the change is part of this commit.
+
+- [ ] **Step 5: Format and commit**
+
+Run: `./vendor/bin/pint --dirty`
+
+```bash
+git add resources/js/Components/MyProfile/PhotoCard.vue tests/Feature/MyProfile/MyProfilePhotoUploadTest.php
+# plus app/Http/Controllers/PersonAvatarController.php if the ownership guard was added
+git commit -m "feat: add PhotoCard with empty/filled/uploading states and ownership guard"
+```
+
+---
+
+## Task 8: Build `QualificationsCard.vue` (reuses existing modals)
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/QualificationsCard.vue`
+- Create: `tests/Feature/MyProfile/MyProfileQualificationTest.php`
+
+- [ ] **Step 1: Create the failing feature test**
+
+Create `tests/Feature/MyProfile/MyProfileQualificationTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileQualificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_staff_user_does_not_receive_approve_permission_in_page_props(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page
+                ->where(
+                    'auth.permissions',
+                    fn ($permissions) => ! collect($permissions)->contains('approve staff qualification'),
+                )
+            );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `php artisan test --filter=MyProfileQualificationTest`
+Expected: PASS — the test describes existing behaviour (the test is a regression guard, not a driver). If it fails because the factory-created user accidentally has the `approve staff qualification` permission, double-check the seeder and adjust the factory.
+
+- [ ] **Step 3: Create `QualificationsCard.vue`**
+
+Create `resources/js/Components/MyProfile/QualificationsCard.vue`:
+
+```vue
+<script setup>
+import { ref, computed } from "vue";
+import { router, usePage } from "@inertiajs/vue3";
+import { useToggle } from "@vueuse/core";
+import NewModal from "@/Components/NewModal.vue";
+import AddQualification from "@/Pages/Qualification/Add.vue";
+import EditQualification from "@/Pages/Qualification/Edit.vue";
+import DeleteQualification from "@/Pages/Qualification/Delete.vue";
+import AttachDocument from "@/Pages/Qualification/AttachDocument.vue";
+
+const props = defineProps({
+	qualifications: { type: Array, default: () => [] },
+	person: { type: Object, required: true },
+});
+
+const page = usePage();
+const permissions = computed(() => page.props?.auth?.permissions ?? []);
+const canAdd = computed(
+	() => permissions.value.includes("create staff qualification")
+		|| permissions.value.includes("update staff"),
+);
+const canExport = computed(() => permissions.value.includes("qualifications.reports.export"));
+
+const openAdd = ref(false);
+const openEdit = ref(false);
+const openDelete = ref(false);
+const openAttach = ref(false);
+const toggleAdd = useToggle(openAdd);
+const toggleEdit = useToggle(openEdit);
+const toggleDelete = useToggle(openDelete);
+const toggleAttach = useToggle(openAttach);
+
+const current = ref(null);
+
+function startEdit(q) {
+	current.value = q;
+	toggleEdit();
+}
+function startDelete(q) {
+	current.value = q;
+	toggleDelete();
+}
+function startAttach(q) {
+	current.value = q;
+	toggleAttach();
+}
+
+function confirmDelete() {
+	router.delete(route("qualification.delete", { qualification: current.value.id }), {
+		preserveScroll: true,
+		onSuccess: () => {
+			current.value = null;
+			toggleDelete();
+			router.reload({ only: ["qualifications"] });
+		},
+	});
+}
+
+function statusTag(status) {
+	const tone = (status ?? "").toLowerCase();
+	if (tone.includes("approved")) return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200";
+	if (tone.includes("pending")) return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
+	return "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200";
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
+	>
+		<header class="flex justify-between items-start mb-4">
+			<div>
+				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">Your qualifications</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					{{ qualifications.length === 0 ? "Degrees, certificates, training. Reviewed by HR." : `${qualifications.length} added` }}
+				</p>
+			</div>
+			<div class="flex items-center gap-2">
+				<a
+					v-if="canExport"
+					:href="route('qualifications.reports.staff.profile.pdf', person.id)"
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-200"
+				>PDF</a>
+				<span
+					v-if="qualifications.length === 0"
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+				>0 added</span>
+				<span
+					v-else
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+				>✓ Active</span>
+			</div>
+		</header>
+
+		<!-- EMPTY -->
+		<div
+			v-if="qualifications.length === 0"
+			class="rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/40 px-6 py-9 text-center"
+		>
+			<div class="text-4xl">🎓</div>
+			<p class="mt-2 text-sm font-bold text-gray-900 dark:text-gray-100">
+				Add your first qualification
+			</p>
+			<p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+				We'll walk you through it — name, institution, year, and an optional certificate upload.
+			</p>
+			<button
+				v-if="canAdd"
+				type="button"
+				class="mt-4 w-full rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm"
+				@click="toggleAdd()"
+			>+ Add qualification</button>
+			<div class="flex flex-wrap justify-center gap-1.5 mt-3">
+				<span
+					v-for="tag in ['Degree', 'Diploma', 'Certificate', 'Training']"
+					:key="tag"
+					class="px-2.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-[11px] text-gray-600 dark:text-gray-300"
+				>{{ tag }}</span>
+			</div>
+		</div>
+
+		<!-- FILLED -->
+		<ul v-else class="space-y-2">
+			<li
+				v-for="q in qualifications"
+				:key="q.id"
+				class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 px-3 py-2.5"
+			>
+				<span class="w-9 h-9 rounded-md bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-200 flex items-center justify-center text-base">🎓</span>
+				<div class="flex-1 min-w-0">
+					<div class="text-sm font-bold truncate text-gray-900 dark:text-gray-50">{{ q.qualification || q.course }}</div>
+					<div class="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5 flex flex-wrap items-center gap-x-1.5">
+						<span v-if="q.institution">{{ q.institution }}</span>
+						<span v-if="q.year">· {{ q.year }}</span>
+						<span v-if="q.status" :class="['px-2 py-0.5 rounded-full text-[10px] font-semibold', statusTag(q.status)]">{{ q.status }}</span>
+						<span v-if="q.documents" class="text-gray-500">· {{ q.documents.length }} document{{ q.documents.length === 1 ? "" : "s" }}</span>
+					</div>
+				</div>
+				<div class="flex items-center gap-2 text-[11px] text-emerald-700 dark:text-emerald-300 font-semibold">
+					<button v-if="q.can_edit" type="button" class="hover:underline" @click="startAttach(q)">Attach</button>
+					<button v-if="q.can_edit" type="button" class="hover:underline" @click="startEdit(q)">Edit</button>
+					<button v-if="q.can_delete" type="button" class="hover:underline text-red-600 dark:text-red-400" @click="startDelete(q)">Delete</button>
+				</div>
+			</li>
+			<li>
+				<button
+					v-if="canAdd"
+					type="button"
+					class="w-full rounded-lg border border-dashed border-emerald-500 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 px-3 py-2.5 text-sm font-semibold hover:bg-emerald-100"
+					@click="toggleAdd()"
+				>+ Add another qualification</button>
+			</li>
+		</ul>
+
+		<NewModal :show="openAdd" @close="toggleAdd()">
+			<AddQualification
+				:person="person.id"
+				:qualification-levels="page.props.qualificationLevels"
+				@form-submitted="() => { toggleAdd(); router.reload({ only: ['qualifications'] }); }"
+			/>
+		</NewModal>
+		<NewModal :show="openEdit" @close="toggleEdit()">
+			<EditQualification
+				:person="person.id"
+				:qualification="current"
+				@form-submitted="() => { toggleEdit(); router.reload({ only: ['qualifications'] }); }"
+			/>
+		</NewModal>
+		<NewModal :show="openDelete" @close="toggleDelete()">
+			<DeleteQualification
+				:person="person.name"
+				@close="toggleDelete()"
+				@delete-confirmed="confirmDelete"
+			/>
+		</NewModal>
+		<NewModal :show="openAttach" @close="toggleAttach()">
+			<AttachDocument
+				:qualification="current"
+				@close="toggleAttach()"
+				@form-submitted="() => { toggleAttach(); router.reload({ only: ['qualifications'] }); }"
+			/>
+		</NewModal>
+	</section>
+</template>
+```
+
+- [ ] **Step 2b: Verify the existing Add.vue/Edit.vue prop names match**
+
+Open `resources/js/Pages/Qualification/Add.vue` and confirm it accepts `person`, `qualificationLevels`, and emits `form-submitted`. If any prop or event name differs, adjust the usage in this card to match — **do not modify `Add.vue`**, as it is still used by `PersonQualifications.vue`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/MyProfile/QualificationsCard.vue tests/Feature/MyProfile/MyProfileQualificationTest.php
+git commit -m "feat: add QualificationsCard with empty + filled states"
+```
+
+---
+
+## Task 9: Build `ContactCard.vue`
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/ContactCard.vue`
+- Create: `tests/Feature/MyProfile/MyProfileContactEditTest.php`
+
+- [ ] **Step 1: Find the existing contact-edit endpoint**
+
+Before writing the component, confirm the route name used by `EditContactForm.vue` today (it is imported into `NewShow.vue`). Open `resources/js/Pages/Staff/EditContactForm.vue` and note the `router.post`/`router.put` URL and prop shape. The component to wire up is exactly the same — we just host it from a new card.
+
+- [ ] **Step 2: Create `ContactCard.vue`**
+
+Create `resources/js/Components/MyProfile/ContactCard.vue`:
+
+```vue
+<script setup>
+import { ref, computed } from "vue";
+import { useToggle } from "@vueuse/core";
+import NewModal from "@/Components/NewModal.vue";
+import EditContactForm from "@/Pages/Staff/EditContactForm.vue";
+
+const props = defineProps({
+	personId: { type: Number, required: true },
+	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
+});
+
+const openEdit = ref(false);
+const toggleEdit = useToggle(openEdit);
+
+const email = computed(
+	() =>
+		(props.contacts ?? []).find(
+			(c) => String(c.contact_type).toLowerCase() === "email" && !c.valid_end,
+		)?.contact ?? "—",
+);
+const phone = computed(
+	() =>
+		(props.contacts ?? []).find(
+			(c) => String(c.contact_type).toLowerCase() === "phone" && !c.valid_end,
+		)?.contact ?? "—",
+);
+const addressDisplay = computed(() => {
+	if (!props.address) return "—";
+	const parts = [
+		props.address.address_line_1,
+		props.address.city,
+		props.address.region,
+	].filter(Boolean);
+	return parts.length ? parts.join(", ") : "—";
+});
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Contact</h3>
+			<button
+				type="button"
+				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+				@click="toggleEdit()"
+			>Edit</button>
+		</header>
+
+		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Email</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">{{ email }}</dd>
+			</div>
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Phone</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">{{ phone }}</dd>
+			</div>
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Address</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">{{ addressDisplay }}</dd>
+			</div>
+		</dl>
+
+		<NewModal :show="openEdit" @close="toggleEdit()">
+			<EditContactForm
+				:contact="personId"
+				@form-submitted="toggleEdit()"
+			/>
+		</NewModal>
+	</section>
+</template>
+```
+
+- [ ] **Step 3: Create the contact feature test**
+
+Create `tests/Feature/MyProfile/MyProfileContactEditTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\Contact;
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileContactEditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_my_profile_payload_exposes_contacts_and_address(): void
+    {
+        $staff = InstitutionPerson::factory()->create();
+        Contact::factory()->create([
+            'person_id' => $staff->person_id,
+            'contact_type' => 'email',
+            'contact' => 'me@example.org',
+        ]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page
+                ->has('contacts')
+                ->where('contacts.0.contact', 'me@example.org')
+            );
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `php artisan test --filter=MyProfileContactEditTest`
+Expected: PASS. If `Contact::factory()` doesn't exist, substitute with the model's create method using fields already present in a `ContactFactory` if one exists; otherwise, inline a `Contact::create(...)` call with required fields after inspecting `app/Models/Contact.php`'s `$fillable`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/Components/MyProfile/ContactCard.vue tests/Feature/MyProfile/MyProfileContactEditTest.php
+git commit -m "feat: add ContactCard wrapping existing EditContactForm"
+```
+
+---
+
+## Task 10: Build `ReadOnlyKvCard.vue`
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/ReadOnlyKvCard.vue`
+
+- [ ] **Step 1: Create the component**
+
+Create `resources/js/Components/MyProfile/ReadOnlyKvCard.vue`:
+
+```vue
+<script setup>
+defineProps({
+	title: { type: String, required: true },
+	rows: {
+		type: Array,
+		required: true,
+	},
+	lockLabel: { type: String, default: "" },
+	footer: { type: String, default: "" },
+});
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">{{ title }}</h3>
+			<span
+				v-if="lockLabel"
+				class="text-[11px] text-gray-400 dark:text-gray-500"
+			>{{ lockLabel }}</span>
+		</header>
+
+		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+			<div v-for="row in rows" :key="row.key" class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">
+					{{ row.value }}
+				</dd>
+			</div>
+		</dl>
+
+		<p v-if="footer" class="mt-3 text-[11px] italic text-gray-500 dark:text-gray-400">
+			{{ footer }}
+		</p>
+	</section>
+</template>
+```
+
+- [ ] **Step 2: Manual smoke — browse `/my-profile` in dev**
+
+```bash
+npm run dev  # in one terminal
+php artisan serve  # in another
+```
+
+Log in as a staff user (or use the user linked to an `InstitutionPerson` factory record in a seeded DB). Confirm the page loads, the identity strip shows, photo card shows "Not set" empty state, qualifications card shows the empty state, and the three secondary cards render. Fix any Vite import errors before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/MyProfile/ReadOnlyKvCard.vue
+git commit -m "feat: add ReadOnlyKvCard for Employment and Dependents"
+```
+
+---
+
+## Task 11: Add "My Profile" nav link in `NewAuthenticated.vue`
+
+**Files:**
+- Modify: `resources/js/Layouts/NewAuthenticated.vue`
+
+- [ ] **Step 1: Find the `navigation` array (around line 32)**
+
+The existing array has entries like `Dashboard`, `Staff`, etc., each with `{ name, href, icon, current, visible }`.
+
+- [ ] **Step 2: Add a `My Profile` entry**
+
+Insert this entry as the FIRST item of the `navigation` array (before `Dashboard`):
+
+```js
+{
+    name: "My Profile",
+    href: route("my-profile.show"),
+    icon: UserGroupIcon,
+    current: route().current("my-profile.*"),
+    visible: Boolean(page.props?.auth?.user?.person_id),
+},
+```
+
+`UserGroupIcon` is already imported at the top of the file. If you prefer a different icon, add the import (`UserIcon` or `IdentificationIcon` from `@heroicons/vue/24/outline`) alongside the existing `UserGroupIcon` import.
+
+- [ ] **Step 3: Manual smoke**
+
+Reload `/my-profile` and any dashboard route; confirm the link appears for users with a `person_id` and is hidden for users without one (e.g., a super-admin created without a linked person).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Layouts/NewAuthenticated.vue
+git commit -m "feat: add My Profile link to authenticated nav"
+```
+
+---
+
+## Task 12: Build `CompletionBanner.vue` and show it on the admin landing
+
+**Files:**
+- Create: `resources/js/Components/MyProfile/CompletionBanner.vue`
+- Modify: `resources/js/Pages/Institution/Show.vue` (admin landing)
+
+- [ ] **Step 1: Confirm the admin landing page**
+
+`DashboardController::redirectToAdminDashboard` redirects to `route('institution.show', [1])`. The banner should appear on `resources/js/Pages/Institution/Show.vue`. Open that file and locate a suitable slot near the top of the main content area — typically just after the page `<Head />` or the first layout heading. If the file structure differs, insert the banner component at the top of the returned `<template>`, wrapped in a container matching existing page padding.
+
+- [ ] **Step 2: Create the banner**
+
+Create `resources/js/Components/MyProfile/CompletionBanner.vue`:
+
+```vue
+<script setup>
+import { computed, ref, onMounted } from "vue";
+import { Link, usePage } from "@inertiajs/vue3";
+
+const page = usePage();
+const auth = computed(() => page.props?.auth ?? {});
+
+const hasPersonId = computed(() => Boolean(auth.value?.user?.person_id));
+const hasPhoto = computed(() => auth.value?.has_photo === true);
+const hasQuals = computed(() => (auth.value?.qualifications_count ?? 0) > 0);
+
+const dismissedKey = "my-profile.banner.dismissed";
+const dismissed = ref(false);
+
+onMounted(() => {
+	dismissed.value = sessionStorage.getItem(dismissedKey) === "1";
+});
+
+const shouldShow = computed(
+	() => hasPersonId.value && (!hasPhoto.value || !hasQuals.value) && !dismissed.value,
+);
+
+function dismiss() {
+	sessionStorage.setItem(dismissedKey, "1");
+	dismissed.value = true;
+}
+
+const message = computed(() => {
+	if (!hasPhoto.value && !hasQuals.value) return "Add your photo and first qualification.";
+	if (!hasPhoto.value) return "Add your profile photo.";
+	return "Add your first qualification.";
+});
+</script>
+
+<template>
+	<div
+		v-if="shouldShow"
+		class="flex items-center gap-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 px-4 py-3"
+	>
+		<div class="text-2xl">📝</div>
+		<div class="flex-1 text-sm text-emerald-900 dark:text-emerald-100">
+			<strong>Complete your profile.</strong>
+			{{ message }}
+		</div>
+		<Link
+			:href="route('my-profile.show')"
+			class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white"
+		>Open My Profile →</Link>
+		<button
+			type="button"
+			class="text-emerald-700 dark:text-emerald-300 text-xs font-semibold hover:underline"
+			@click="dismiss"
+		>Dismiss</button>
+	</div>
+</template>
+```
+
+- [ ] **Step 3: Mount the banner on `Institution/Show.vue`**
+
+Add the import near the other component imports:
+
+```js
+import CompletionBanner from "@/Components/MyProfile/CompletionBanner.vue";
+```
+
+And render it at the top of the main content, e.g.:
+
+```vue
+<CompletionBanner class="mb-4" />
+```
+
+- [ ] **Step 4: Manual smoke**
+
+Log in as an admin user whose account *also* has a `person_id` but no photo → the banner should appear on `/institution/{id}`. Click "Dismiss" → it should stay hidden for the session. Reload after closing the tab → banner reappears (sessionStorage was cleared).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/Components/MyProfile/CompletionBanner.vue resources/js/Pages/Institution/Show.vue
+git commit -m "feat: show profile-completion banner on admin landing for staff-linked users"
+```
+
+---
+
+## Task 13: Final regression + manual verification
+
+**Files:**
+- None (this is a verification gate)
+
+- [ ] **Step 1: Run the full backend suite**
+
+```bash
+./vendor/bin/pint --dirty
+php artisan test
+```
+
+Expected: PASS. The specific new tests added are:
+- `Tests\Unit\Services\StaffProfileProviderTest` (4)
+- `Tests\Feature\MyProfile\MyProfileShowTest` (4)
+- `Tests\Feature\MyProfile\SharedPropsTest` (4)
+- `Tests\Feature\MyProfile\StaffLandingRedirectTest` (1)
+- `Tests\Feature\MyProfile\MyProfilePhotoUploadTest` (2)
+- `Tests\Feature\MyProfile\MyProfileQualificationTest` (1)
+- `Tests\Feature\MyProfile\MyProfileContactEditTest` (1)
+
+That's 17 new tests. Existing admin tests must still pass.
+
+- [ ] **Step 2: Run frontend linters**
+
+```bash
+npm run lint
+npm run format
+npm run build
+```
+
+Expected: no errors; bundle builds.
+
+- [ ] **Step 3: Manual browser checklist**
+
+`php artisan serve` and `npm run dev`, log in as:
+
+1. **Staff-only user (no photo, no qualifications):**
+   - Hitting `/dashboard` redirects to `/my-profile`.
+   - Page shows identity strip, amber "0% complete" chip (or 33% if contacts already set), empty photo drop zone, empty qualifications card with `+ Add qualification`.
+   - "My Profile" appears in nav.
+   - Upload a JPG under 2 MB — card flips to filled state, progress chip updates.
+   - Upload a non-image — inline error, no crash.
+   - Upload a >2 MB image — inline error.
+   - Click `+ Add qualification` → modal opens, submit → list renders the new row.
+   - Open Contact → edit email → save → card reflects new email.
+
+2. **Multi-role user with admin dashboard access:**
+   - Choose "admin" mode → land on `/institution/1` → banner visible if photo missing.
+   - Dismiss banner → gone.
+   - Reload page in same tab → still hidden.
+   - Open new tab → banner returns.
+
+3. **User without `person_id`:**
+   - `/my-profile` returns 403.
+   - Nav no longer shows "My Profile".
+   - Admin dashboard banner not shown.
+
+4. **Dark mode:**
+   - Toggle to dark theme; confirm identity strip, priority cards, secondary cards, progress chip, and banner all have legible dark variants.
+
+5. **Mobile (<768 px):**
+   - Identity strip stacks; priority grid becomes a column; secondary grid becomes a column; drop zone still acts as a tap target.
+
+- [ ] **Step 4: Commit any polish found during manual verification**
+
+```bash
+./vendor/bin/pint --dirty
+git add -A
+git commit -m "chore: polish from My Profile manual verification pass"
+```
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin feature/staff-my-profile-redesign
+```
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "feat: staff My Profile page with photo and qualifications focus" --body "$(cat <<'EOF'
+## Summary
+- New `/my-profile` route + `MyProfileController` for staff self-service
+- `StaffProfileProvider` service extracts payload shared between admin and self-service pages
+- New UI with photo upload and qualifications as the two primary actions
+- Editable contact card; read-only employment and dependents
+- Completion banner on admin landing for staff-linked users
+- Staff-only login lands on `/my-profile` instead of admin staff show
+
+Spec: docs/superpowers/specs/2026-04-17-staff-my-profile-redesign-design.md
+
+## Test plan
+- [ ] Backend suite passes (`php artisan test`)
+- [ ] Staff user sees new page on login and can upload photo
+- [ ] Staff user can add a qualification end-to-end
+- [ ] Staff user can edit their email / phone / address
+- [ ] Admin view (`/staff/{id}`) unchanged
+- [ ] Multi-role user sees dismissible banner on admin landing
+- [ ] Mobile layout stacks correctly
+- [ ] Dark mode legible
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Spec → Task Coverage Map
+
+| Spec requirement | Task |
+|---|---|
+| New `/my-profile` route + controller | Task 2 |
+| Shared `StaffProfileProvider` + admin refactor | Task 1 |
+| Shared Inertia props (`person_id`, `has_photo`, `qualifications_count`) | Task 3 |
+| Staff-only landing redirected to My Profile | Task 4 |
+| `MyProfile/Index.vue` page shell | Task 5 |
+| `IdentityStrip` + progress chip | Task 6 |
+| `PhotoCard` empty/filled/uploading/error + inline remove | Task 7 |
+| `QualificationsCard` empty/filled + reuse of existing modals | Task 8 |
+| `ContactCard` using existing EditContactForm | Task 9 |
+| `ReadOnlyKvCard` for Employment + Dependents | Task 10 |
+| Nav link | Task 11 |
+| Dashboard banner for multi-role users | Task 12 |
+| Feature test suite | Tasks 2, 3, 4, 7, 8, 9 |
+| Regression + manual verification | Task 13 |
+
+Admin approval / email verification / phone OTP are explicitly out of scope (deferred to Spec 2) and have no tasks here.

--- a/docs/superpowers/specs/2026-04-17-staff-my-profile-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-17-staff-my-profile-redesign-design.md
@@ -1,0 +1,223 @@
+# Staff "My Profile" — Redesign for Self-Service Photo & Qualifications
+
+**Status:** Draft — pending approval
+**Branch:** `feature/staff-my-profile-redesign`
+**Date:** 2026-04-17
+
+## Problem
+
+The HR system is about to be opened to all staff. The first two actions a new staff user is expected to take — upload a photo and add their qualifications — are awkward on the existing profile page (`resources/js/Pages/Staff/NewShow.vue`):
+
+- The photo is a small corner avatar; upload is a pencil icon on hover, not an obvious action.
+- Qualifications sit below many HR-admin cards (Dates, Status, Type, Position, Promotions, Transfers), so a first-time user scrolls past a wall of mostly-empty data to reach the one section they can act on.
+- There is no guidance or empty-state coaching for either action, and no signal of completion progress.
+- The same page serves two audiences — staff viewing themselves and HR/admin managing the record — which makes both experiences mediocre.
+
+## Goals
+
+- A dedicated staff-facing `GET /my-profile` page, distinct from the admin `Staff/NewShow.vue`.
+- Photo upload and qualification management are the two most visible actions on first visit, with equal weight.
+- Clear, labelled empty states and a lightweight completion signal guide a new user to act.
+- Staff can also edit their own personal contact info (email, phone, primary address) from this page.
+- Admin `Staff/NewShow.vue` is unchanged.
+- Page works cleanly on desktop, tablet, and mobile, and supports dark mode to the same standard as the existing app.
+
+## Non-Goals (Deferred to Spec 2)
+
+The following are explicitly out of scope for this spec and will be picked up in a follow-up:
+
+- Admin approval workflow for staff-uploaded photos (the photo goes live immediately here).
+- Email-change verification via tokenised link (new email is saved immediately here).
+- Phone-number-change verification via SMS OTP (new phone is saved immediately here; no SMS vendor is installed in the project today).
+- Any dependent self-service (the dependents workflow is incomplete; dependents appear read-only on My Profile for now).
+- Any change to admin staff management screens.
+
+## Design
+
+### Architecture & routing
+
+A single new controller and page, backed by a shared service so we don't duplicate the eager-load logic already in `InstitutionPersonController@show`.
+
+```
+GET /my-profile ─► MyProfileController@show
+                    │
+                    ├─► StaffProfileProvider::forPerson($authUser->person_id)
+                    │        (shared with InstitutionPersonController@show)
+                    │
+                    └─► Inertia::render('MyProfile/Index', [...])
+```
+
+- **Route:** `Route::middleware(['auth','password_changed'])->get('/my-profile', [MyProfileController::class, 'show'])->name('my-profile.show');` — authenticated users only; a `403` is returned for users whose account has no linked `person_id`.
+- **No new resource routes for photo, contacts, qualifications.** Existing endpoints are reused:
+  - `POST /person/{person}/avatar` (`PersonAvatarController@update`)
+  - `DELETE /person/{person}/avatar/delete` (`PersonAvatarController@delete`)
+  - Qualification CRUD under `qualification.*`
+  - Contact & address edit endpoints already wired into `EditContactForm.vue` and the address modal.
+- **Admin view:** `resources/js/Pages/Staff/NewShow.vue` is untouched. Staff with admin rights can still reach it via `/staff/{id}`. A later follow-up may consolidate.
+
+### Backend
+
+#### `app/Services/StaffProfileProvider.php` (new)
+
+Extracts the eager-load-and-map logic that currently lives inline in `InstitutionPersonController@show` (lines ~174–290) so it can be reused by `MyProfileController`. Returns the payload shape already produced by that controller: `['person' => ..., 'staff' => ..., 'contacts' => ..., 'address' => ..., 'qualifications' => ..., ]`.
+
+```php
+final class StaffProfileProvider
+{
+    public function forPerson(int $personId): ?array
+    {
+        // Mirrors InstitutionPersonController@show's eager load + map.
+        // Returns null when no active InstitutionPerson is found for the person.
+    }
+}
+```
+
+`InstitutionPersonController@show` is refactored to call this service, so there is a single source of truth. The public JSON shape stays identical — an important constraint, because `NewShow.vue` already consumes it.
+
+#### `app/Http/Controllers/MyProfileController.php` (new)
+
+```php
+public function show(Request $request, StaffProfileProvider $provider): Response
+{
+    $personId = $request->user()->person_id;
+    abort_unless($personId, 403, 'Your account is not linked to a staff record.');
+
+    $profile = $provider->forPerson($personId);
+    abort_if($profile === null, 404, 'Staff record not found.');
+
+    return Inertia::render('MyProfile/Index', $profile);
+}
+```
+
+No `authorize()` gate is needed beyond the `person_id` ownership check — the route itself scopes to the authenticated user. All per-field edit endpoints already enforce their own authorization.
+
+### Vue components
+
+```
+resources/js/Pages/MyProfile/Index.vue         (page — composes the strip, priority grid, secondary grid)
+
+resources/js/Components/MyProfile/
+  IdentityStrip.vue        (avatar, name, meta, progress chip)
+  PhotoCard.vue            (empty + filled + uploading + error states; drag-and-drop)
+  QualificationsCard.vue   (empty + filled states; wraps existing AddQualification/EditQualification/AttachDocument modals and QualificationList)
+  ContactCard.vue          (email, phone, primary address; opens existing EditContactForm + address modals)
+  ReadOnlyKvCard.vue       (generic key-value card — used for Employment and Dependents)
+  ProfileProgress.vue      (computes & renders the completion chip)
+```
+
+Everything uses `<script setup>`. Existing `Avatar.vue`, `ImageUpload.vue`, `NewModal.vue`, `EditContactForm.vue`, `AddQualification`, `EditQualification`, `AttachDocument`, and `QualificationList` are reused — no forks.
+
+### Photo upload UX
+
+Single `PhotoCard.vue` with four visual states driven by local component state plus props.
+
+| State | Trigger | UI |
+|---|---|---|
+| Empty | `person.image === null` | 2 px dashed drop zone filling the card body; "Drop your photo here" + file-picker button. Amber "Not set" chip in the card header. |
+| Uploading | submit in flight | Drop zone greys out; progress bar + spinner over it. |
+| Filled | `person.image !== null` and no in-flight submit | 120 × 120 preview + "Change photo" (ghost, green) + "Remove" (ghost, red) buttons. Green "✓ Set" chip in the card header. |
+| Error | validation or server failure | Inline message under the drop zone (no modal). Drop zone remains interactive so the user can retry without a page reload. |
+
+- **Client-side validation:** JPG or PNG, ≤ 2 MB. Anything else shows the error state before any HTTP call.
+- **Submit:** `router.post(route('person.avatar.update', { person: props.person.id }), formData, { forceFormData: true, preserveScroll: true, onSuccess: () => router.reload({ only: ['person'] }) })`.
+- **Remove:** `router.delete(route('person.avatar.delete', { person: props.person.id }), { preserveScroll: true, onSuccess: () => router.reload({ only: ['person'] }) })`. A small confirm dialog (reuse existing `DeleteAvatar.vue`) is shown first.
+- **No full-page modal.** The current flow opens a `NewModal` wrapping `EditAvatarForm`; the new flow is inline on the card.
+
+### Qualifications flow
+
+`QualificationsCard.vue` delegates heavily to what already exists.
+
+| State | Trigger | UI |
+|---|---|---|
+| Empty | `qualifications.length === 0` | Centered empty-state with 🎓 glyph, "Add your first qualification" heading, one-line helper, primary `+ Add qualification` button, and a row of non-interactive example tags ("Degree", "Diploma", "Certificate", "Training"). |
+| Filled | `qualifications.length > 0` | Denser list than `QualificationList.vue`'s admin layout — one row per qualification with title, institution · year · status tag · document count, plus inline Edit / Attach actions. A full-width dashed `+ Add another qualification` button sits below the list. |
+
+- The add / edit / delete / attach modals are the existing `Pages/Qualification/Add.vue`, `Edit.vue`, `Delete.vue`, `AttachDocument.vue`, mounted inside `NewModal` exactly as `PersonQualifications.vue` does today.
+- The existing permission-gated **Approve** button is not rendered on My Profile (staff can't approve their own); all other permission checks (`edit staff qualification`, `delete staff qualification`, `create staff qualification`) carry over.
+- After any successful mutation: close the modal, `router.reload({ only: ['qualifications'] })`.
+- The existing "Download Profile PDF" link (rendered when the user has `qualifications.reports.export`) is kept in the card header for users with the permission.
+
+### Identity strip & progress
+
+`IdentityStrip.vue` is a single row on desktop, stacked on mobile:
+
+```
+[avatar 72×72]  Name (22px, bold)                              [progress chip]
+                Current rank · Department · Staff #{staff_number}
+```
+
+`ProfileProgress.vue` computes completion client-side from the same props:
+
+```js
+const checkpoints = computed(() => [
+  Boolean(props.person.image),
+  props.qualifications.length > 0,
+  Boolean(props.contacts?.some(c => c.contact_type === 'email'))
+    && Boolean(props.contacts?.some(c => c.contact_type === 'phone')),
+]);
+const percent = computed(() => Math.round(checkpoints.value.filter(Boolean).length / 3 * 100));
+```
+
+- `< 100 %` renders an **amber** chip (`bg-amber-50 text-amber-800`) reading `X% complete`.
+- `= 100 %` renders a **green** chip (`bg-emerald-50 text-emerald-800`) reading `✓ Profile complete`.
+- No persistence, no API. Purely derived from the already-loaded props.
+
+### Secondary section (Contact, Employment, Dependents)
+
+Three equal-width `ReadOnlyKvCard.vue` instances, except Contact which has an Edit action.
+
+- **Contact:** rows for Email, Phone, Primary Address. "Edit" link in the header opens the existing `EditContactForm.vue` (phone/email) or address modal. No new backend work.
+- **Employment:** read-only rows — Rank (current), Unit (current), Joined (hire date). Header label reads "HR-managed" in muted grey; there is no pencil or edit affordance.
+- **Dependents:** read-only list — Spouse name (if any), number of children. Header label reads "View only"; a muted, italic footer reads "Need changes? Contact HR." All add/edit buttons that `StaffDependents/Index.vue` currently renders are suppressed here.
+
+### Dashboard banner & nav link
+
+- **Nav:** append a "My Profile" link to the authenticated top bar in `resources/js/Layouts/NewAuthenticated.vue`, visible to any user whose `page.props.auth.user.person_id` is truthy.
+- **Dashboard banner:** `resources/js/Components/MyProfile/CompletionBanner.vue`, rendered on the dashboard when the authenticated user has a `person_id` and at least one of "photo missing" or "qualifications count = 0" is true. Dismissible for the session via `sessionStorage` (no backend persistence, no new column). Clicking the banner deep-links to `/my-profile`. The banner needs `person_id`, `has_photo`, and `qualifications_count` to be present in `HandleInertiaRequests` shared props — add those three fields there so the banner can render without an extra HTTP call.
+- **No forced redirect.** The banner is an invitation, not a gate.
+
+### Mobile and dark mode
+
+- `<768 px`: identity strip stacks (avatar on top, name/meta centred, chip on its own row); priority grid becomes a single column (photo card first, qualifications second); secondary grid collapses to one column. Drag-and-drop gracefully degrades to tap-to-pick.
+- Every colour token has a `dark:` variant matching the existing app palette (greens and greys already in use across `NewShow.vue`, `QualificationList.vue`).
+
+## Testing
+
+Feature tests (PHPUnit, `tests/Feature/MyProfile/`):
+
+- `MyProfileShowTest`
+  - `guest_is_redirected_to_login`
+  - `authenticated_user_without_person_id_gets_403`
+  - `authenticated_user_with_active_staff_record_sees_page_with_their_data`
+  - `authenticated_user_with_separated_staff_record_sees_404`
+  - `payload_shape_matches_admin_staff_show_payload` (golden-shape test — asserts `StaffProfileProvider` returns the same keys/structure the admin page consumes)
+- `MyProfilePhotoUploadTest`
+  - `staff_can_upload_own_photo` (hits existing `person.avatar.update` — coverage here protects the My Profile flow specifically)
+  - `staff_cannot_upload_photo_for_another_person` (existing behaviour; regression guard)
+- `MyProfileQualificationTest`
+  - `staff_can_add_qualification_to_own_record`
+  - `approve_action_is_not_exposed_on_my_profile_page_props` (asserts permissions gate does what the UI assumes)
+- `MyProfileContactEditTest`
+  - `staff_can_update_own_email_and_phone`
+  - `staff_cannot_update_contacts_for_another_person`
+
+The refactor of `InstitutionPersonController@show` to use `StaffProfileProvider` is covered by the existing admin show tests (which must continue to pass). Add a regression test if none currently assert that the admin payload contains its expected keys — otherwise rely on the existing coverage.
+
+Vue unit tests are not part of the existing project's conventions; we follow that. Manual verification checklist lives in the PR description.
+
+## Rollout
+
+- Feature is gated by the existence of the `/my-profile` route plus the nav link. No feature flag.
+- No migrations, no seeders, no new permissions.
+- The dashboard banner is dismissible per-session so it won't block anyone.
+- Admin `Staff/NewShow.vue` behaviour is unchanged — no coordinated release needed.
+
+## Future work (Spec 2)
+
+The following was discussed and intentionally deferred to a follow-up spec so Spec 1 can ship quickly:
+
+- **Admin approval for photo changes.** Mirror the existing `Qualification` approval pattern (`approved_by`, `approved_at`, an `approve photo` permission, admin queue UI). Until Spec 2 lands, photo updates go live immediately.
+- **Email-change verification.** New `email_change_tokens` table, mailable, and verify endpoint. Until Spec 2 lands, email updates go live immediately.
+- **Phone-change verification via OTP.** Requires an SMS vendor decision (Africa's Talking, Twilio, Vonage, …), a `phone_verification_codes` table with expiry + rate limit, send/verify endpoints, and a code-entry UI. Until Spec 2 lands, phone updates go live immediately.
+
+When Spec 2 is written, the hook points are: `PhotoCard.vue` (add a "pending review" state), `ContactCard.vue` (add "verification sent — check your inbox" and "enter 6-digit code" states), and a new admin queue route for photo review. The current data shape is designed so those additions are new fields rather than schema rewrites.

--- a/resources/js/Components/MyProfile/AddressCard.vue
+++ b/resources/js/Components/MyProfile/AddressCard.vue
@@ -159,7 +159,7 @@ function changeAddress() {
 					</button>
 					<button
 						type="button"
-						class="text-[11px] font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+						class="text-[11px] font-semibold text-green-600 dark:text-green-400 hover:underline"
 						@click="openChangeModal()"
 					>
 						Change
@@ -325,7 +325,9 @@ function changeAddress() {
 						</p>
 					</div>
 
-					<div class="mt-5 flex justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-700">
+					<div
+						class="mt-5 flex justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-700"
+					>
 						<button
 							type="button"
 							class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -378,7 +380,7 @@ function changeAddress() {
 							v-model="changeForm.address_line_1"
 							type="text"
 							required
-							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
 							:class="{ 'border-red-500': changeErrors.address_line_1 }"
 						/>
 						<p
@@ -400,7 +402,7 @@ function changeAddress() {
 							id="change_address_line_2"
 							v-model="changeForm.address_line_2"
 							type="text"
-							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
 						/>
 					</div>
 
@@ -417,7 +419,7 @@ function changeAddress() {
 								v-model="changeForm.city"
 								type="text"
 								required
-								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
 								:class="{ 'border-red-500': changeErrors.city }"
 							/>
 							<p
@@ -438,7 +440,7 @@ function changeAddress() {
 								id="change_post_code"
 								v-model="changeForm.post_code"
 								type="text"
-								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-green-500"
 							/>
 						</div>
 					</div>
@@ -489,7 +491,7 @@ function changeAddress() {
 						</p>
 					</div>
 
-					<div class="mt-5 flex justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-700">
+					<div class="mt-5 flex justify-end gap-2 pt-4">
 						<button
 							type="button"
 							class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -499,7 +501,7 @@ function changeAddress() {
 						</button>
 						<button
 							type="submit"
-							class="inline-flex items-center rounded-lg bg-blue-600 hover:bg-blue-700 px-4 py-2 text-sm font-bold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors"
+							class="inline-flex items-center rounded-lg bg-green-600 hover:bg-green-700 px-4 py-2 text-sm font-bold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 dark:focus:ring-offset-gray-800 transition-colors"
 						>
 							Save as new address
 						</button>

--- a/resources/js/Components/MyProfile/AddressCard.vue
+++ b/resources/js/Components/MyProfile/AddressCard.vue
@@ -144,7 +144,7 @@ function changeAddress() {
 
 <template>
 	<section
-		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+		class="bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
 	>
 		<header class="flex justify-between items-center mb-3">
 			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Address</h3>
@@ -194,7 +194,9 @@ function changeAddress() {
 					v-if="Object.keys(editErrors).length"
 					class="mb-3 rounded-md bg-red-50 dark:bg-red-900/20 px-4 py-2"
 				>
-					<ul class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1">
+					<ul
+						class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1"
+					>
 						<li v-for="(msg, field) in editErrors" :key="field">{{ msg }}</li>
 					</ul>
 				</div>
@@ -215,7 +217,10 @@ function changeAddress() {
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
 							:class="{ 'border-red-500': editErrors.address_line_1 }"
 						/>
-						<p v-if="editErrors.address_line_1" class="mt-1 text-xs text-red-600 dark:text-red-400">
+						<p
+							v-if="editErrors.address_line_1"
+							class="mt-1 text-xs text-red-600 dark:text-red-400"
+						>
 							{{ editErrors.address_line_1 }}
 						</p>
 					</div>
@@ -251,7 +256,10 @@ function changeAddress() {
 								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
 								:class="{ 'border-red-500': editErrors.city }"
 							/>
-							<p v-if="editErrors.city" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							<p
+								v-if="editErrors.city"
+								class="mt-1 text-xs text-red-600 dark:text-red-400"
+							>
 								{{ editErrors.city }}
 							</p>
 						</div>
@@ -309,24 +317,27 @@ function changeAddress() {
 								{{ c.label ?? c }}
 							</option>
 						</select>
-						<p v-if="editErrors.country" class="mt-1 text-xs text-red-600 dark:text-red-400">
+						<p
+							v-if="editErrors.country"
+							class="mt-1 text-xs text-red-600 dark:text-red-400"
+						>
 							{{ editErrors.country }}
 						</p>
 					</div>
 
-					<div class="mt-4 flex justify-end gap-3">
+					<div class="mt-5 flex justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-700">
 						<button
 							type="button"
-							class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
+							class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 							@click="toggleEdit()"
 						>
 							Cancel
 						</button>
 						<button
 							type="submit"
-							class="text-sm font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+							class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2 text-sm font-bold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 dark:focus:ring-offset-gray-800 transition-colors"
 						>
-							Save
+							Save changes
 						</button>
 					</div>
 				</form>
@@ -347,7 +358,9 @@ function changeAddress() {
 					v-if="Object.keys(changeErrors).length"
 					class="mb-3 rounded-md bg-red-50 dark:bg-red-900/20 px-4 py-2"
 				>
-					<ul class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1">
+					<ul
+						class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1"
+					>
 						<li v-for="(msg, field) in changeErrors" :key="field">{{ msg }}</li>
 					</ul>
 				</div>
@@ -368,7 +381,10 @@ function changeAddress() {
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
 							:class="{ 'border-red-500': changeErrors.address_line_1 }"
 						/>
-						<p v-if="changeErrors.address_line_1" class="mt-1 text-xs text-red-600 dark:text-red-400">
+						<p
+							v-if="changeErrors.address_line_1"
+							class="mt-1 text-xs text-red-600 dark:text-red-400"
+						>
 							{{ changeErrors.address_line_1 }}
 						</p>
 					</div>
@@ -404,7 +420,10 @@ function changeAddress() {
 								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
 								:class="{ 'border-red-500': changeErrors.city }"
 							/>
-							<p v-if="changeErrors.city" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							<p
+								v-if="changeErrors.city"
+								class="mt-1 text-xs text-red-600 dark:text-red-400"
+							>
 								{{ changeErrors.city }}
 							</p>
 						</div>
@@ -462,22 +481,25 @@ function changeAddress() {
 								{{ c.label ?? c }}
 							</option>
 						</select>
-						<p v-if="changeErrors.country" class="mt-1 text-xs text-red-600 dark:text-red-400">
+						<p
+							v-if="changeErrors.country"
+							class="mt-1 text-xs text-red-600 dark:text-red-400"
+						>
 							{{ changeErrors.country }}
 						</p>
 					</div>
 
-					<div class="mt-4 flex justify-end gap-3">
+					<div class="mt-5 flex justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-700">
 						<button
 							type="button"
-							class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
+							class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 							@click="toggleChange()"
 						>
 							Cancel
 						</button>
 						<button
 							type="submit"
-							class="text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+							class="inline-flex items-center rounded-lg bg-blue-600 hover:bg-blue-700 px-4 py-2 text-sm font-bold text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors"
 						>
 							Save as new address
 						</button>

--- a/resources/js/Components/MyProfile/AddressCard.vue
+++ b/resources/js/Components/MyProfile/AddressCard.vue
@@ -12,6 +12,9 @@ const props = defineProps({
 const openEdit = ref(false);
 const toggleEdit = useToggle(openEdit);
 
+const openChange = ref(false);
+const toggleChange = useToggle(openChange);
+
 const countries = ref([]);
 onMounted(async () => {
 	try {
@@ -36,40 +39,52 @@ const addressDisplay = computed(() => {
 		.join(", ");
 });
 
-const form = ref({
-	address_line_1: "",
-	address_line_2: "",
-	city: "",
-	region: "",
-	country: "",
-	post_code: "",
-});
+function blankForm() {
+	return {
+		address_line_1: "",
+		address_line_2: "",
+		city: "",
+		region: "",
+		country: "",
+		post_code: "",
+	};
+}
+
+const editForm = ref(blankForm());
+const editErrors = ref({});
+
+const changeForm = ref(blankForm());
+const changeErrors = ref({});
 
 function openEditModal() {
-	if (props.address) {
-		form.value = {
-			address_line_1: props.address.address_line_1 ?? "",
-			address_line_2: props.address.address_line_2 ?? "",
-			city: props.address.city ?? "",
-			region: props.address.region ?? "",
-			country: props.address.country ?? "",
-			post_code: props.address.post_code ?? "",
-		};
-	} else {
-		form.value = {
-			address_line_1: "",
-			address_line_2: "",
-			city: "",
-			region: "",
-			country: "",
-			post_code: "",
-		};
-	}
+	editErrors.value = {};
+	editForm.value = props.address
+		? {
+				address_line_1: props.address.address_line_1 ?? "",
+				address_line_2: props.address.address_line_2 ?? "",
+				city: props.address.city ?? "",
+				region: props.address.region ?? "",
+				country: props.address.country ?? "",
+				post_code: props.address.post_code ?? "",
+			}
+		: blankForm();
+	toggleEdit();
+}
+
+function openChangeModal() {
+	changeErrors.value = {};
+	changeForm.value = blankForm();
+	toggleChange();
+}
+
+function openAddModal() {
+	editErrors.value = {};
+	editForm.value = blankForm();
 	toggleEdit();
 }
 
 function saveAddress() {
-	const data = { ...form.value };
+	editErrors.value = {};
 
 	if (props.address) {
 		router.patch(
@@ -77,28 +92,53 @@ function saveAddress() {
 				person: props.personId,
 				address: props.address.id,
 			}),
-			data,
+			editForm.value,
 			{
 				preserveScroll: true,
 				onSuccess: () => {
-					toggleEdit();
+					openEdit.value = false;
 					router.reload({ only: ["address"] });
+				},
+				onError: (errors) => {
+					editErrors.value = errors;
 				},
 			},
 		);
 	} else {
 		router.post(
 			route("person.address.create", { person: props.personId }),
-			data,
+			editForm.value,
 			{
 				preserveScroll: true,
 				onSuccess: () => {
-					toggleEdit();
+					openEdit.value = false;
 					router.reload({ only: ["address"] });
+				},
+				onError: (errors) => {
+					editErrors.value = errors;
 				},
 			},
 		);
 	}
+}
+
+function changeAddress() {
+	changeErrors.value = {};
+
+	router.post(
+		route("person.address.change", { person: props.personId }),
+		changeForm.value,
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				openChange.value = false;
+				router.reload({ only: ["address"] });
+			},
+			onError: (errors) => {
+				changeErrors.value = errors;
+			},
+		},
+	);
 }
 </script>
 
@@ -108,13 +148,32 @@ function saveAddress() {
 	>
 		<header class="flex justify-between items-center mb-3">
 			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Address</h3>
-			<button
-				type="button"
-				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
-				@click="openEditModal()"
-			>
-				{{ address ? "Edit" : "Add address" }}
-			</button>
+			<div class="flex items-center gap-3">
+				<template v-if="address">
+					<button
+						type="button"
+						class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+						@click="openEditModal()"
+					>
+						Edit
+					</button>
+					<button
+						type="button"
+						class="text-[11px] font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+						@click="openChangeModal()"
+					>
+						Change
+					</button>
+				</template>
+				<button
+					v-else
+					type="button"
+					class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+					@click="openAddModal()"
+				>
+					Add address
+				</button>
+			</div>
 		</header>
 
 		<div v-if="addressDisplay" class="text-sm text-gray-900 dark:text-gray-100">
@@ -124,39 +183,53 @@ function saveAddress() {
 			No address on file.
 		</p>
 
+		<!-- Edit / Add modal -->
 		<NewModal :show="openEdit" @close="toggleEdit()">
 			<div class="px-6 py-6">
 				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
 					{{ address ? "Edit address" : "Add address" }}
 				</h2>
 
+				<div
+					v-if="Object.keys(editErrors).length"
+					class="mb-3 rounded-md bg-red-50 dark:bg-red-900/20 px-4 py-2"
+				>
+					<ul class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1">
+						<li v-for="(msg, field) in editErrors" :key="field">{{ msg }}</li>
+					</ul>
+				</div>
+
 				<form class="space-y-3" @submit.prevent="saveAddress">
 					<div>
 						<label
-							for="address_line_1"
+							for="edit_address_line_1"
 							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 						>
 							Address line 1 <span class="text-red-500">*</span>
 						</label>
 						<input
-							id="address_line_1"
-							v-model="form.address_line_1"
+							id="edit_address_line_1"
+							v-model="editForm.address_line_1"
 							type="text"
 							required
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+							:class="{ 'border-red-500': editErrors.address_line_1 }"
 						/>
+						<p v-if="editErrors.address_line_1" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							{{ editErrors.address_line_1 }}
+						</p>
 					</div>
 
 					<div>
 						<label
-							for="address_line_2"
+							for="edit_address_line_2"
 							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 						>
 							Address line 2
 						</label>
 						<input
-							id="address_line_2"
-							v-model="form.address_line_2"
+							id="edit_address_line_2"
+							v-model="editForm.address_line_2"
 							type="text"
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
 						/>
@@ -165,29 +238,33 @@ function saveAddress() {
 					<div class="grid grid-cols-2 gap-3">
 						<div>
 							<label
-								for="city"
+								for="edit_city"
 								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 							>
 								City <span class="text-red-500">*</span>
 							</label>
 							<input
-								id="city"
-								v-model="form.city"
+								id="edit_city"
+								v-model="editForm.city"
 								type="text"
 								required
 								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+								:class="{ 'border-red-500': editErrors.city }"
 							/>
+							<p v-if="editErrors.city" class="mt-1 text-xs text-red-600 dark:text-red-400">
+								{{ editErrors.city }}
+							</p>
 						</div>
 						<div>
 							<label
-								for="post_code"
+								for="edit_post_code"
 								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 							>
 								Post code
 							</label>
 							<input
-								id="post_code"
-								v-model="form.post_code"
+								id="edit_post_code"
+								v-model="editForm.post_code"
 								type="text"
 								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
 							/>
@@ -196,14 +273,14 @@ function saveAddress() {
 
 					<div>
 						<label
-							for="region"
+							for="edit_region"
 							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 						>
 							Region
 						</label>
 						<input
-							id="region"
-							v-model="form.region"
+							id="edit_region"
+							v-model="editForm.region"
 							type="text"
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
 						/>
@@ -211,16 +288,17 @@ function saveAddress() {
 
 					<div>
 						<label
-							for="country"
+							for="edit_country"
 							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
 						>
 							Country <span class="text-red-500">*</span>
 						</label>
 						<select
-							id="country"
-							v-model="form.country"
+							id="edit_country"
+							v-model="editForm.country"
 							required
 							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+							:class="{ 'border-red-500': editErrors.country }"
 						>
 							<option value="" disabled>Select country</option>
 							<option
@@ -231,6 +309,9 @@ function saveAddress() {
 								{{ c.label ?? c }}
 							</option>
 						</select>
+						<p v-if="editErrors.country" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							{{ editErrors.country }}
+						</p>
 					</div>
 
 					<div class="mt-4 flex justify-end gap-3">
@@ -246,6 +327,159 @@ function saveAddress() {
 							class="text-sm font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
 						>
 							Save
+						</button>
+					</div>
+				</form>
+			</div>
+		</NewModal>
+
+		<!-- Change address modal -->
+		<NewModal :show="openChange" @close="toggleChange()">
+			<div class="px-6 py-6">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-1">
+					Change address
+				</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+					The current address will be archived and replaced with this new one.
+				</p>
+
+				<div
+					v-if="Object.keys(changeErrors).length"
+					class="mb-3 rounded-md bg-red-50 dark:bg-red-900/20 px-4 py-2"
+				>
+					<ul class="list-disc list-inside text-sm text-red-700 dark:text-red-300 space-y-1">
+						<li v-for="(msg, field) in changeErrors" :key="field">{{ msg }}</li>
+					</ul>
+				</div>
+
+				<form class="space-y-3" @submit.prevent="changeAddress">
+					<div>
+						<label
+							for="change_address_line_1"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Address line 1 <span class="text-red-500">*</span>
+						</label>
+						<input
+							id="change_address_line_1"
+							v-model="changeForm.address_line_1"
+							type="text"
+							required
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							:class="{ 'border-red-500': changeErrors.address_line_1 }"
+						/>
+						<p v-if="changeErrors.address_line_1" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							{{ changeErrors.address_line_1 }}
+						</p>
+					</div>
+
+					<div>
+						<label
+							for="change_address_line_2"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Address line 2
+						</label>
+						<input
+							id="change_address_line_2"
+							v-model="changeForm.address_line_2"
+							type="text"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div class="grid grid-cols-2 gap-3">
+						<div>
+							<label
+								for="change_city"
+								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+							>
+								City <span class="text-red-500">*</span>
+							</label>
+							<input
+								id="change_city"
+								v-model="changeForm.city"
+								type="text"
+								required
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+								:class="{ 'border-red-500': changeErrors.city }"
+							/>
+							<p v-if="changeErrors.city" class="mt-1 text-xs text-red-600 dark:text-red-400">
+								{{ changeErrors.city }}
+							</p>
+						</div>
+						<div>
+							<label
+								for="change_post_code"
+								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+							>
+								Post code
+							</label>
+							<input
+								id="change_post_code"
+								v-model="changeForm.post_code"
+								type="text"
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							/>
+						</div>
+					</div>
+
+					<div>
+						<label
+							for="change_region"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Region
+						</label>
+						<input
+							id="change_region"
+							v-model="changeForm.region"
+							type="text"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
+
+					<div>
+						<label
+							for="change_country"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Country <span class="text-red-500">*</span>
+						</label>
+						<select
+							id="change_country"
+							v-model="changeForm.country"
+							required
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+							:class="{ 'border-red-500': changeErrors.country }"
+						>
+							<option value="" disabled>Select country</option>
+							<option
+								v-for="c in countries"
+								:key="c.value ?? c"
+								:value="c.value ?? c"
+							>
+								{{ c.label ?? c }}
+							</option>
+						</select>
+						<p v-if="changeErrors.country" class="mt-1 text-xs text-red-600 dark:text-red-400">
+							{{ changeErrors.country }}
+						</p>
+					</div>
+
+					<div class="mt-4 flex justify-end gap-3">
+						<button
+							type="button"
+							class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
+							@click="toggleChange()"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							class="text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+						>
+							Save as new address
 						</button>
 					</div>
 				</form>

--- a/resources/js/Components/MyProfile/AddressCard.vue
+++ b/resources/js/Components/MyProfile/AddressCard.vue
@@ -1,0 +1,255 @@
+<script setup>
+import { ref, computed, onMounted } from "vue";
+import { router } from "@inertiajs/vue3";
+import { useToggle } from "@vueuse/core";
+import NewModal from "@/Components/NewModal.vue";
+
+const props = defineProps({
+	personId: { type: Number, required: true },
+	address: { type: Object, default: () => null },
+});
+
+const openEdit = ref(false);
+const toggleEdit = useToggle(openEdit);
+
+const countries = ref([]);
+onMounted(async () => {
+	try {
+		const response = await axios.get(route("country.index"));
+		countries.value = response.data;
+	} catch {
+		countries.value = [];
+	}
+});
+
+const addressDisplay = computed(() => {
+	if (!props.address) return null;
+	return [
+		props.address.address_line_1,
+		props.address.address_line_2,
+		props.address.city,
+		props.address.region,
+		props.address.country,
+		props.address.post_code,
+	]
+		.filter(Boolean)
+		.join(", ");
+});
+
+const form = ref({
+	address_line_1: "",
+	address_line_2: "",
+	city: "",
+	region: "",
+	country: "",
+	post_code: "",
+});
+
+function openEditModal() {
+	if (props.address) {
+		form.value = {
+			address_line_1: props.address.address_line_1 ?? "",
+			address_line_2: props.address.address_line_2 ?? "",
+			city: props.address.city ?? "",
+			region: props.address.region ?? "",
+			country: props.address.country ?? "",
+			post_code: props.address.post_code ?? "",
+		};
+	} else {
+		form.value = {
+			address_line_1: "",
+			address_line_2: "",
+			city: "",
+			region: "",
+			country: "",
+			post_code: "",
+		};
+	}
+	toggleEdit();
+}
+
+function saveAddress() {
+	const data = { ...form.value };
+
+	if (props.address) {
+		router.patch(
+			route("person.address.update", {
+				person: props.personId,
+				address: props.address.id,
+			}),
+			data,
+			{
+				preserveScroll: true,
+				onSuccess: () => {
+					toggleEdit();
+					router.reload({ only: ["address"] });
+				},
+			},
+		);
+	} else {
+		router.post(
+			route("person.address.create", { person: props.personId }),
+			data,
+			{
+				preserveScroll: true,
+				onSuccess: () => {
+					toggleEdit();
+					router.reload({ only: ["address"] });
+				},
+			},
+		);
+	}
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Address</h3>
+			<button
+				type="button"
+				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+				@click="openEditModal()"
+			>
+				{{ address ? "Edit" : "Add address" }}
+			</button>
+		</header>
+
+		<div v-if="addressDisplay" class="text-sm text-gray-900 dark:text-gray-100">
+			<p class="leading-relaxed">{{ addressDisplay }}</p>
+		</div>
+		<p v-else class="text-sm text-gray-500 dark:text-gray-400 py-1">
+			No address on file.
+		</p>
+
+		<NewModal :show="openEdit" @close="toggleEdit()">
+			<div class="px-6 py-6">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+					{{ address ? "Edit address" : "Add address" }}
+				</h2>
+
+				<form class="space-y-3" @submit.prevent="saveAddress">
+					<div>
+						<label
+							for="address_line_1"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Address line 1 <span class="text-red-500">*</span>
+						</label>
+						<input
+							id="address_line_1"
+							v-model="form.address_line_1"
+							type="text"
+							required
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+						/>
+					</div>
+
+					<div>
+						<label
+							for="address_line_2"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Address line 2
+						</label>
+						<input
+							id="address_line_2"
+							v-model="form.address_line_2"
+							type="text"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+						/>
+					</div>
+
+					<div class="grid grid-cols-2 gap-3">
+						<div>
+							<label
+								for="city"
+								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+							>
+								City <span class="text-red-500">*</span>
+							</label>
+							<input
+								id="city"
+								v-model="form.city"
+								type="text"
+								required
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+							/>
+						</div>
+						<div>
+							<label
+								for="post_code"
+								class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+							>
+								Post code
+							</label>
+							<input
+								id="post_code"
+								v-model="form.post_code"
+								type="text"
+								class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+							/>
+						</div>
+					</div>
+
+					<div>
+						<label
+							for="region"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Region
+						</label>
+						<input
+							id="region"
+							v-model="form.region"
+							type="text"
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+						/>
+					</div>
+
+					<div>
+						<label
+							for="country"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+						>
+							Country <span class="text-red-500">*</span>
+						</label>
+						<select
+							id="country"
+							v-model="form.country"
+							required
+							class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+						>
+							<option value="" disabled>Select country</option>
+							<option
+								v-for="c in countries"
+								:key="c.value ?? c"
+								:value="c.value ?? c"
+							>
+								{{ c.label ?? c }}
+							</option>
+						</select>
+					</div>
+
+					<div class="mt-4 flex justify-end gap-3">
+						<button
+							type="button"
+							class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
+							@click="toggleEdit()"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							class="text-sm font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+						>
+							Save
+						</button>
+					</div>
+				</form>
+			</div>
+		</NewModal>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/CompletionBanner.vue
+++ b/resources/js/Components/MyProfile/CompletionBanner.vue
@@ -9,12 +9,38 @@ const hasPersonId = computed(() => Boolean(auth.value?.user?.person_id));
 const hasPhoto = computed(() => auth.value?.has_photo === true);
 const hasQuals = computed(() => (auth.value?.qualifications_count ?? 0) > 0);
 
-const dismissedKey = "my-profile.banner.dismissed";
+// Dismissal persists across tabs and restarts for seven days. After that the
+// banner reappears so users who still haven't completed their profile get
+// another gentle nudge.
+const dismissedKey = "my-profile.banner.dismissed-at";
+const dismissalTtlMs = 7 * 24 * 60 * 60 * 1000;
 const dismissed = ref(false);
 
 onMounted(() => {
-	dismissed.value = sessionStorage.getItem(dismissedKey) === "1";
+	dismissed.value = isCurrentlyDismissed();
 });
+
+function isCurrentlyDismissed() {
+	try {
+		const value = localStorage.getItem(dismissedKey);
+		if (!value) return false;
+		const dismissedAt = Number(value);
+		if (!Number.isFinite(dismissedAt)) return false;
+		return Date.now() - dismissedAt < dismissalTtlMs;
+	} catch {
+		// localStorage unavailable (private mode, etc.) — don't suppress the banner.
+		return false;
+	}
+}
+
+function dismiss() {
+	try {
+		localStorage.setItem(dismissedKey, String(Date.now()));
+	} catch {
+		// Swallow — UI still hides for the rest of this render.
+	}
+	dismissed.value = true;
+}
 
 const shouldShow = computed(
 	() =>
@@ -22,11 +48,6 @@ const shouldShow = computed(
 		(!hasPhoto.value || !hasQuals.value) &&
 		!dismissed.value,
 );
-
-function dismiss() {
-	sessionStorage.setItem(dismissedKey, "1");
-	dismissed.value = true;
-}
 
 const message = computed(() => {
 	if (!hasPhoto.value && !hasQuals.value)
@@ -39,6 +60,7 @@ const message = computed(() => {
 <template>
 	<div
 		v-if="shouldShow"
+		data-testid="profile-completion-banner"
 		class="flex items-center gap-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 px-4 py-3"
 	>
 		<div class="text-2xl">📝</div>

--- a/resources/js/Components/MyProfile/CompletionBanner.vue
+++ b/resources/js/Components/MyProfile/CompletionBanner.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed, ref, onMounted } from "vue";
+import { Link, usePage } from "@inertiajs/vue3";
+
+const page = usePage();
+const auth = computed(() => page.props?.auth ?? {});
+
+const hasPersonId = computed(() => Boolean(auth.value?.user?.person_id));
+const hasPhoto = computed(() => auth.value?.has_photo === true);
+const hasQuals = computed(() => (auth.value?.qualifications_count ?? 0) > 0);
+
+const dismissedKey = "my-profile.banner.dismissed";
+const dismissed = ref(false);
+
+onMounted(() => {
+	dismissed.value = sessionStorage.getItem(dismissedKey) === "1";
+});
+
+const shouldShow = computed(
+	() => hasPersonId.value && (!hasPhoto.value || !hasQuals.value) && !dismissed.value,
+);
+
+function dismiss() {
+	sessionStorage.setItem(dismissedKey, "1");
+	dismissed.value = true;
+}
+
+const message = computed(() => {
+	if (!hasPhoto.value && !hasQuals.value) return "Add your photo and first qualification.";
+	if (!hasPhoto.value) return "Add your profile photo.";
+	return "Add your first qualification.";
+});
+</script>
+
+<template>
+	<div
+		v-if="shouldShow"
+		class="flex items-center gap-3 rounded-xl bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 px-4 py-3"
+	>
+		<div class="text-2xl">📝</div>
+		<div class="flex-1 text-sm text-emerald-900 dark:text-emerald-100">
+			<strong>Complete your profile.</strong>
+			{{ message }}
+		</div>
+		<Link
+			:href="route('my-profile.show')"
+			class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white"
+		>Open My Profile →</Link>
+		<button
+			type="button"
+			class="text-emerald-700 dark:text-emerald-300 text-xs font-semibold hover:underline"
+			@click="dismiss"
+		>Dismiss</button>
+	</div>
+</template>

--- a/resources/js/Components/MyProfile/CompletionBanner.vue
+++ b/resources/js/Components/MyProfile/CompletionBanner.vue
@@ -17,7 +17,10 @@ onMounted(() => {
 });
 
 const shouldShow = computed(
-	() => hasPersonId.value && (!hasPhoto.value || !hasQuals.value) && !dismissed.value,
+	() =>
+		hasPersonId.value &&
+		(!hasPhoto.value || !hasQuals.value) &&
+		!dismissed.value,
 );
 
 function dismiss() {
@@ -26,7 +29,8 @@ function dismiss() {
 }
 
 const message = computed(() => {
-	if (!hasPhoto.value && !hasQuals.value) return "Add your photo and first qualification.";
+	if (!hasPhoto.value && !hasQuals.value)
+		return "Add your photo and first qualification.";
 	if (!hasPhoto.value) return "Add your profile photo.";
 	return "Add your first qualification.";
 });
@@ -45,11 +49,14 @@ const message = computed(() => {
 		<Link
 			:href="route('my-profile.show')"
 			class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white"
-		>Open My Profile →</Link>
+			>Open My Profile →</Link
+		>
 		<button
 			type="button"
 			class="text-emerald-700 dark:text-emerald-300 text-xs font-semibold hover:underline"
 			@click="dismiss"
-		>Dismiss</button>
+		>
+			Dismiss
+		</button>
 	</div>
 </template>

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -66,7 +66,9 @@ function onMutationSuccess() {
 				type="button"
 				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
 				@click="toggleAdd()"
-			>+ Add</button>
+			>
+				+ Add
+			</button>
 		</header>
 
 		<ul v-if="activeContacts.length > 0" class="space-y-2">
@@ -75,20 +77,28 @@ function onMutationSuccess() {
 				:key="c.id"
 				class="flex items-center gap-2 text-sm"
 			>
-				<span class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 whitespace-nowrap">
+				<span
+					class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 whitespace-nowrap"
+				>
 					{{ c.contact_type_dis }}
 				</span>
-				<span class="flex-1 truncate text-gray-900 dark:text-gray-100">{{ c.contact }}</span>
+				<span class="flex-1 truncate text-gray-900 dark:text-gray-100">{{
+					c.contact
+				}}</span>
 				<button
 					type="button"
 					class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
 					@click="startEdit(c)"
-				>Edit</button>
+				>
+					Edit
+				</button>
 				<button
 					type="button"
 					class="text-[11px] font-semibold text-red-600 dark:text-red-400 hover:underline"
 					@click="startDelete(c)"
-				>Delete</button>
+				>
+					Delete
+				</button>
 			</li>
 		</ul>
 		<p v-else class="text-sm text-gray-500 dark:text-gray-400 py-2">
@@ -98,7 +108,12 @@ function onMutationSuccess() {
 		<NewModal :show="openAdd" @close="toggleAdd()">
 			<AddContact
 				:person="personId"
-				@form-submitted="() => { toggleAdd(); onMutationSuccess(); }"
+				@form-submitted="
+					() => {
+						toggleAdd();
+						onMutationSuccess();
+					}
+				"
 			/>
 		</NewModal>
 
@@ -107,7 +122,12 @@ function onMutationSuccess() {
 				v-if="current"
 				:person="personId"
 				:contact="current"
-				@form-submitted="() => { toggleEdit(); onMutationSuccess(); }"
+				@form-submitted="
+					() => {
+						toggleEdit();
+						onMutationSuccess();
+					}
+				"
 			/>
 		</NewModal>
 
@@ -117,19 +137,25 @@ function onMutationSuccess() {
 					Delete contact?
 				</h2>
 				<p v-if="current" class="text-sm text-gray-600 dark:text-gray-300 mb-5">
-					Remove <strong>{{ current.contact }}</strong> ({{ current.contact_type_dis }}) from your profile. This cannot be undone.
+					Remove <strong>{{ current.contact }}</strong> ({{
+						current.contact_type_dis
+					}}) from your profile. This cannot be undone.
 				</p>
 				<div class="flex justify-end gap-2">
 					<button
 						type="button"
 						class="text-sm text-gray-600 dark:text-gray-400 hover:underline px-3 py-1.5"
 						@click="toggleDelete()"
-					>Cancel</button>
+					>
+						Cancel
+					</button>
 					<button
 						type="button"
 						class="text-sm font-semibold text-white bg-red-600 hover:bg-red-700 rounded-lg px-3 py-1.5"
 						@click="confirmDelete"
-					>Delete</button>
+					>
+						Delete
+					</button>
 				</div>
 			</div>
 		</NewModal>

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -7,6 +7,8 @@ import AddContact from "@/Pages/Person/partials/AddContact.vue";
 import EditContact from "@/Pages/Person/partials/EditContact.vue";
 
 const CONTACT_TYPE_PHONE = 2;
+const CONTACT_TYPE_EMAIL = 1;
+const PROTECTED_EMAIL_DOMAIN = "audit.gov.gh";
 
 const props = defineProps({
 	personId: { type: Number, required: true },
@@ -37,6 +39,18 @@ function isLastActivePhone(c) {
 		(x) => x.id !== c.id && x.contact_type === CONTACT_TYPE_PHONE && !x.valid_end,
 	);
 	return otherActivePhones.length === 0;
+}
+
+function isProtectedOrgEmail(c) {
+	if (c.contact_type !== CONTACT_TYPE_EMAIL) {
+		return false;
+	}
+	const email = String(c.contact ?? "").toLowerCase();
+	const at = email.lastIndexOf("@");
+	if (at === -1) {
+		return false;
+	}
+	return email.slice(at + 1) === PROTECTED_EMAIL_DOMAIN;
 }
 
 function startEdit(contact) {
@@ -107,10 +121,10 @@ function onMutationSuccess() {
 				>
 					Edit
 				</button>
-				<template v-if="isLastActivePhone(c)">
-					<span class="text-[11px] italic text-gray-500 dark:text-gray-400"
-						>Required</span
-					>
+				<template v-if="isLastActivePhone(c) || isProtectedOrgEmail(c)">
+					<span class="text-[11px] italic text-gray-500 dark:text-gray-400">{{
+						isProtectedOrgEmail(c) ? "Org email" : "Required"
+					}}</span>
 				</template>
 				<button
 					v-else

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -24,9 +24,16 @@ const toggleDelete = useToggle(openDelete);
 
 const current = ref(null);
 
-const activeContacts = computed(() =>
-	(props.contacts ?? []).filter((c) => !c.valid_end),
-);
+const activeContacts = computed(() => {
+	const active = (props.contacts ?? []).filter((c) => !c.valid_end);
+	// Pin protected org emails to the top. Stable sort preserves insertion
+	// order for every other contact.
+	return [...active].sort((a, b) => {
+		const ap = isProtectedOrgEmail(a) ? 0 : 1;
+		const bp = isProtectedOrgEmail(b) ? 0 : 1;
+		return ap - bp;
+	});
+});
 
 function isLastActivePhone(c) {
 	if (c.contact_type !== CONTACT_TYPE_PHONE) {
@@ -115,6 +122,7 @@ function onMutationSuccess() {
 					c.contact
 				}}</span>
 				<button
+					v-if="!isProtectedOrgEmail(c)"
 					type="button"
 					class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
 					@click="startEdit(c)"

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -3,58 +3,56 @@ import { ref, computed } from "vue";
 import { router } from "@inertiajs/vue3";
 import { useToggle } from "@vueuse/core";
 import NewModal from "@/Components/NewModal.vue";
-
-// ContactTypeEnum integer values (backed int enum in PHP)
-const CONTACT_TYPE_EMAIL = 1;
-const CONTACT_TYPE_PHONE = 2;
+import AddContact from "@/Pages/Person/partials/AddContact.vue";
+import EditContact from "@/Pages/Person/partials/EditContact.vue";
 
 const props = defineProps({
 	personId: { type: Number, required: true },
 	contacts: { type: Array, default: () => null },
 });
 
+const openAdd = ref(false);
 const openEdit = ref(false);
+const openDelete = ref(false);
+const toggleAdd = useToggle(openAdd);
 const toggleEdit = useToggle(openEdit);
+const toggleDelete = useToggle(openDelete);
+
+const current = ref(null);
 
 const activeContacts = computed(() =>
 	(props.contacts ?? []).filter((c) => !c.valid_end),
 );
 
-const primaryEmail = computed(
-	() =>
-		activeContacts.value.find((c) => c.contact_type === CONTACT_TYPE_EMAIL) ??
-		null,
-);
-const primaryPhone = computed(
-	() =>
-		activeContacts.value.find((c) => c.contact_type === CONTACT_TYPE_PHONE) ??
-		null,
-);
-
-// Local editable copies for the modal form
-const editableContacts = ref([]);
-
-function openEditModal() {
-	editableContacts.value = activeContacts.value.map((c) => ({ ...c }));
+function startEdit(contact) {
+	current.value = contact;
 	toggleEdit();
 }
 
-function saveContact(c) {
-	router.patch(
-		route("contact.update", { contact: c.id }),
-		{
-			contact_type: c.contact_type,
-			contact: c.contact,
-			valid_end: c.valid_end ?? null,
-		},
+function startDelete(contact) {
+	current.value = contact;
+	toggleDelete();
+}
+
+function confirmDelete() {
+	router.delete(
+		route("person.contact.delete", {
+			person: props.personId,
+			contact: current.value.id,
+		}),
 		{
 			preserveScroll: true,
 			onSuccess: () => {
-				toggleEdit();
+				current.value = null;
+				toggleDelete();
 				router.reload({ only: ["contacts"] });
 			},
 		},
 	);
+}
+
+function onMutationSuccess() {
+	router.reload({ only: ["contacts"] });
 }
 </script>
 
@@ -67,80 +65,71 @@ function saveContact(c) {
 			<button
 				type="button"
 				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
-				@click="openEditModal()"
-			>
-				Edit
-			</button>
+				@click="toggleAdd()"
+			>+ Add</button>
 		</header>
 
-		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
-			<div class="flex justify-between py-1.5">
-				<dt class="text-gray-500 dark:text-gray-400">Email</dt>
-				<dd
-					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
-				>
-					{{ primaryEmail?.contact ?? "—" }}
-				</dd>
-			</div>
-			<div class="flex justify-between py-1.5">
-				<dt class="text-gray-500 dark:text-gray-400">Phone</dt>
-				<dd
-					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
-				>
-					{{ primaryPhone?.contact ?? "—" }}
-				</dd>
-			</div>
-		</dl>
+		<ul v-if="activeContacts.length > 0" class="space-y-2">
+			<li
+				v-for="c in activeContacts"
+				:key="c.id"
+				class="flex items-center gap-2 text-sm"
+			>
+				<span class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 whitespace-nowrap">
+					{{ c.contact_type_dis }}
+				</span>
+				<span class="flex-1 truncate text-gray-900 dark:text-gray-100">{{ c.contact }}</span>
+				<button
+					type="button"
+					class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+					@click="startEdit(c)"
+				>Edit</button>
+				<button
+					type="button"
+					class="text-[11px] font-semibold text-red-600 dark:text-red-400 hover:underline"
+					@click="startDelete(c)"
+				>Delete</button>
+			</li>
+		</ul>
+		<p v-else class="text-sm text-gray-500 dark:text-gray-400 py-2">
+			No contacts on file. Click <strong>Add</strong> to add one.
+		</p>
+
+		<NewModal :show="openAdd" @close="toggleAdd()">
+			<AddContact
+				:person="personId"
+				@form-submitted="() => { toggleAdd(); onMutationSuccess(); }"
+			/>
+		</NewModal>
 
 		<NewModal :show="openEdit" @close="toggleEdit()">
-			<div class="bg-gray-100 dark:bg-gray-700 px-6 py-6">
-				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
-					Edit Contacts
+			<EditContact
+				v-if="current"
+				:person="personId"
+				:contact="current"
+				@form-submitted="() => { toggleEdit(); onMutationSuccess(); }"
+			/>
+		</NewModal>
+
+		<NewModal :show="openDelete" @close="toggleDelete()">
+			<div class="bg-gray-100 dark:bg-gray-700 px-8 py-8">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+					Delete contact?
 				</h2>
-
-				<div
-					v-if="editableContacts.length === 0"
-					class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center"
-				>
-					No contacts on record. Contact HR to add contact information.
-				</div>
-
-				<ul v-else class="space-y-4">
-					<li
-						v-for="c in editableContacts"
-						:key="c.id"
-						class="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
-					>
-						<p
-							class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-2"
-						>
-							{{ c.contact_type_dis }}
-						</p>
-						<div class="flex gap-2 items-center">
-							<input
-								v-model="c.contact"
-								type="text"
-								class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
-							/>
-							<button
-								type="button"
-								class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline whitespace-nowrap"
-								@click="saveContact(c)"
-							>
-								Save
-							</button>
-						</div>
-					</li>
-				</ul>
-
-				<div class="mt-4 flex justify-end">
+				<p v-if="current" class="text-sm text-gray-600 dark:text-gray-300 mb-5">
+					Remove <strong>{{ current.contact }}</strong> ({{ current.contact_type_dis }}) from your profile. This cannot be undone.
+				</p>
+				<div class="flex justify-end gap-2">
 					<button
 						type="button"
-						class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
-						@click="toggleEdit()"
-					>
-						Close
-					</button>
+						class="text-sm text-gray-600 dark:text-gray-400 hover:underline px-3 py-1.5"
+						@click="toggleDelete()"
+					>Cancel</button>
+					<button
+						type="button"
+						class="text-sm font-semibold text-white bg-red-600 hover:bg-red-700 rounded-lg px-3 py-1.5"
+						@click="confirmDelete"
+					>Delete</button>
 				</div>
 			</div>
 		</NewModal>

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -43,7 +43,8 @@ function isLastActivePhone(c) {
 		return false;
 	}
 	const otherActivePhones = activeContacts.value.filter(
-		(x) => x.id !== c.id && x.contact_type === CONTACT_TYPE_PHONE && !x.valid_end,
+		(x) =>
+			x.id !== c.id && x.contact_type === CONTACT_TYPE_PHONE && !x.valid_end,
 	);
 	return otherActivePhones.length === 0;
 }
@@ -175,7 +176,7 @@ function onMutationSuccess() {
 		</NewModal>
 
 		<NewModal :show="openDelete" @close="toggleDelete()">
-			<div class="bg-gray-100 dark:bg-gray-700 px-8 py-8">
+			<div class="bg-gray-100 dark:bg-gray-800 px-8 py-8">
 				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
 					Delete contact?
 				</h2>

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -1,0 +1,167 @@
+<script setup>
+import { ref, computed } from "vue";
+import { router } from "@inertiajs/vue3";
+import { useToggle } from "@vueuse/core";
+import NewModal from "@/Components/NewModal.vue";
+
+// ContactTypeEnum integer values (backed int enum in PHP)
+const CONTACT_TYPE_EMAIL = 1;
+const CONTACT_TYPE_PHONE = 2;
+
+const props = defineProps({
+	personId: { type: Number, required: true },
+	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
+});
+
+const openEdit = ref(false);
+const toggleEdit = useToggle(openEdit);
+
+const activeContacts = computed(() =>
+	(props.contacts ?? []).filter((c) => !c.valid_end),
+);
+
+const primaryEmail = computed(
+	() =>
+		activeContacts.value.find((c) => c.contact_type === CONTACT_TYPE_EMAIL) ??
+		null,
+);
+const primaryPhone = computed(
+	() =>
+		activeContacts.value.find((c) => c.contact_type === CONTACT_TYPE_PHONE) ??
+		null,
+);
+
+const addressDisplay = computed(() => {
+	if (!props.address) return "—";
+	const parts = [
+		props.address.address_line_1,
+		props.address.city,
+		props.address.region,
+	].filter(Boolean);
+	return parts.length ? parts.join(", ") : "—";
+});
+
+// Local editable copies for the modal form
+const editableContacts = ref([]);
+
+function openEditModal() {
+	editableContacts.value = activeContacts.value.map((c) => ({ ...c }));
+	toggleEdit();
+}
+
+function saveContact(c) {
+	router.patch(
+		route("contact.update", { contact: c.id }),
+		{
+			contact_type: c.contact_type,
+			contact: c.contact,
+			valid_end: c.valid_end ?? null,
+		},
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				toggleEdit();
+				router.reload({ only: ["contacts"] });
+			},
+		},
+	);
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Contact</h3>
+			<button
+				type="button"
+				class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline"
+				@click="openEditModal()"
+			>
+				Edit
+			</button>
+		</header>
+
+		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Email</dt>
+				<dd
+					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+				>
+					{{ primaryEmail?.contact ?? "—" }}
+				</dd>
+			</div>
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Phone</dt>
+				<dd
+					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+				>
+					{{ primaryPhone?.contact ?? "—" }}
+				</dd>
+			</div>
+			<div class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">Address</dt>
+				<dd
+					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+				>
+					{{ addressDisplay }}
+				</dd>
+			</div>
+		</dl>
+
+		<NewModal :show="openEdit" @close="toggleEdit()">
+			<div class="bg-gray-100 dark:bg-gray-700 px-6 py-6">
+				<h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+					Edit Contacts
+				</h2>
+
+				<div
+					v-if="editableContacts.length === 0"
+					class="text-sm text-gray-500 dark:text-gray-400 py-4 text-center"
+				>
+					No contacts on record. Contact HR to add contact information.
+				</div>
+
+				<ul v-else class="space-y-4">
+					<li
+						v-for="c in editableContacts"
+						:key="c.id"
+						class="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-600"
+					>
+						<p
+							class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase mb-2"
+						>
+							{{ c.contact_type_dis }}
+						</p>
+						<div class="flex gap-2 items-center">
+							<input
+								v-model="c.contact"
+								type="text"
+								class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+							/>
+							<button
+								type="button"
+								class="text-[11px] font-semibold text-emerald-700 dark:text-emerald-300 hover:underline whitespace-nowrap"
+								@click="saveContact(c)"
+							>
+								Save
+							</button>
+						</div>
+					</li>
+				</ul>
+
+				<div class="mt-4 flex justify-end">
+					<button
+						type="button"
+						class="text-sm text-gray-600 dark:text-gray-400 hover:underline"
+						@click="toggleEdit()"
+					>
+						Close
+					</button>
+				</div>
+			</div>
+		</NewModal>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -6,6 +6,8 @@ import NewModal from "@/Components/NewModal.vue";
 import AddContact from "@/Pages/Person/partials/AddContact.vue";
 import EditContact from "@/Pages/Person/partials/EditContact.vue";
 
+const CONTACT_TYPE_PHONE = 2;
+
 const props = defineProps({
 	personId: { type: Number, required: true },
 	contacts: { type: Array, default: () => null },
@@ -23,6 +25,19 @@ const current = ref(null);
 const activeContacts = computed(() =>
 	(props.contacts ?? []).filter((c) => !c.valid_end),
 );
+
+function isLastActivePhone(c) {
+	if (c.contact_type !== CONTACT_TYPE_PHONE) {
+		return false;
+	}
+	if (c.valid_end) {
+		return false;
+	}
+	const otherActivePhones = activeContacts.value.filter(
+		(x) => x.id !== c.id && x.contact_type === CONTACT_TYPE_PHONE && !x.valid_end,
+	);
+	return otherActivePhones.length === 0;
+}
 
 function startEdit(contact) {
 	current.value = contact;
@@ -92,7 +107,13 @@ function onMutationSuccess() {
 				>
 					Edit
 				</button>
+				<template v-if="isLastActivePhone(c)">
+					<span class="text-[11px] italic text-gray-500 dark:text-gray-400"
+						>Required</span
+					>
+				</template>
 				<button
+					v-else
 					type="button"
 					class="text-[11px] font-semibold text-red-600 dark:text-red-400 hover:underline"
 					@click="startDelete(c)"

--- a/resources/js/Components/MyProfile/ContactCard.vue
+++ b/resources/js/Components/MyProfile/ContactCard.vue
@@ -11,7 +11,6 @@ const CONTACT_TYPE_PHONE = 2;
 const props = defineProps({
 	personId: { type: Number, required: true },
 	contacts: { type: Array, default: () => null },
-	address: { type: Object, default: () => null },
 });
 
 const openEdit = ref(false);
@@ -31,16 +30,6 @@ const primaryPhone = computed(
 		activeContacts.value.find((c) => c.contact_type === CONTACT_TYPE_PHONE) ??
 		null,
 );
-
-const addressDisplay = computed(() => {
-	if (!props.address) return "—";
-	const parts = [
-		props.address.address_line_1,
-		props.address.city,
-		props.address.region,
-	].filter(Boolean);
-	return parts.length ? parts.join(", ") : "—";
-});
 
 // Local editable copies for the modal form
 const editableContacts = ref([]);
@@ -99,14 +88,6 @@ function saveContact(c) {
 					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
 				>
 					{{ primaryPhone?.contact ?? "—" }}
-				</dd>
-			</div>
-			<div class="flex justify-between py-1.5">
-				<dt class="text-gray-500 dark:text-gray-400">Address</dt>
-				<dd
-					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
-				>
-					{{ addressDisplay }}
 				</dd>
 			</div>
 		</dl>

--- a/resources/js/Components/MyProfile/DependentsCard.vue
+++ b/resources/js/Components/MyProfile/DependentsCard.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	dependents: { type: Array, default: () => null },
+});
+
+const rows = computed(() => props.dependents ?? []);
+const hasDependents = computed(() => rows.value.length > 0);
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Dependents</h3>
+			<span class="text-[11px] text-gray-400 dark:text-gray-500">View only</span>
+		</header>
+
+		<div v-if="hasDependents" class="overflow-x-auto">
+			<table class="w-full text-sm">
+				<thead>
+					<tr class="text-left text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+						<th class="py-2 pr-3">Name</th>
+						<th class="py-2 pr-3">Relation</th>
+						<th class="py-2 pr-3">Gender</th>
+						<th class="py-2">Age</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-gray-100 dark:divide-gray-700">
+					<tr
+						v-for="d in rows"
+						:key="d.id"
+						class="text-gray-900 dark:text-gray-100"
+					>
+						<td class="py-2 pr-3 font-medium truncate">{{ d.name }}</td>
+						<td class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.relation ?? "—" }}</td>
+						<td class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.gender ?? "—" }}</td>
+						<td class="py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.age ?? "—" }}</td>
+					</tr>
+				</tbody>
+			</table>
+			<p class="mt-3 text-[11px] italic text-gray-500 dark:text-gray-400">
+				Need changes? Contact HR.
+			</p>
+		</div>
+
+		<div v-else class="py-3">
+			<p class="text-sm text-gray-500 dark:text-gray-400">
+				Contact HR to add dependants.
+			</p>
+		</div>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/DependentsCard.vue
+++ b/resources/js/Components/MyProfile/DependentsCard.vue
@@ -14,14 +14,20 @@ const hasDependents = computed(() => rows.value.length > 0);
 		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
 	>
 		<header class="flex justify-between items-center mb-3">
-			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Dependents</h3>
-			<span class="text-[11px] text-gray-400 dark:text-gray-500">View only</span>
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">
+				Dependents
+			</h3>
+			<span class="text-[11px] text-gray-400 dark:text-gray-500"
+				>View only</span
+			>
 		</header>
 
 		<div v-if="hasDependents" class="overflow-x-auto">
 			<table class="w-full text-sm">
 				<thead>
-					<tr class="text-left text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+					<tr
+						class="text-left text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700"
+					>
 						<th class="py-2 pr-3">Name</th>
 						<th class="py-2 pr-3">Relation</th>
 						<th class="py-2 pr-3">Gender</th>
@@ -35,9 +41,19 @@ const hasDependents = computed(() => rows.value.length > 0);
 						class="text-gray-900 dark:text-gray-100"
 					>
 						<td class="py-2 pr-3 font-medium truncate">{{ d.name }}</td>
-						<td class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.relation ?? "—" }}</td>
-						<td class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.gender ?? "—" }}</td>
-						<td class="py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">{{ d.age ?? "—" }}</td>
+						<td
+							class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap"
+						>
+							{{ d.relation ?? "—" }}
+						</td>
+						<td
+							class="py-2 pr-3 text-gray-600 dark:text-gray-400 whitespace-nowrap"
+						>
+							{{ d.gender ?? "—" }}
+						</td>
+						<td class="py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+							{{ d.age ?? "—" }}
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/resources/js/Components/MyProfile/IdentityStrip.vue
+++ b/resources/js/Components/MyProfile/IdentityStrip.vue
@@ -13,7 +13,8 @@ const currentRank = computed(
 	() => props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0],
 );
 const currentDepartment = computed(() => {
-	const unit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	const unit =
+		props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
 	return unit?.department ?? unit?.unit_name ?? null;
 });
 </script>
@@ -46,7 +47,9 @@ const currentDepartment = computed(() => {
 				<span v-if="currentRank">{{ currentRank.name }}</span>
 				<span v-if="currentRank && currentDepartment"> · </span>
 				<span v-if="currentDepartment">{{ currentDepartment }}</span>
-				<span v-if="staff.staff_number"> · Staff #{{ staff.staff_number }}</span>
+				<span v-if="staff.staff_number">
+					· Staff #{{ staff.staff_number }}</span
+				>
 			</p>
 		</div>
 		<div class="flex items-center justify-center sm:justify-end">

--- a/resources/js/Components/MyProfile/IdentityStrip.vue
+++ b/resources/js/Components/MyProfile/IdentityStrip.vue
@@ -1,0 +1,60 @@
+<script setup>
+import ProfileProgress from "@/Components/MyProfile/ProfileProgress.vue";
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	staff: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+});
+
+const currentRank = computed(
+	() => props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0],
+);
+const currentDepartment = computed(() => {
+	const unit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	return unit?.department ?? unit?.unit_name ?? null;
+});
+</script>
+
+<template>
+	<div
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm flex flex-col sm:flex-row items-center sm:items-stretch gap-4 sm:gap-5"
+	>
+		<div class="flex-shrink-0">
+			<img
+				v-if="person.image"
+				:src="person.image"
+				alt=""
+				class="w-[72px] h-[72px] rounded-full object-cover border-2 border-white dark:border-gray-700 shadow"
+			/>
+			<div
+				v-else
+				class="w-[72px] h-[72px] rounded-full bg-gradient-to-br from-gray-400 to-gray-600 dark:from-gray-500 dark:to-gray-700 flex items-center justify-center text-white font-bold text-2xl"
+			>
+				{{ person.initials }}
+			</div>
+		</div>
+		<div class="flex-1 min-w-0 text-center sm:text-left">
+			<h1
+				class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+			>
+				{{ person.name }}
+			</h1>
+			<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+				<span v-if="currentRank">{{ currentRank.name }}</span>
+				<span v-if="currentRank && currentDepartment"> · </span>
+				<span v-if="currentDepartment">{{ currentDepartment }}</span>
+				<span v-if="staff.staff_number"> · Staff #{{ staff.staff_number }}</span>
+			</p>
+		</div>
+		<div class="flex items-center justify-center sm:justify-end">
+			<ProfileProgress
+				:person="person"
+				:qualifications="qualifications"
+				:contacts="contacts"
+			/>
+		</div>
+	</div>
+</template>

--- a/resources/js/Components/MyProfile/IdentityStrip.vue
+++ b/resources/js/Components/MyProfile/IdentityStrip.vue
@@ -7,6 +7,7 @@ const props = defineProps({
 	staff: { type: Object, required: true },
 	qualifications: { type: Array, default: () => [] },
 	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
 });
 
 const currentRank = computed(
@@ -57,6 +58,7 @@ const currentDepartment = computed(() => {
 				:person="person"
 				:qualifications="qualifications"
 				:contacts="contacts"
+				:address="address"
 			/>
 		</div>
 	</div>

--- a/resources/js/Components/MyProfile/PersonalDetailsCard.vue
+++ b/resources/js/Components/MyProfile/PersonalDetailsCard.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+});
+
+const rows = computed(() => {
+	const r = [];
+	const dobWithAge = props.person.dob
+		? `${props.person.dob}${props.person.age ? ` (${props.person.age})` : ""}`
+		: null;
+	if (dobWithAge) r.push({ key: "Date of birth", value: dobWithAge });
+	if (props.person.gender) r.push({ key: "Gender", value: props.person.gender });
+	if (props.person.nationality) r.push({ key: "Nationality", value: props.person.nationality });
+	if (props.person.religion) r.push({ key: "Religion", value: props.person.religion });
+	if (props.person.marital_status) r.push({ key: "Marital status", value: props.person.marital_status });
+	return r;
+});
+
+const identities = computed(() => props.person.identities ?? []);
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Personal details</h3>
+			<span class="text-[11px] text-gray-400 dark:text-gray-500">HR-managed</span>
+		</header>
+
+		<dl v-if="rows.length > 0" class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+			<div v-for="row in rows" :key="row.key" class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">
+					{{ row.value }}
+				</dd>
+			</div>
+		</dl>
+		<p v-else class="text-xs text-gray-500 dark:text-gray-400 py-1.5">No personal details on file.</p>
+
+		<div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
+			<h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+				Identity documents
+			</h4>
+			<ul v-if="identities.length > 0" class="space-y-1.5">
+				<li
+					v-for="idRow in identities"
+					:key="idRow.id"
+					class="flex items-center gap-2 text-sm"
+				>
+					<span
+						class="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 whitespace-nowrap"
+					>
+						{{ idRow.id_type_display }}
+					</span>
+					<span class="font-mono text-gray-900 dark:text-gray-100 truncate">{{ idRow.id_number }}</span>
+				</li>
+			</ul>
+			<p v-else class="text-xs italic text-gray-500 dark:text-gray-400">
+				No identity document on file
+			</p>
+		</div>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/PersonalDetailsCard.vue
+++ b/resources/js/Components/MyProfile/PersonalDetailsCard.vue
@@ -11,10 +11,14 @@ const rows = computed(() => {
 		? `${props.person.dob}${props.person.age ? ` (${props.person.age})` : ""}`
 		: null;
 	if (dobWithAge) r.push({ key: "Date of birth", value: dobWithAge });
-	if (props.person.gender) r.push({ key: "Gender", value: props.person.gender });
-	if (props.person.nationality) r.push({ key: "Nationality", value: props.person.nationality });
-	if (props.person.religion) r.push({ key: "Religion", value: props.person.religion });
-	if (props.person.marital_status) r.push({ key: "Marital status", value: props.person.marital_status });
+	if (props.person.gender)
+		r.push({ key: "Gender", value: props.person.gender });
+	if (props.person.nationality)
+		r.push({ key: "Nationality", value: props.person.nationality });
+	if (props.person.religion)
+		r.push({ key: "Religion", value: props.person.religion });
+	if (props.person.marital_status)
+		r.push({ key: "Marital status", value: props.person.marital_status });
 	return r;
 });
 
@@ -26,22 +30,39 @@ const identities = computed(() => props.person.identities ?? []);
 		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
 	>
 		<header class="flex justify-between items-center mb-3">
-			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">Personal details</h3>
-			<span class="text-[11px] text-gray-400 dark:text-gray-500">HR-managed</span>
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">
+				Personal details
+			</h3>
+			<span class="text-[11px] text-gray-400 dark:text-gray-500"
+				>HR-managed</span
+			>
 		</header>
 
-		<dl v-if="rows.length > 0" class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
-			<div v-for="row in rows" :key="row.key" class="flex justify-between py-1.5">
+		<dl
+			v-if="rows.length > 0"
+			class="divide-y divide-gray-100 dark:divide-gray-700 text-sm"
+		>
+			<div
+				v-for="row in rows"
+				:key="row.key"
+				class="flex justify-between py-1.5"
+			>
 				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
-				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">
+				<dd
+					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+				>
 					{{ row.value }}
 				</dd>
 			</div>
 		</dl>
-		<p v-else class="text-xs text-gray-500 dark:text-gray-400 py-1.5">No personal details on file.</p>
+		<p v-else class="text-xs text-gray-500 dark:text-gray-400 py-1.5">
+			No personal details on file.
+		</p>
 
 		<div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
-			<h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+			<h4
+				class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2"
+			>
 				Identity documents
 			</h4>
 			<ul v-if="identities.length > 0" class="space-y-1.5">
@@ -55,7 +76,9 @@ const identities = computed(() => props.person.identities ?? []);
 					>
 						{{ idRow.id_type_display }}
 					</span>
-					<span class="font-mono text-gray-900 dark:text-gray-100 truncate">{{ idRow.id_number }}</span>
+					<span class="font-mono text-gray-900 dark:text-gray-100 truncate">{{
+						idRow.id_number
+					}}</span>
 				</li>
 			</ul>
 			<p v-else class="text-xs italic text-gray-500 dark:text-gray-400">

--- a/resources/js/Components/MyProfile/PhotoCard.vue
+++ b/resources/js/Components/MyProfile/PhotoCard.vue
@@ -17,6 +17,8 @@ const showDeleteModal = ref(false);
 const accepted = ["image/jpeg", "image/png"];
 const maxBytes = 2 * 1024 * 1024;
 
+const hasPending = computed(() => Boolean(props.person.pending_image));
+
 const statusLabel = computed(() => (props.person.image ? "✓ Set" : "Not set"));
 const statusClass = computed(() =>
 	props.person.image
@@ -111,11 +113,24 @@ function remove() {
 					}}
 				</p>
 			</div>
-			<span
-				class="text-[11px] font-semibold px-2.5 py-1 rounded-full"
-				:class="statusClass"
-				>{{ statusLabel }}</span
-			>
+			<div class="flex items-center gap-2">
+				<span
+					v-if="hasPending"
+					class="flex items-center gap-1.5 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+				>
+					<img
+						:src="person.pending_image"
+						alt="Pending photo"
+						class="w-5 h-5 rounded-full object-cover"
+					/>
+					Pending review
+				</span>
+				<span
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+					:class="statusClass"
+					>{{ statusLabel }}</span
+				>
+			</div>
 		</header>
 
 		<!-- FILLED -->

--- a/resources/js/Components/MyProfile/PhotoCard.vue
+++ b/resources/js/Components/MyProfile/PhotoCard.vue
@@ -59,19 +59,24 @@ function submit(file) {
 	formData.append("image", file);
 
 	isUploading.value = true;
-	router.post(route("person.avatar.update", { person: props.person.id }), formData, {
-		forceFormData: true,
-		preserveScroll: true,
-		onSuccess: () => {
-			router.reload({ only: ["person"] });
+	router.post(
+		route("person.avatar.update", { person: props.person.id }),
+		formData,
+		{
+			forceFormData: true,
+			preserveScroll: true,
+			onSuccess: () => {
+				router.reload({ only: ["person"] });
+			},
+			onError: (errors) => {
+				errorMessage.value =
+					errors.image ?? "Upload failed — please try again.";
+			},
+			onFinish: () => {
+				isUploading.value = false;
+			},
 		},
-		onError: (errors) => {
-			errorMessage.value = errors.image ?? "Upload failed — please try again.";
-		},
-		onFinish: () => {
-			isUploading.value = false;
-		},
-	});
+	);
 }
 
 function confirmRemove() {
@@ -95,7 +100,9 @@ function remove() {
 	>
 		<header class="flex justify-between items-start mb-4">
 			<div>
-				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">Your photo</h2>
+				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">
+					Your photo
+				</h2>
 				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
 					{{
 						person.image
@@ -107,7 +114,8 @@ function remove() {
 			<span
 				class="text-[11px] font-semibold px-2.5 py-1 rounded-full"
 				:class="statusClass"
-			>{{ statusLabel }}</span>
+				>{{ statusLabel }}</span
+			>
 		</header>
 
 		<!-- FILLED -->
@@ -123,14 +131,23 @@ function remove() {
 						type="button"
 						class="inline-flex items-center rounded-lg bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border border-emerald-200 dark:border-emerald-700 px-3 py-1.5 text-xs font-semibold hover:bg-emerald-100"
 						@click="openPicker"
-					>Change photo</button>
+					>
+						Change photo
+					</button>
 					<button
 						type="button"
 						class="inline-flex items-center rounded-lg bg-white dark:bg-gray-900 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-700 px-3 py-1.5 text-xs font-semibold hover:bg-red-50 dark:hover:bg-red-900/30"
 						@click="confirmRemove"
-					>Remove</button>
+					>
+						Remove
+					</button>
 				</div>
-				<p v-if="errorMessage" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+				<p
+					v-if="errorMessage"
+					class="mt-2 text-xs text-red-600 dark:text-red-400"
+				>
+					{{ errorMessage }}
+				</p>
 			</div>
 		</div>
 
@@ -150,7 +167,9 @@ function remove() {
 				@click="openPicker"
 			>
 				<div class="text-4xl">📷</div>
-				<p class="mt-2 text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+				<p
+					class="mt-2 text-sm font-semibold text-emerald-900 dark:text-emerald-100"
+				>
 					{{ isUploading ? "Uploading..." : "Drop your photo here" }}
 				</p>
 				<p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
@@ -161,9 +180,16 @@ function remove() {
 					type="button"
 					class="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700"
 					@click.stop="openPicker"
-				>Choose a file</button>
+				>
+					Choose a file
+				</button>
 			</div>
-			<p v-if="errorMessage" class="mt-3 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+			<p
+				v-if="errorMessage"
+				class="mt-3 text-xs text-red-600 dark:text-red-400"
+			>
+				{{ errorMessage }}
+			</p>
 		</div>
 
 		<input

--- a/resources/js/Components/MyProfile/PhotoCard.vue
+++ b/resources/js/Components/MyProfile/PhotoCard.vue
@@ -1,0 +1,184 @@
+<script setup>
+import { ref, computed } from "vue";
+import { router } from "@inertiajs/vue3";
+import NewModal from "@/Components/NewModal.vue";
+import DeleteAvatar from "@/Pages/Staff/DeleteAvatar.vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+});
+
+const isUploading = ref(false);
+const errorMessage = ref("");
+const isDragging = ref(false);
+const fileInput = ref(null);
+const showDeleteModal = ref(false);
+
+const accepted = ["image/jpeg", "image/png"];
+const maxBytes = 2 * 1024 * 1024;
+
+const statusLabel = computed(() => (props.person.image ? "✓ Set" : "Not set"));
+const statusClass = computed(() =>
+	props.person.image
+		? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+		: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+);
+
+function openPicker() {
+	fileInput.value?.click();
+}
+
+function onFileChange(event) {
+	const file = event.target.files?.[0];
+	if (file) {
+		submit(file);
+	}
+}
+
+function onDrop(event) {
+	event.preventDefault();
+	isDragging.value = false;
+	const file = event.dataTransfer.files?.[0];
+	if (file) {
+		submit(file);
+	}
+}
+
+function submit(file) {
+	errorMessage.value = "";
+	if (!accepted.includes(file.type)) {
+		errorMessage.value = "Please choose a JPG or PNG image.";
+		return;
+	}
+	if (file.size > maxBytes) {
+		errorMessage.value = "Image must be 2 MB or smaller.";
+		return;
+	}
+
+	const formData = new FormData();
+	formData.append("image", file);
+
+	isUploading.value = true;
+	router.post(route("person.avatar.update", { person: props.person.id }), formData, {
+		forceFormData: true,
+		preserveScroll: true,
+		onSuccess: () => {
+			router.reload({ only: ["person"] });
+		},
+		onError: (errors) => {
+			errorMessage.value = errors.image ?? "Upload failed — please try again.";
+		},
+		onFinish: () => {
+			isUploading.value = false;
+		},
+	});
+}
+
+function confirmRemove() {
+	showDeleteModal.value = true;
+}
+
+function remove() {
+	router.delete(route("person.avatar.delete", { person: props.person.id }), {
+		preserveScroll: true,
+		onSuccess: () => {
+			showDeleteModal.value = false;
+			router.reload({ only: ["person"] });
+		},
+	});
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
+	>
+		<header class="flex justify-between items-start mb-4">
+			<div>
+				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">Your photo</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					{{
+						person.image
+							? "Visible across the HR system."
+							: "Help colleagues recognise you. Used across the system."
+					}}
+				</p>
+			</div>
+			<span
+				class="text-[11px] font-semibold px-2.5 py-1 rounded-full"
+				:class="statusClass"
+			>{{ statusLabel }}</span>
+		</header>
+
+		<!-- FILLED -->
+		<div v-if="person.image && !isUploading" class="flex gap-4 items-center">
+			<img
+				:src="person.image"
+				alt="Profile photo"
+				class="w-[120px] h-[120px] rounded-xl object-cover border-[3px] border-white dark:border-gray-700 shadow"
+			/>
+			<div class="flex-1">
+				<div class="flex flex-wrap gap-2">
+					<button
+						type="button"
+						class="inline-flex items-center rounded-lg bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 border border-emerald-200 dark:border-emerald-700 px-3 py-1.5 text-xs font-semibold hover:bg-emerald-100"
+						@click="openPicker"
+					>Change photo</button>
+					<button
+						type="button"
+						class="inline-flex items-center rounded-lg bg-white dark:bg-gray-900 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-700 px-3 py-1.5 text-xs font-semibold hover:bg-red-50 dark:hover:bg-red-900/30"
+						@click="confirmRemove"
+					>Remove</button>
+				</div>
+				<p v-if="errorMessage" class="mt-2 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+			</div>
+		</div>
+
+		<!-- EMPTY / ERROR / UPLOADING -->
+		<div v-else>
+			<div
+				:class="[
+					'rounded-xl border-2 border-dashed px-6 py-9 text-center transition-colors cursor-pointer',
+					isDragging
+						? 'border-emerald-600 bg-emerald-50 dark:bg-emerald-900/30'
+						: 'border-emerald-500 bg-emerald-50/60 hover:bg-emerald-50 dark:bg-emerald-900/20 dark:hover:bg-emerald-900/30',
+					isUploading ? 'opacity-60 pointer-events-none' : '',
+				]"
+				@dragover.prevent="isDragging = true"
+				@dragleave.prevent="isDragging = false"
+				@drop="onDrop"
+				@click="openPicker"
+			>
+				<div class="text-4xl">📷</div>
+				<p class="mt-2 text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+					{{ isUploading ? "Uploading..." : "Drop your photo here" }}
+				</p>
+				<p class="text-xs text-gray-600 dark:text-gray-400 mt-1">
+					JPG or PNG, up to 2 MB · square crop works best
+				</p>
+				<p class="text-[11px] text-gray-500 mt-3 mb-2">or</p>
+				<button
+					type="button"
+					class="inline-flex items-center rounded-lg bg-emerald-600 px-4 py-2 text-xs font-semibold text-white shadow-sm hover:bg-emerald-700"
+					@click.stop="openPicker"
+				>Choose a file</button>
+			</div>
+			<p v-if="errorMessage" class="mt-3 text-xs text-red-600 dark:text-red-400">{{ errorMessage }}</p>
+		</div>
+
+		<input
+			ref="fileInput"
+			type="file"
+			class="hidden"
+			accept="image/jpeg,image/png"
+			@change="onFileChange"
+		/>
+
+		<NewModal :show="showDeleteModal" @close="showDeleteModal = false">
+			<DeleteAvatar
+				@deleteConfirmed="remove"
+				@close="showDeleteModal = false"
+			/>
+		</NewModal>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/PhotoCard.vue
+++ b/resources/js/Components/MyProfile/PhotoCard.vue
@@ -176,7 +176,7 @@ function remove() {
 
 		<NewModal :show="showDeleteModal" @close="showDeleteModal = false">
 			<DeleteAvatar
-				@deleteConfirmed="remove"
+				@delete-confirmed="remove"
 				@close="showDeleteModal = false"
 			/>
 		</NewModal>

--- a/resources/js/Components/MyProfile/ProfileProgress.vue
+++ b/resources/js/Components/MyProfile/ProfileProgress.vue
@@ -20,8 +20,8 @@ const checkpoints = computed(() => {
 	return [hasPhoto, hasQualification, hasContacts];
 });
 
-const percent = computed(
-	() => Math.round((checkpoints.value.filter(Boolean).length / 3) * 100),
+const percent = computed(() =>
+	Math.round((checkpoints.value.filter(Boolean).length / 3) * 100),
 );
 const isComplete = computed(() => percent.value === 100);
 </script>
@@ -38,7 +38,9 @@ const isComplete = computed(() => percent.value === 100);
 		<div
 			:class="[
 				'w-20 h-1.5 rounded-full overflow-hidden',
-				isComplete ? 'bg-emerald-200 dark:bg-emerald-800' : 'bg-amber-200 dark:bg-amber-800',
+				isComplete
+					? 'bg-emerald-200 dark:bg-emerald-800'
+					: 'bg-amber-200 dark:bg-amber-800',
 			]"
 		>
 			<div

--- a/resources/js/Components/MyProfile/ProfileProgress.vue
+++ b/resources/js/Components/MyProfile/ProfileProgress.vue
@@ -1,27 +1,31 @@
 <script setup>
 import { computed } from "vue";
 
+// ContactTypeEnum: Phone = 2 (backed int enum serialized as integer).
+const CONTACT_TYPE_PHONE = 2;
+
 const props = defineProps({
 	person: { type: Object, required: true },
 	qualifications: { type: Array, default: () => [] },
 	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
 });
-
-// ContactTypeEnum: Email = 1, Phone = 2 (backed int enum serialized as integer).
-const CONTACT_TYPE_EMAIL = 1;
-const CONTACT_TYPE_PHONE = 2;
 
 const checkpoints = computed(() => {
 	const hasPhoto = Boolean(props.person?.image);
 	const hasQualification = props.qualifications.length > 0;
-	const active = (props.contacts ?? []).filter((c) => !c.valid_end);
-	const hasEmail = active.some((c) => c.contact_type === CONTACT_TYPE_EMAIL);
-	const hasPhone = active.some((c) => c.contact_type === CONTACT_TYPE_PHONE);
-	return [hasPhoto, hasQualification, hasEmail && hasPhone];
+	const hasPhone = (props.contacts ?? []).some(
+		(c) => c.contact_type === CONTACT_TYPE_PHONE && !c.valid_end,
+	);
+	const a = props.address;
+	const hasValidAddress = Boolean(
+		a && a.address_line_1 && a.city && a.country,
+	);
+	return [hasPhoto, hasQualification, hasPhone, hasValidAddress];
 });
 
 const percent = computed(() =>
-	Math.round((checkpoints.value.filter(Boolean).length / 3) * 100),
+	Math.round((checkpoints.value.filter(Boolean).length / 4) * 100),
 );
 const isComplete = computed(() => percent.value === 100);
 </script>

--- a/resources/js/Components/MyProfile/ProfileProgress.vue
+++ b/resources/js/Components/MyProfile/ProfileProgress.vue
@@ -7,17 +7,17 @@ const props = defineProps({
 	contacts: { type: Array, default: () => null },
 });
 
+// ContactTypeEnum: Email = 1, Phone = 2 (backed int enum serialized as integer).
+const CONTACT_TYPE_EMAIL = 1;
+const CONTACT_TYPE_PHONE = 2;
+
 const checkpoints = computed(() => {
 	const hasPhoto = Boolean(props.person?.image);
 	const hasQualification = props.qualifications.length > 0;
-	const emails = (props.contacts ?? []).filter(
-		(c) => String(c.contact_type).toLowerCase() === "email" && !c.valid_end,
-	);
-	const phones = (props.contacts ?? []).filter(
-		(c) => String(c.contact_type).toLowerCase() === "phone" && !c.valid_end,
-	);
-	const hasContacts = emails.length > 0 && phones.length > 0;
-	return [hasPhoto, hasQualification, hasContacts];
+	const active = (props.contacts ?? []).filter((c) => !c.valid_end);
+	const hasEmail = active.some((c) => c.contact_type === CONTACT_TYPE_EMAIL);
+	const hasPhone = active.some((c) => c.contact_type === CONTACT_TYPE_PHONE);
+	return [hasPhoto, hasQualification, hasEmail && hasPhone];
 });
 
 const percent = computed(() =>

--- a/resources/js/Components/MyProfile/ProfileProgress.vue
+++ b/resources/js/Components/MyProfile/ProfileProgress.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+});
+
+const checkpoints = computed(() => {
+	const hasPhoto = Boolean(props.person?.image);
+	const hasQualification = props.qualifications.length > 0;
+	const emails = (props.contacts ?? []).filter(
+		(c) => String(c.contact_type).toLowerCase() === "email" && !c.valid_end,
+	);
+	const phones = (props.contacts ?? []).filter(
+		(c) => String(c.contact_type).toLowerCase() === "phone" && !c.valid_end,
+	);
+	const hasContacts = emails.length > 0 && phones.length > 0;
+	return [hasPhoto, hasQualification, hasContacts];
+});
+
+const percent = computed(
+	() => Math.round((checkpoints.value.filter(Boolean).length / 3) * 100),
+);
+const isComplete = computed(() => percent.value === 100);
+</script>
+
+<template>
+	<div
+		:class="[
+			'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold',
+			isComplete
+				? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+				: 'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+		]"
+	>
+		<div
+			:class="[
+				'w-20 h-1.5 rounded-full overflow-hidden',
+				isComplete ? 'bg-emerald-200 dark:bg-emerald-800' : 'bg-amber-200 dark:bg-amber-800',
+			]"
+		>
+			<div
+				:class="[
+					'h-full transition-all',
+					isComplete ? 'bg-emerald-600' : 'bg-amber-500',
+				]"
+				:style="{ width: `${percent}%` }"
+			></div>
+		</div>
+		<span v-if="isComplete">✓ Profile complete</span>
+		<span v-else>{{ percent }}% complete</span>
+	</div>
+</template>

--- a/resources/js/Components/MyProfile/ProfileProgress.vue
+++ b/resources/js/Components/MyProfile/ProfileProgress.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 // ContactTypeEnum: Phone = 2 (backed int enum serialized as integer).
 const CONTACT_TYPE_PHONE = 2;
@@ -18,44 +18,175 @@ const checkpoints = computed(() => {
 		(c) => c.contact_type === CONTACT_TYPE_PHONE && !c.valid_end,
 	);
 	const a = props.address;
-	const hasValidAddress = Boolean(
-		a && a.address_line_1 && a.city && a.country,
-	);
-	return [hasPhoto, hasQualification, hasPhone, hasValidAddress];
+	const hasValidAddress = Boolean(a && a.address_line_1 && a.city && a.country);
+	return [
+		{
+			label: "Profile photo",
+			hint: "Upload a clear headshot (JPG or PNG, up to 2 MB).",
+			done: hasPhoto,
+		},
+		{
+			label: "Qualification",
+			hint: "Add at least one degree, diploma, or certificate.",
+			done: hasQualification,
+		},
+		{
+			label: "Phone number",
+			hint: "Add at least one active phone contact.",
+			done: hasPhone,
+		},
+		{
+			label: "Address",
+			hint: "Fill in address line 1, city, and country.",
+			done: hasValidAddress,
+		},
+	];
 });
 
+const doneCount = computed(
+	() => checkpoints.value.filter((c) => c.done).length,
+);
 const percent = computed(() =>
-	Math.round((checkpoints.value.filter(Boolean).length / 4) * 100),
+	Math.round((doneCount.value / checkpoints.value.length) * 100),
 );
 const isComplete = computed(() => percent.value === 100);
+
+const isOpen = ref(false);
+let closeTimer = null;
+
+function show() {
+	if (closeTimer) {
+		clearTimeout(closeTimer);
+		closeTimer = null;
+	}
+	isOpen.value = true;
+}
+
+function scheduleHide() {
+	if (closeTimer) clearTimeout(closeTimer);
+	closeTimer = setTimeout(() => {
+		isOpen.value = false;
+		closeTimer = null;
+	}, 150);
+}
+
+function toggle() {
+	isOpen.value = !isOpen.value;
+}
 </script>
 
 <template>
 	<div
-		:class="[
-			'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold',
-			isComplete
-				? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
-				: 'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
-		]"
+		class="relative inline-block"
+		@mouseenter="show"
+		@mouseleave="scheduleHide"
+		@focusin="show"
+		@focusout="scheduleHide"
 	>
-		<div
+		<button
+			type="button"
+			:aria-expanded="isOpen"
+			aria-haspopup="true"
 			:class="[
-				'w-20 h-1.5 rounded-full overflow-hidden',
+				'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
 				isComplete
-					? 'bg-emerald-200 dark:bg-emerald-800'
-					: 'bg-amber-200 dark:bg-amber-800',
+					? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200'
+					: 'bg-amber-50 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
 			]"
+			@click="toggle"
 		>
 			<div
 				:class="[
-					'h-full transition-all',
-					isComplete ? 'bg-emerald-600' : 'bg-amber-500',
+					'w-20 h-1.5 rounded-full overflow-hidden',
+					isComplete
+						? 'bg-emerald-200 dark:bg-emerald-800'
+						: 'bg-amber-200 dark:bg-amber-800',
 				]"
-				:style="{ width: `${percent}%` }"
-			></div>
-		</div>
-		<span v-if="isComplete">✓ Profile complete</span>
-		<span v-else>{{ percent }}% complete</span>
+			>
+				<div
+					:class="[
+						'h-full transition-all',
+						isComplete ? 'bg-emerald-600' : 'bg-amber-500',
+					]"
+					:style="{ width: `${percent}%` }"
+				></div>
+			</div>
+			<span v-if="isComplete">✓ Profile complete</span>
+			<span v-else>{{ percent }}% complete</span>
+		</button>
+
+		<transition
+			enter-active-class="transition duration-150 ease-out"
+			enter-from-class="opacity-0 translate-y-1"
+			enter-to-class="opacity-100 translate-y-0"
+			leave-active-class="transition duration-100 ease-in"
+			leave-from-class="opacity-100 translate-y-0"
+			leave-to-class="opacity-0 translate-y-1"
+		>
+			<div
+				v-if="isOpen"
+				role="dialog"
+				aria-label="Profile completion details"
+				class="absolute right-0 z-20 mt-2 w-72 rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg p-4"
+			>
+				<div class="flex items-baseline justify-between mb-3">
+					<h4 class="text-sm font-bold text-gray-900 dark:text-gray-50">
+						Profile completion
+					</h4>
+					<span
+						:class="[
+							'text-[11px] font-semibold',
+							isComplete
+								? 'text-emerald-700 dark:text-emerald-300'
+								: 'text-amber-700 dark:text-amber-300',
+						]"
+					>
+						{{ doneCount }} of {{ checkpoints.length }}
+					</span>
+				</div>
+
+				<ul class="space-y-2.5">
+					<li v-for="cp in checkpoints" :key="cp.label" class="flex gap-3">
+						<span
+							:class="[
+								'mt-0.5 inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[11px] font-bold',
+								cp.done
+									? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-200'
+									: 'bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500',
+							]"
+							:aria-hidden="true"
+						>
+							<span v-if="cp.done">✓</span>
+							<span v-else>○</span>
+						</span>
+						<div class="flex-1 min-w-0">
+							<p
+								:class="[
+									'text-sm font-semibold',
+									cp.done
+										? 'text-gray-900 dark:text-gray-100 line-through decoration-emerald-400/60 decoration-2'
+										: 'text-gray-900 dark:text-gray-100',
+								]"
+							>
+								{{ cp.label }}
+							</p>
+							<p
+								v-if="!cp.done"
+								class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"
+							>
+								{{ cp.hint }}
+							</p>
+						</div>
+					</li>
+				</ul>
+
+				<p
+					v-if="isComplete"
+					class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700 text-xs text-emerald-700 dark:text-emerald-300"
+				>
+					Everything on file — thanks!
+				</p>
+			</div>
+		</transition>
 	</div>
 </template>

--- a/resources/js/Components/MyProfile/QualificationsCard.vue
+++ b/resources/js/Components/MyProfile/QualificationsCard.vue
@@ -4,9 +4,9 @@ import { router, usePage } from "@inertiajs/vue3";
 import { useToggle } from "@vueuse/core";
 import NewModal from "@/Components/NewModal.vue";
 import AddQualification from "@/Pages/Qualification/Add.vue";
-import EditQualification from "@/Pages/Qualification/Edit.vue";
 import DeleteQualification from "@/Pages/Qualification/Delete.vue";
 import AttachDocument from "@/Pages/Qualification/AttachDocument.vue";
+import ViewQualification from "@/Pages/Qualification/View.vue";
 
 const props = defineProps({
 	qualifications: { type: Array, default: () => [] },
@@ -25,19 +25,19 @@ const canExport = computed(() =>
 );
 
 const openAdd = ref(false);
-const openEdit = ref(false);
+const openView = ref(false);
 const openDelete = ref(false);
 const openAttach = ref(false);
 const toggleAdd = useToggle(openAdd);
-const toggleEdit = useToggle(openEdit);
+const toggleView = useToggle(openView);
 const toggleDelete = useToggle(openDelete);
 const toggleAttach = useToggle(openAttach);
 
 const current = ref(null);
 
-function startEdit(q) {
+function startView(q) {
 	current.value = q;
-	toggleEdit();
+	toggleView();
 }
 function startDelete(q) {
 	current.value = q;
@@ -183,20 +183,19 @@ function statusTag(status) {
 					class="flex items-center gap-2 text-[11px] text-emerald-700 dark:text-emerald-300 font-semibold"
 				>
 					<button
+						type="button"
+						class="hover:underline"
+						@click="startView(q)"
+					>
+						View
+					</button>
+					<button
 						v-if="q.can_edit"
 						type="button"
 						class="hover:underline"
 						@click="startAttach(q)"
 					>
 						Attach
-					</button>
-					<button
-						v-if="q.can_edit"
-						type="button"
-						class="hover:underline"
-						@click="startEdit(q)"
-					>
-						Edit
 					</button>
 					<button
 						v-if="q.can_delete"
@@ -233,17 +232,12 @@ function statusTag(status) {
 			/>
 		</NewModal>
 
-		<!-- Edit Qualification Modal -->
-		<NewModal :show="openEdit" @close="toggleEdit()">
-			<EditQualification
+		<!-- View Qualification Modal -->
+		<NewModal :show="openView" @close="toggleView()">
+			<ViewQualification
 				v-if="current"
 				:qualification="current"
-				@form-submitted="
-					() => {
-						toggleEdit();
-						router.reload({ only: ['qualifications'] });
-					}
-				"
+				@close="toggleView()"
 			/>
 		</NewModal>
 

--- a/resources/js/Components/MyProfile/QualificationsCard.vue
+++ b/resources/js/Components/MyProfile/QualificationsCard.vue
@@ -96,15 +96,18 @@ function statusTag(status) {
 					v-if="canExport"
 					:href="route('qualifications.reports.staff.profile.pdf', person.id)"
 					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-200"
-				>PDF</a>
+					>PDF</a
+				>
 				<span
 					v-if="qualifications.length === 0"
 					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
-				>0 added</span>
+					>0 added</span
+				>
 				<span
 					v-else
 					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
-				>&#10003; Active</span>
+					>&#10003; Active</span
+				>
 			</div>
 		</header>
 
@@ -134,7 +137,8 @@ function statusTag(status) {
 					v-for="tag in ['Degree', 'Diploma', 'Certificate', 'Training']"
 					:key="tag"
 					class="px-2.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-[11px] text-gray-600 dark:text-gray-300"
-				>{{ tag }}</span>
+					>{{ tag }}</span
+				>
 			</div>
 		</div>
 
@@ -147,7 +151,8 @@ function statusTag(status) {
 			>
 				<span
 					class="w-9 h-9 rounded-md bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-200 flex items-center justify-center text-base"
-				>&#127891;</span>
+					>&#127891;</span
+				>
 				<div class="flex-1 min-w-0">
 					<div
 						class="text-sm font-bold truncate text-gray-900 dark:text-gray-50"
@@ -165,10 +170,12 @@ function statusTag(status) {
 								'px-2 py-0.5 rounded-full text-[10px] font-semibold',
 								statusTag(q.status),
 							]"
-						>{{ q.status }}</span>
+							>{{ q.status }}</span
+						>
 						<span v-if="q.documents" class="text-gray-500"
-							>&#183; {{ q.documents.length }}
-							document{{ q.documents.length === 1 ? "" : "s" }}</span
+							>&#183; {{ q.documents.length }} document{{
+								q.documents.length === 1 ? "" : "s"
+							}}</span
 						>
 					</div>
 				</div>

--- a/resources/js/Components/MyProfile/QualificationsCard.vue
+++ b/resources/js/Components/MyProfile/QualificationsCard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { router, usePage } from "@inertiajs/vue3";
 import { useToggle } from "@vueuse/core";
 import NewModal from "@/Components/NewModal.vue";
@@ -34,6 +34,22 @@ const toggleDelete = useToggle(openDelete);
 const toggleAttach = useToggle(openAttach);
 
 const current = ref(null);
+
+// When the qualifications prop changes (e.g. after a document delete inside
+// the View modal triggers `router.reload({ only: ['qualifications'] })`),
+// re-sync `current` to the fresh version of the same qualification so the
+// nested View modal's props update. Drop the reference if it's gone.
+watch(
+	() => props.qualifications,
+	(list) => {
+		if (!current.value) {
+			return;
+		}
+		const fresh = (list ?? []).find((q) => q.id === current.value.id);
+		current.value = fresh ?? null;
+	},
+	{ deep: true },
+);
 
 function startView(q) {
 	current.value = q;

--- a/resources/js/Components/MyProfile/QualificationsCard.vue
+++ b/resources/js/Components/MyProfile/QualificationsCard.vue
@@ -15,10 +15,10 @@ const props = defineProps({
 
 const page = usePage();
 const permissions = computed(() => page.props?.auth?.permissions ?? []);
-const canAdd = computed(
-	() =>
-		permissions.value.includes("create staff qualification") ||
-		permissions.value.includes("update staff"),
+// Route middleware on qualification.store is `can:create staff qualification`,
+// so that permission is the only one that actually lets this button succeed.
+const canAdd = computed(() =>
+	permissions.value.includes("create staff qualification"),
 );
 const canExport = computed(() =>
 	permissions.value.includes("qualifications.reports.export"),

--- a/resources/js/Components/MyProfile/QualificationsCard.vue
+++ b/resources/js/Components/MyProfile/QualificationsCard.vue
@@ -1,0 +1,267 @@
+<script setup>
+import { ref, computed } from "vue";
+import { router, usePage } from "@inertiajs/vue3";
+import { useToggle } from "@vueuse/core";
+import NewModal from "@/Components/NewModal.vue";
+import AddQualification from "@/Pages/Qualification/Add.vue";
+import EditQualification from "@/Pages/Qualification/Edit.vue";
+import DeleteQualification from "@/Pages/Qualification/Delete.vue";
+import AttachDocument from "@/Pages/Qualification/AttachDocument.vue";
+
+const props = defineProps({
+	qualifications: { type: Array, default: () => [] },
+	person: { type: Object, required: true },
+});
+
+const page = usePage();
+const permissions = computed(() => page.props?.auth?.permissions ?? []);
+const canAdd = computed(
+	() =>
+		permissions.value.includes("create staff qualification") ||
+		permissions.value.includes("update staff"),
+);
+const canExport = computed(() =>
+	permissions.value.includes("qualifications.reports.export"),
+);
+
+const openAdd = ref(false);
+const openEdit = ref(false);
+const openDelete = ref(false);
+const openAttach = ref(false);
+const toggleAdd = useToggle(openAdd);
+const toggleEdit = useToggle(openEdit);
+const toggleDelete = useToggle(openDelete);
+const toggleAttach = useToggle(openAttach);
+
+const current = ref(null);
+
+function startEdit(q) {
+	current.value = q;
+	toggleEdit();
+}
+function startDelete(q) {
+	current.value = q;
+	toggleDelete();
+}
+function startAttach(q) {
+	current.value = q;
+	toggleAttach();
+}
+
+function confirmDelete() {
+	router.delete(
+		route("qualification.delete", { qualification: current.value.id }),
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				current.value = null;
+				toggleDelete();
+				router.reload({ only: ["qualifications"] });
+			},
+		},
+	);
+}
+
+function statusTag(status) {
+	const tone = (status ?? "").toLowerCase();
+	if (tone.includes("approved")) {
+		return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200";
+	}
+	if (tone.includes("pending")) {
+		return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
+	}
+	return "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200";
+}
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
+	>
+		<header class="flex justify-between items-start mb-4">
+			<div>
+				<h2 class="text-base font-bold text-gray-900 dark:text-gray-50">
+					Your qualifications
+				</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					{{
+						qualifications.length === 0
+							? "Degrees, certificates, training. Reviewed by HR."
+							: `${qualifications.length} added`
+					}}
+				</p>
+			</div>
+			<div class="flex items-center gap-2">
+				<a
+					v-if="canExport"
+					:href="route('qualifications.reports.staff.profile.pdf', person.id)"
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-200"
+				>PDF</a>
+				<span
+					v-if="qualifications.length === 0"
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
+				>0 added</span>
+				<span
+					v-else
+					class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"
+				>&#10003; Active</span>
+			</div>
+		</header>
+
+		<!-- EMPTY STATE -->
+		<div
+			v-if="qualifications.length === 0"
+			class="rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/40 px-6 py-9 text-center"
+		>
+			<div class="text-4xl">&#127891;</div>
+			<p class="mt-2 text-sm font-bold text-gray-900 dark:text-gray-100">
+				Add your first qualification
+			</p>
+			<p class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+				We'll walk you through it — name, institution, year, and an optional
+				certificate upload.
+			</p>
+			<button
+				v-if="canAdd"
+				type="button"
+				class="mt-4 w-full rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm"
+				@click="toggleAdd()"
+			>
+				+ Add qualification
+			</button>
+			<div class="flex flex-wrap justify-center gap-1.5 mt-3">
+				<span
+					v-for="tag in ['Degree', 'Diploma', 'Certificate', 'Training']"
+					:key="tag"
+					class="px-2.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-[11px] text-gray-600 dark:text-gray-300"
+				>{{ tag }}</span>
+			</div>
+		</div>
+
+		<!-- FILLED STATE -->
+		<ul v-else class="space-y-2">
+			<li
+				v-for="q in qualifications"
+				:key="q.id"
+				class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 px-3 py-2.5"
+			>
+				<span
+					class="w-9 h-9 rounded-md bg-emerald-50 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-200 flex items-center justify-center text-base"
+				>&#127891;</span>
+				<div class="flex-1 min-w-0">
+					<div
+						class="text-sm font-bold truncate text-gray-900 dark:text-gray-50"
+					>
+						{{ q.qualification || q.course }}
+					</div>
+					<div
+						class="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5 flex flex-wrap items-center gap-x-1.5"
+					>
+						<span v-if="q.institution">{{ q.institution }}</span>
+						<span v-if="q.year">&#183; {{ q.year }}</span>
+						<span
+							v-if="q.status"
+							:class="[
+								'px-2 py-0.5 rounded-full text-[10px] font-semibold',
+								statusTag(q.status),
+							]"
+						>{{ q.status }}</span>
+						<span v-if="q.documents" class="text-gray-500"
+							>&#183; {{ q.documents.length }}
+							document{{ q.documents.length === 1 ? "" : "s" }}</span
+						>
+					</div>
+				</div>
+				<div
+					class="flex items-center gap-2 text-[11px] text-emerald-700 dark:text-emerald-300 font-semibold"
+				>
+					<button
+						v-if="q.can_edit"
+						type="button"
+						class="hover:underline"
+						@click="startAttach(q)"
+					>
+						Attach
+					</button>
+					<button
+						v-if="q.can_edit"
+						type="button"
+						class="hover:underline"
+						@click="startEdit(q)"
+					>
+						Edit
+					</button>
+					<button
+						v-if="q.can_delete"
+						type="button"
+						class="hover:underline text-red-600 dark:text-red-400"
+						@click="startDelete(q)"
+					>
+						Delete
+					</button>
+				</div>
+			</li>
+			<li>
+				<button
+					v-if="canAdd"
+					type="button"
+					class="w-full rounded-lg border border-dashed border-emerald-500 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200 px-3 py-2.5 text-sm font-semibold hover:bg-emerald-100"
+					@click="toggleAdd()"
+				>
+					+ Add another qualification
+				</button>
+			</li>
+		</ul>
+
+		<!-- Add Qualification Modal -->
+		<NewModal :show="openAdd" @close="toggleAdd()">
+			<AddQualification
+				:person="person.id"
+				@form-submitted="
+					() => {
+						toggleAdd();
+						router.reload({ only: ['qualifications'] });
+					}
+				"
+			/>
+		</NewModal>
+
+		<!-- Edit Qualification Modal -->
+		<NewModal :show="openEdit" @close="toggleEdit()">
+			<EditQualification
+				v-if="current"
+				:qualification="current"
+				@form-submitted="
+					() => {
+						toggleEdit();
+						router.reload({ only: ['qualifications'] });
+					}
+				"
+			/>
+		</NewModal>
+
+		<!-- Delete Qualification Modal -->
+		<NewModal :show="openDelete" @close="toggleDelete()">
+			<DeleteQualification
+				:person="person.name"
+				@close="toggleDelete()"
+				@delete-confirmed="confirmDelete"
+			/>
+		</NewModal>
+
+		<!-- Attach Document Modal -->
+		<NewModal :show="openAttach" @close="toggleAttach()">
+			<AttachDocument
+				v-if="current"
+				:qualification="current"
+				@close="toggleAttach()"
+				@form-submitted="
+					() => {
+						toggleAttach();
+						router.reload({ only: ['qualifications'] });
+					}
+				"
+			/>
+		</NewModal>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
+++ b/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
@@ -1,0 +1,38 @@
+<script setup>
+defineProps({
+	title: { type: String, required: true },
+	rows: {
+		type: Array,
+		required: true,
+	},
+	lockLabel: { type: String, default: "" },
+	footer: { type: String, default: "" },
+});
+</script>
+
+<template>
+	<section
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
+	>
+		<header class="flex justify-between items-center mb-3">
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">{{ title }}</h3>
+			<span
+				v-if="lockLabel"
+				class="text-[11px] text-gray-400 dark:text-gray-500"
+			>{{ lockLabel }}</span>
+		</header>
+
+		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+			<div v-for="row in rows" :key="row.key" class="flex justify-between py-1.5">
+				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
+				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">
+					{{ row.value }}
+				</dd>
+			</div>
+		</dl>
+
+		<p v-if="footer" class="mt-3 text-[11px] italic text-gray-500 dark:text-gray-400">
+			{{ footer }}
+		</p>
+	</section>
+</template>

--- a/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
+++ b/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
@@ -15,23 +15,35 @@ defineProps({
 		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm"
 	>
 		<header class="flex justify-between items-center mb-3">
-			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">{{ title }}</h3>
+			<h3 class="text-sm font-bold text-gray-900 dark:text-gray-50">
+				{{ title }}
+			</h3>
 			<span
 				v-if="lockLabel"
 				class="text-[11px] text-gray-400 dark:text-gray-500"
-			>{{ lockLabel }}</span>
+				>{{ lockLabel }}</span
+			>
 		</header>
 
 		<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
-			<div v-for="row in rows" :key="row.key" class="flex justify-between py-1.5">
+			<div
+				v-for="row in rows"
+				:key="row.key"
+				class="flex justify-between py-1.5"
+			>
 				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
-				<dd class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right">
+				<dd
+					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+				>
 					{{ row.value }}
 				</dd>
 			</div>
 		</dl>
 
-		<p v-if="footer" class="mt-3 text-[11px] italic text-gray-500 dark:text-gray-400">
+		<p
+			v-if="footer"
+			class="mt-3 text-[11px] italic text-gray-500 dark:text-gray-400"
+		>
 			{{ footer }}
 		</p>
 	</section>

--- a/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
+++ b/resources/js/Components/MyProfile/ReadOnlyKvCard.vue
@@ -29,13 +29,21 @@ defineProps({
 			<div
 				v-for="row in rows"
 				:key="row.key"
-				class="flex justify-between py-1.5"
+				class="flex justify-between gap-2 py-1.5"
 			>
-				<dt class="text-gray-500 dark:text-gray-400">{{ row.key }}</dt>
+				<dt class="text-gray-500 dark:text-gray-400 shrink-0">
+					{{ row.key }}
+				</dt>
 				<dd
-					class="font-medium text-gray-900 dark:text-gray-100 truncate max-w-[60%] text-right"
+					class="min-w-0 text-right font-medium text-gray-900 dark:text-gray-100"
 				>
-					{{ row.value }}
+					<div class="truncate">{{ row.value }}</div>
+					<div
+						v-if="row.sub"
+						class="mt-0.5 text-[11px] font-normal text-gray-500 dark:text-gray-400 truncate"
+					>
+						{{ row.sub }}
+					</div>
 				</dd>
 			</div>
 		</dl>

--- a/resources/js/Components/NewModal.vue
+++ b/resources/js/Components/NewModal.vue
@@ -46,7 +46,7 @@ defineProps({
 						leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
 					>
 						<DialogPanel
-							class="relative transform overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-700 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg md:max-w-xl lg:max-w-2xl sm:p-6 w-full"
+							class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:max-w-lg md:max-w-xl lg:max-w-2xl xl:max-w-3xl sm:p-6 w-full"
 						>
 							<slot />
 						</DialogPanel>

--- a/resources/js/Layouts/NewAuthenticated.vue
+++ b/resources/js/Layouts/NewAuthenticated.vue
@@ -23,6 +23,7 @@ import {
 	XMarkIcon,
 	UserGroupIcon,
 	ShieldCheckIcon,
+	PhotoIcon,
 } from "@heroicons/vue/24/outline";
 import BreezeApplicationLogo from "@/Components/ApplicationLogo.vue";
 
@@ -158,6 +159,13 @@ const navigation = [
 		icon: UsersIcon,
 		current: route().current("logs.*"),
 		visible: permissions.value?.includes("view all audit logs"),
+	},
+	{
+		name: "Photo Approvals",
+		href: route("photo-approvals.index"),
+		icon: PhotoIcon,
+		current: route().current("photo-approvals.*"),
+		visible: permissions.value?.includes("approve staff photo"),
 	},
 	{
 		name: "Data Integrity",

--- a/resources/js/Layouts/NewAuthenticated.vue
+++ b/resources/js/Layouts/NewAuthenticated.vue
@@ -31,6 +31,13 @@ const permissions = computed(() => page.props?.auth?.permissions);
 const alert = computed(() => page.props?.flash);
 const navigation = [
 	{
+		name: "My Profile",
+		href: route("my-profile.show"),
+		icon: UserGroupIcon,
+		current: route().current("my-profile.*"),
+		visible: Boolean(page.props?.auth?.user?.person_id),
+	},
+	{
 		name: "Dashboard",
 		href: route("dashboard"),
 		icon: HomeIcon,

--- a/resources/js/Pages/Institution/Show.vue
+++ b/resources/js/Pages/Institution/Show.vue
@@ -23,6 +23,7 @@ import EditForm from "./partials/EditForm.vue";
 import DeleteUnit from "../Unit/Delete.vue";
 
 import { PlusIcon, Cog6ToothIcon } from "@heroicons/vue/24/outline";
+import CompletionBanner from "@/Components/MyProfile/CompletionBanner.vue";
 
 const props = defineProps({
 	institution: Object,
@@ -108,6 +109,9 @@ function closeStaffModal() {
 
 	<NewLayout>
 		<main class="w-full px-4 sm:px-6 lg:px-8 py-6">
+			<!-- Profile Completion Banner -->
+			<CompletionBanner class="mb-4" />
+
 			<!-- Header -->
 			<div
 				class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8"

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -32,11 +32,19 @@ const employmentRows = computed(() => {
 
 	return [
 		{ key: "Joined", value: props.staff.hire_date ?? "—" },
-		{ key: "Rank", value: withDistance(currentRank?.name, currentRank?.distance) },
-		{ key: "Unit", value: withDistance(currentUnit?.unit_name ?? currentUnit?.department, currentUnit?.distance) },
+		{
+			key: "Rank",
+			value: withDistance(currentRank?.name, currentRank?.distance),
+		},
+		{
+			key: "Unit",
+			value: withDistance(
+				currentUnit?.unit_name ?? currentUnit?.department,
+				currentUnit?.distance,
+			),
+		},
 	];
 });
-
 </script>
 
 <template>
@@ -61,10 +69,7 @@ const employmentRows = computed(() => {
 			<!-- Row 1: Personal + Contact + Address (three evenly-balanced cards) -->
 			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				<PersonalDetailsCard :person="person" />
-				<ContactCard
-					:person-id="person.id"
-					:contacts="contacts"
-				/>
+				<ContactCard :person-id="person.id" :contacts="contacts" />
 				<AddressCard :person-id="person.id" :address="address" />
 			</div>
 

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -6,6 +6,7 @@ import PhotoCard from "@/Components/MyProfile/PhotoCard.vue";
 import QualificationsCard from "@/Components/MyProfile/QualificationsCard.vue";
 import ContactCard from "@/Components/MyProfile/ContactCard.vue";
 import ReadOnlyKvCard from "@/Components/MyProfile/ReadOnlyKvCard.vue";
+import PersonalDetailsCard from "@/Components/MyProfile/PersonalDetailsCard.vue";
 import { computed } from "vue";
 
 const props = defineProps({
@@ -68,7 +69,8 @@ const dependentRows = computed(() => {
 				/>
 			</div>
 
-			<div class="mt-5 grid grid-cols-1 md:grid-cols-3 gap-4">
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+				<PersonalDetailsCard :person="person" />
 				<ContactCard
 					:person-id="person.id"
 					:contacts="contacts"

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -7,6 +7,7 @@ import QualificationsCard from "@/Components/MyProfile/QualificationsCard.vue";
 import ContactCard from "@/Components/MyProfile/ContactCard.vue";
 import ReadOnlyKvCard from "@/Components/MyProfile/ReadOnlyKvCard.vue";
 import PersonalDetailsCard from "@/Components/MyProfile/PersonalDetailsCard.vue";
+import DependentsCard from "@/Components/MyProfile/DependentsCard.vue";
 import { computed } from "vue";
 
 const props = defineProps({
@@ -35,19 +36,6 @@ const employmentRows = computed(() => {
 	];
 });
 
-const dependentRows = computed(() => {
-	const deps = props.staff.dependents ?? [];
-	const spouse = deps.find(
-		(d) => (d.relation ?? "").toLowerCase() === "spouse",
-	);
-	const childrenCount = deps.filter(
-		(d) => (d.relation ?? "").toLowerCase() === "child",
-	).length;
-	return [
-		{ key: "Spouse", value: spouse?.name ?? "—" },
-		{ key: "Children", value: String(childrenCount) },
-	];
-});
 </script>
 
 <template>
@@ -81,12 +69,7 @@ const dependentRows = computed(() => {
 					lock-label="HR-managed"
 					:rows="employmentRows"
 				/>
-				<ReadOnlyKvCard
-					title="Dependents"
-					lock-label="View only"
-					:rows="dependentRows"
-					footer="Need changes? Contact HR."
-				/>
+				<DependentsCard :dependents="staff.dependents" />
 			</div>
 		</main>
 	</MainLayout>

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -1,13 +1,79 @@
 <script setup>
-defineProps({
-    person: Object,
-    qualifications: Array,
-    contacts: Array,
-    address: Object,
-    staff: Object,
-})
+import { Head } from "@inertiajs/vue3";
+import MainLayout from "@/Layouts/NewAuthenticated.vue";
+import IdentityStrip from "@/Components/MyProfile/IdentityStrip.vue";
+import PhotoCard from "@/Components/MyProfile/PhotoCard.vue";
+import QualificationsCard from "@/Components/MyProfile/QualificationsCard.vue";
+import ContactCard from "@/Components/MyProfile/ContactCard.vue";
+import ReadOnlyKvCard from "@/Components/MyProfile/ReadOnlyKvCard.vue";
+import { computed } from "vue";
+
+const props = defineProps({
+	person: { type: Object, required: true },
+	staff: { type: Object, required: true },
+	qualifications: { type: Array, default: () => [] },
+	contacts: { type: Array, default: () => null },
+	address: { type: Object, default: () => null },
+});
+
+const employmentRows = computed(() => {
+	const currentRank = props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0];
+	const currentUnit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	return [
+		{ key: "Rank", value: currentRank?.name ?? "—" },
+		{ key: "Unit", value: currentUnit?.unit_name ?? "—" },
+		{ key: "Joined", value: props.staff.hire_date ?? "—" },
+	];
+});
+
+const dependentRows = computed(() => {
+	const deps = props.staff.dependents ?? [];
+	const spouse = deps.find((d) => (d.relation ?? "").toLowerCase() === "spouse");
+	const childrenCount = deps.filter((d) => (d.relation ?? "").toLowerCase() === "child").length;
+	return [
+		{ key: "Spouse", value: spouse?.name ?? "—" },
+		{ key: "Children", value: String(childrenCount) },
+	];
+});
 </script>
 
 <template>
-    <div></div>
+	<Head title="My Profile" />
+	<MainLayout>
+		<main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+			<IdentityStrip
+				:person="person"
+				:staff="staff"
+				:qualifications="qualifications"
+				:contacts="contacts"
+			/>
+
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-5">
+				<PhotoCard :person="person" />
+				<QualificationsCard
+					:qualifications="qualifications"
+					:person="{ id: person.id, name: person.name }"
+				/>
+			</div>
+
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-3 gap-4">
+				<ContactCard
+					:person-id="person.id"
+					:contacts="contacts"
+					:address="address"
+				/>
+				<ReadOnlyKvCard
+					title="Employment"
+					lock-label="HR-managed"
+					:rows="employmentRows"
+				/>
+				<ReadOnlyKvCard
+					title="Dependents"
+					lock-label="View only"
+					:rows="dependentRows"
+					footer="Need changes? Contact HR."
+				/>
+			</div>
+		</main>
+	</MainLayout>
 </template>

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -17,8 +17,10 @@ const props = defineProps({
 });
 
 const employmentRows = computed(() => {
-	const currentRank = props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0];
-	const currentUnit = props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+	const currentRank =
+		props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0];
+	const currentUnit =
+		props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
 	return [
 		{ key: "Rank", value: currentRank?.name ?? "—" },
 		{ key: "Unit", value: currentUnit?.unit_name ?? "—" },
@@ -28,8 +30,12 @@ const employmentRows = computed(() => {
 
 const dependentRows = computed(() => {
 	const deps = props.staff.dependents ?? [];
-	const spouse = deps.find((d) => (d.relation ?? "").toLowerCase() === "spouse");
-	const childrenCount = deps.filter((d) => (d.relation ?? "").toLowerCase() === "child").length;
+	const spouse = deps.find(
+		(d) => (d.relation ?? "").toLowerCase() === "spouse",
+	);
+	const childrenCount = deps.filter(
+		(d) => (d.relation ?? "").toLowerCase() === "child",
+	).length;
 	return [
 		{ key: "Spouse", value: spouse?.name ?? "—" },
 		{ key: "Children", value: String(childrenCount) },

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -1,0 +1,13 @@
+<script setup>
+defineProps({
+    person: Object,
+    qualifications: Array,
+    contacts: Array,
+    address: Object,
+    staff: Object,
+})
+</script>
+
+<template>
+    <div></div>
+</template>

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -5,6 +5,7 @@ import IdentityStrip from "@/Components/MyProfile/IdentityStrip.vue";
 import PhotoCard from "@/Components/MyProfile/PhotoCard.vue";
 import QualificationsCard from "@/Components/MyProfile/QualificationsCard.vue";
 import ContactCard from "@/Components/MyProfile/ContactCard.vue";
+import AddressCard from "@/Components/MyProfile/AddressCard.vue";
 import ReadOnlyKvCard from "@/Components/MyProfile/ReadOnlyKvCard.vue";
 import PersonalDetailsCard from "@/Components/MyProfile/PersonalDetailsCard.vue";
 import DependentsCard from "@/Components/MyProfile/DependentsCard.vue";
@@ -57,13 +58,18 @@ const employmentRows = computed(() => {
 				/>
 			</div>
 
-			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+			<!-- Row 1: Personal + Contact + Address (three evenly-balanced cards) -->
+			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 				<PersonalDetailsCard :person="person" />
 				<ContactCard
 					:person-id="person.id"
 					:contacts="contacts"
-					:address="address"
 				/>
+				<AddressCard :person-id="person.id" :address="address" />
+			</div>
+
+			<!-- Row 2: Employment + Dependents (wider cards with more breathing room) -->
+			<div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
 				<ReadOnlyKvCard
 					title="Employment"
 					lock-label="HR-managed"

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -21,10 +21,16 @@ const employmentRows = computed(() => {
 		props.staff.ranks?.find((r) => !r.end_date) ?? props.staff.ranks?.[0];
 	const currentUnit =
 		props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
+
+	const withDistance = (label, distance) => {
+		if (!label) return "—";
+		return distance ? `${label} · ${distance}` : label;
+	};
+
 	return [
-		{ key: "Rank", value: currentRank?.name ?? "—" },
-		{ key: "Unit", value: currentUnit?.unit_name ?? "—" },
 		{ key: "Joined", value: props.staff.hire_date ?? "—" },
+		{ key: "Rank", value: withDistance(currentRank?.name, currentRank?.distance) },
+		{ key: "Unit", value: withDistance(currentUnit?.unit_name ?? currentUnit?.department, currentUnit?.distance) },
 	];
 });
 

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -25,23 +25,21 @@ const employmentRows = computed(() => {
 	const currentUnit =
 		props.staff.units?.find((u) => !u.end_date) ?? props.staff.units?.[0];
 
-	const withDistance = (label, distance) => {
-		if (!label) return "—";
-		return distance ? `${label} · ${distance}` : label;
-	};
-
 	return [
-		{ key: "Joined", value: props.staff.hire_date ?? "—" },
+		{
+			key: "Joined",
+			value: props.staff.hire_date ?? "—",
+			sub: props.staff.hire_date_display,
+		},
 		{
 			key: "Rank",
-			value: withDistance(currentRank?.name, currentRank?.distance),
+			value: currentRank?.name ?? "—",
+			sub: currentRank?.distance,
 		},
 		{
 			key: "Unit",
-			value: withDistance(
-				currentUnit?.unit_name ?? currentUnit?.department,
-				currentUnit?.distance,
-			),
+			value: currentUnit?.unit_name ?? currentUnit?.department ?? "—",
+			sub: currentUnit?.distance,
 		},
 	];
 });

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -15,7 +15,7 @@ const props = defineProps({
 	person: { type: Object, required: true },
 	staff: { type: Object, required: true },
 	qualifications: { type: Array, default: () => [] },
-	contacts: { type: Array, default: () => null },
+	contacts: { type: Array, default: () => [] },
 	address: { type: Object, default: () => null },
 });
 

--- a/resources/js/Pages/MyProfile/Index.vue
+++ b/resources/js/Pages/MyProfile/Index.vue
@@ -56,6 +56,7 @@ const employmentRows = computed(() => {
 				:staff="staff"
 				:qualifications="qualifications"
 				:contacts="contacts"
+				:address="address"
 			/>
 
 			<div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-5">

--- a/resources/js/Pages/Person/partials/AddContact.vue
+++ b/resources/js/Pages/Person/partials/AddContact.vue
@@ -35,7 +35,7 @@ const submitHandler = (data, node) => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
+	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-800">
 		<h1 class="text-2xl pb-4 dark:text-gray-100">Add Contacts</h1>
 		<FormKit type="form" submit-label="Save" @submit="submitHandler">
 			<FormKit

--- a/resources/js/Pages/Person/partials/ContactForm.vue
+++ b/resources/js/Pages/Person/partials/ContactForm.vue
@@ -16,6 +16,8 @@ onMounted(async () => {
 		placeholder="Select one"
 		validation="required"
 		:options="contact_types"
+		outer-class="w-full"
+		input-class="w-full"
 	/>
 	<FormKit
 		id="contact"
@@ -24,5 +26,17 @@ onMounted(async () => {
 		label="Contact"
 		placeholder="Contact"
 		validation="required|length:2,100"
+		outer-class="w-full"
+		input-class="w-full"
 	/>
 </template>
+
+<style scoped>
+:deep(.formkit-outer) {
+	width: 100%;
+}
+:deep(.formkit-inner),
+:deep(.formkit-input) {
+	width: 100%;
+}
+</style>

--- a/resources/js/Pages/Person/partials/ContactForm.vue
+++ b/resources/js/Pages/Person/partials/ContactForm.vue
@@ -32,11 +32,14 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-:deep(.formkit-outer) {
-	width: 100%;
-}
+:deep(.formkit-outer),
+:deep(.formkit-wrapper),
 :deep(.formkit-inner),
 :deep(.formkit-input) {
 	width: 100%;
+	max-width: 100%;
+}
+:deep(.formkit-input) {
+	box-sizing: border-box;
 }
 </style>

--- a/resources/js/Pages/Person/partials/EditContact.vue
+++ b/resources/js/Pages/Person/partials/EditContact.vue
@@ -44,7 +44,7 @@ const submitHandler = (data, node) => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
+	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-800">
 		<h1 class="text-2xl pb-4 dark:text-gray-100">Edit Contacts</h1>
 		<FormKit
 			:value="props.contact"

--- a/resources/js/Pages/PhotoApprovals/Index.vue
+++ b/resources/js/Pages/PhotoApprovals/Index.vue
@@ -1,0 +1,151 @@
+<script setup>
+import { Head } from "@inertiajs/vue3";
+import { router } from "@inertiajs/vue3";
+import NewAuthenticated from "@/Layouts/NewAuthenticated.vue";
+
+defineProps({
+	pending: {
+		type: Array,
+		default: () => [],
+	},
+});
+
+function approve(personId) {
+	router.post(
+		route("photo-approvals.approve", { person: personId }),
+		{},
+		{ preserveScroll: true, onSuccess: () => router.reload() },
+	);
+}
+
+function reject(personId) {
+	router.post(
+		route("photo-approvals.reject", { person: personId }),
+		{},
+		{ preserveScroll: true, onSuccess: () => router.reload() },
+	);
+}
+</script>
+
+<template>
+	<Head title="Photo Approvals" />
+	<NewAuthenticated>
+		<div class="px-4 py-6 sm:px-6 lg:px-8">
+			<div class="mb-6">
+				<h1 class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+					Photo Approvals
+				</h1>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Review and approve or reject pending staff profile photo submissions.
+				</p>
+			</div>
+
+			<div
+				v-if="pending.length === 0"
+				class="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-6 py-12 text-center shadow-sm"
+			>
+				<p class="text-sm text-gray-500 dark:text-gray-400">
+					No pending photo submissions.
+				</p>
+			</div>
+
+			<div v-else class="overflow-hidden rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700">
+				<table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+					<thead class="bg-gray-50 dark:bg-gray-900">
+						<tr>
+							<th
+								class="px-6 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+							>
+								Staff Member
+							</th>
+							<th
+								class="px-6 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+							>
+								Current Photo
+							</th>
+							<th
+								class="px-6 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+							>
+								Pending Photo
+							</th>
+							<th
+								class="px-6 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+							>
+								Submitted
+							</th>
+							<th
+								class="px-6 py-3 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+							>
+								Actions
+							</th>
+						</tr>
+					</thead>
+					<tbody
+						class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"
+					>
+						<tr
+							v-for="item in pending"
+							:key="item.id"
+							class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+						>
+							<td class="px-6 py-4 whitespace-nowrap">
+								<p
+									class="text-sm font-semibold text-gray-900 dark:text-gray-50"
+								>
+									{{ item.name }}
+								</p>
+							</td>
+							<td class="px-6 py-4 whitespace-nowrap">
+								<img
+									v-if="item.current_image"
+									:src="item.current_image"
+									alt="Current photo"
+									class="w-20 h-20 rounded-lg object-cover border border-gray-200 dark:border-gray-700"
+								/>
+								<div
+									v-else
+									class="w-20 h-20 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center"
+								>
+									<span
+										class="text-xs text-gray-400 dark:text-gray-500"
+										>None</span
+									>
+								</div>
+							</td>
+							<td class="px-6 py-4 whitespace-nowrap">
+								<img
+									:src="item.pending_image"
+									alt="Pending photo"
+									class="w-20 h-20 rounded-lg object-cover border-2 border-amber-400 dark:border-amber-500"
+								/>
+							</td>
+							<td class="px-6 py-4 whitespace-nowrap">
+								<span class="text-sm text-gray-500 dark:text-gray-400">{{
+									item.pending_image_at
+								}}</span>
+							</td>
+							<td
+								class="px-6 py-4 whitespace-nowrap text-right space-x-2"
+							>
+								<button
+									type="button"
+									class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors"
+									@click="approve(item.id)"
+								>
+									Approve
+								</button>
+								<button
+									type="button"
+									class="inline-flex items-center rounded-lg bg-red-600 hover:bg-red-700 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors"
+									@click="reject(item.id)"
+								>
+									Reject
+								</button>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</NewAuthenticated>
+</template>

--- a/resources/js/Pages/Qualification/Add.vue
+++ b/resources/js/Pages/Qualification/Add.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
+import { getNode } from "@formkit/core";
 import axios from "axios";
 import {
 	ArrowPathIcon,
@@ -41,19 +42,23 @@ const form = ref({
 	qualification_number: "",
 	institution: "",
 	year: "",
-	document_type: "",
 });
 
 // ── Step-1 validation errors ──────────────────────────────────────────────────
 const step1Errors = ref({});
 
-// ── Step-2: selected files ────────────────────────────────────────────────────
+// ── Step-2: selected files with per-file metadata ────────────────────────────
+// Each entry: { file: File, document_type: string, document_title: string }
 const selectedFiles = ref([]);
 
 function onFileInput(event) {
 	const files = Array.from(event.target.files || []);
-	selectedFiles.value = [...selectedFiles.value, ...files];
-	// Reset the input so the same file can be added again if needed
+	const newEntries = files.map((file) => ({
+		file,
+		document_type: "",
+		document_title: file.name.replace(/\.[^.]+$/, ""),
+	}));
+	selectedFiles.value = [...selectedFiles.value, ...newEntries];
 	event.target.value = "";
 }
 
@@ -66,8 +71,6 @@ function formatSize(bytes) {
 }
 
 // ── Step 1 → 2 ───────────────────────────────────────────────────────────────
-const step1FormRef = ref(null);
-
 // FormKit only fires @submit after validation passes, so both "Next" and
 // "Save without document" route through this single handler. The button
 // sets `pendingAction` on click (before the submit fires) so we know which
@@ -87,12 +90,19 @@ function onStep1Submit() {
 
 function clickSaveWithoutDocuments() {
 	pendingAction.value = "save";
-	step1FormRef.value?.node?.submit();
+	getNode("addQualificationStep1")?.submit();
 }
 
 function goBackToStep1() {
 	currentStep.value = 1;
 }
+
+// ── Step-2 validation ─────────────────────────────────────────────────────────
+const hasIncompleteFiles = computed(() =>
+	selectedFiles.value.some(
+		(entry) => !entry.document_type || !entry.document_title.trim(),
+	),
+);
 
 // ── Save button label ─────────────────────────────────────────────────────────
 const saveLabel = computed(() => {
@@ -121,9 +131,10 @@ function buildFormData() {
 	fd.append("year", form.value.year ?? "");
 
 	if (selectedFiles.value.length > 0) {
-		fd.append("document_type", form.value.document_type ?? "");
-		selectedFiles.value.forEach((file) => {
-			fd.append("file_name[]", file);
+		selectedFiles.value.forEach((entry) => {
+			fd.append("file_name[]", entry.file);
+			fd.append("document_type[]", entry.document_type);
+			fd.append("document_title[]", entry.document_title);
 		});
 	}
 
@@ -181,7 +192,6 @@ function submit() {
 				qualification_number: "",
 				institution: "",
 				year: "",
-				document_type: "",
 			};
 			selectedFiles.value = [];
 			currentStep.value = 1;
@@ -195,7 +205,6 @@ function submit() {
 		},
 	});
 }
-
 </script>
 
 <template>
@@ -289,7 +298,7 @@ function submit() {
 		<!-- ── STEP 1: Qualification details ─────────────────────────────── -->
 		<div v-show="currentStep === 1">
 			<FormKit
-				ref="step1FormRef"
+				id="addQualificationStep1"
 				type="form"
 				:disabled="isSubmitting"
 				:actions="false"
@@ -376,9 +385,7 @@ function submit() {
 				</div>
 
 				<!-- Row 4: Year (narrow) -->
-				<div
-					class="w-1/2 sm:w-1/3 xl:w-1/4"
-				>
+				<div class="w-1/2 sm:w-1/3 xl:w-1/4">
 					<FormKit
 						id="year"
 						v-model="form.year"
@@ -448,20 +455,6 @@ function submit() {
 				</p>
 			</div>
 
-			<!-- Document type -->
-			<FormKit
-				v-model="form.document_type"
-				type="select"
-				name="document_type"
-				label="Document type"
-				placeholder="Select type"
-				:options="documentTypes"
-				:validation="
-					selectedFiles.length > 0 ? 'required' : ''
-				"
-				validation-visibility="submit"
-			/>
-
 			<!-- File picker -->
 			<div class="mt-1 mb-3">
 				<label
@@ -483,42 +476,118 @@ function submit() {
 				</label>
 			</div>
 
-			<!-- File list -->
+			<!-- File list with per-file type + title -->
 			<ul
 				v-if="selectedFiles.length > 0"
-				class="space-y-2 mb-4"
+				class="space-y-3 mb-4"
 			>
 				<li
-					v-for="(file, index) in selectedFiles"
+					v-for="(entry, index) in selectedFiles"
 					:key="index"
-					class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-2.5"
+					class="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-3"
 				>
-					<div
-						class="w-9 h-9 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center flex-shrink-0"
-					>
-						<DocumentIcon class="h-4 w-4 text-gray-400" />
-					</div>
-					<div class="flex-1 min-w-0 text-xs">
-						<p
-							class="font-semibold text-gray-900 dark:text-gray-100 truncate"
+					<!-- File info row -->
+					<div class="flex items-center gap-3 mb-2">
+						<div
+							class="w-9 h-9 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center flex-shrink-0"
 						>
-							{{ file.name }}
-						</p>
-						<p class="text-gray-500 dark:text-gray-400">
-							{{ formatSize(file.size) }} &middot;
-							{{ file.type || "unknown type" }}
-						</p>
+							<DocumentIcon class="h-4 w-4 text-gray-400" />
+						</div>
+						<div class="flex-1 min-w-0 text-xs">
+							<p
+								class="font-semibold text-gray-900 dark:text-gray-100 truncate"
+							>
+								{{ entry.file.name }}
+							</p>
+							<p class="text-gray-500 dark:text-gray-400">
+								{{ formatSize(entry.file.size) }} &middot;
+								{{ entry.file.type || "unknown type" }}
+							</p>
+						</div>
+						<button
+							type="button"
+							class="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
+							:aria-label="`Remove ${entry.file.name}`"
+							@click="removeFile(index)"
+						>
+							<XCircleIcon class="h-5 w-5" />
+						</button>
 					</div>
-					<button
-						type="button"
-						class="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
-						:aria-label="`Remove ${file.name}`"
-						@click="removeFile(index)"
-					>
-						<XCircleIcon class="h-5 w-5" />
-					</button>
+
+					<!-- Per-file metadata -->
+					<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+						<div>
+							<label
+								:for="`doc-type-${index}`"
+								class="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1"
+							>
+								Document type
+								<span class="text-red-500">*</span>
+							</label>
+							<select
+								:id="`doc-type-${index}`"
+								v-model="entry.document_type"
+								class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+								:class="{
+									'border-red-400 dark:border-red-500':
+										!entry.document_type,
+								}"
+							>
+								<option value="" disabled>Select type</option>
+								<option
+									v-for="opt in documentTypes"
+									:key="opt.value"
+									:value="opt.value"
+								>
+									{{ opt.label }}
+								</option>
+							</select>
+							<p
+								v-if="!entry.document_type"
+								class="mt-1 text-[11px] text-red-500"
+							>
+								Document type is required
+							</p>
+						</div>
+						<div>
+							<label
+								:for="`doc-title-${index}`"
+								class="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1"
+							>
+								Document title
+								<span class="text-red-500">*</span>
+							</label>
+							<input
+								:id="`doc-title-${index}`"
+								v-model="entry.document_title"
+								type="text"
+								maxlength="100"
+								placeholder="e.g. Bachelor of Science Degree"
+								class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
+								:class="{
+									'border-red-400 dark:border-red-500':
+										!entry.document_title.trim(),
+								}"
+							/>
+							<p
+								v-if="!entry.document_title.trim()"
+								class="mt-1 text-[11px] text-red-500"
+							>
+								Document title is required
+							</p>
+						</div>
+					</div>
 				</li>
 			</ul>
+
+			<!-- Hint when files have incomplete metadata -->
+			<p
+				v-if="selectedFiles.length > 0 && hasIncompleteFiles"
+				class="text-xs text-amber-600 dark:text-amber-400 mb-3"
+			>
+				Please fill in the document type and title for every file before
+				saving.
+			</p>
 
 			<!-- Step 2 actions -->
 			<div
@@ -535,7 +604,7 @@ function submit() {
 
 				<button
 					type="button"
-					:disabled="isSubmitting"
+					:disabled="isSubmitting || hasIncompleteFiles"
 					class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 					@click="submit"
 				>

--- a/resources/js/Pages/Qualification/Add.vue
+++ b/resources/js/Pages/Qualification/Add.vue
@@ -68,14 +68,26 @@ function formatSize(bytes) {
 // ── Step 1 → 2 ───────────────────────────────────────────────────────────────
 const step1FormRef = ref(null);
 
-async function goToStep2() {
+// FormKit only fires @submit after validation passes, so both "Next" and
+// "Save without document" route through this single handler. The button
+// sets `pendingAction` on click (before the submit fires) so we know which
+// path to take once validation is done.
+const pendingAction = ref("next");
+
+function onStep1Submit() {
 	step1Errors.value = {};
-	// Trigger FormKit validation
-	const valid = await step1FormRef.value.node.submit();
-	if (valid === false) {
-		return;
+	if (pendingAction.value === "save") {
+		selectedFiles.value = [];
+		submit();
+	} else {
+		currentStep.value = 2;
 	}
-	currentStep.value = 2;
+	pendingAction.value = "next";
+}
+
+function clickSaveWithoutDocuments() {
+	pendingAction.value = "save";
+	step1FormRef.value?.node?.submit();
 }
 
 function goBackToStep1() {
@@ -184,16 +196,6 @@ function submit() {
 	});
 }
 
-// "Skip — save without documents" from step 1 submits directly
-async function saveWithoutDocuments() {
-	step1Errors.value = {};
-	const valid = await step1FormRef.value.node.submit();
-	if (valid === false) {
-		return;
-	}
-	selectedFiles.value = [];
-	submit();
-}
 </script>
 
 <template>
@@ -291,7 +293,7 @@ async function saveWithoutDocuments() {
 				type="form"
 				:disabled="isSubmitting"
 				:actions="false"
-				@submit="goToStep2"
+				@submit="onStep1Submit"
 			>
 				<h3
 					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3"
@@ -406,7 +408,7 @@ async function saveWithoutDocuments() {
 							type="button"
 							class="text-sm text-emerald-600 dark:text-emerald-400 hover:underline px-2 py-2 transition-colors"
 							:disabled="isSubmitting"
-							@click="saveWithoutDocuments"
+							@click="clickSaveWithoutDocuments"
 						>
 							Save without document
 						</button>
@@ -414,6 +416,7 @@ async function saveWithoutDocuments() {
 							type="submit"
 							:disabled="isSubmitting"
 							class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+							@click="pendingAction = 'next'"
 						>
 							Next: Add documents
 						</button>

--- a/resources/js/Pages/Qualification/Add.vue
+++ b/resources/js/Pages/Qualification/Add.vue
@@ -123,10 +123,7 @@ function buildFormData() {
 	fd.append("course", form.value.course ?? "");
 	fd.append("level", form.value.level ?? "");
 	fd.append("qualification", form.value.qualification ?? "");
-	fd.append(
-		"qualification_number",
-		form.value.qualification_number ?? "",
-	);
+	fd.append("qualification_number", form.value.qualification_number ?? "");
 	fd.append("institution", form.value.institution ?? "");
 	fd.append("year", form.value.year ?? "");
 
@@ -208,9 +205,7 @@ function submit() {
 </script>
 
 <template>
-	<main
-		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
-	>
+	<main class="bg-white dark:bg-gray-800 rounded-2xl p-5 sm:p-6 shadow-sm">
 		<!-- Header -->
 		<header class="flex justify-between items-start mb-5">
 			<div>
@@ -218,8 +213,8 @@ function submit() {
 					Add Qualification
 				</h2>
 				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-					Degree, diploma, certificate, or training. Optional
-					certificate upload.
+					Degree, diploma, certificate, or training. Optional certificate
+					upload.
 				</p>
 			</div>
 			<button
@@ -244,10 +239,7 @@ function submit() {
 							: 'bg-emerald-50 dark:bg-emerald-900/30 border-emerald-500 text-emerald-600 dark:text-emerald-400'
 					"
 				>
-					<CheckCircleIcon
-						v-if="currentStep === 2"
-						class="w-4 h-4"
-					/>
+					<CheckCircleIcon v-if="currentStep === 2" class="w-4 h-4" />
 					<span v-else>1</span>
 				</div>
 				<span
@@ -265,9 +257,7 @@ function submit() {
 			<div
 				class="flex-1 h-px transition-colors"
 				:class="
-					currentStep === 2
-						? 'bg-emerald-400'
-						: 'bg-gray-200 dark:bg-gray-700'
+					currentStep === 2 ? 'bg-emerald-400' : 'bg-gray-200 dark:bg-gray-700'
 				"
 			/>
 
@@ -477,10 +467,7 @@ function submit() {
 			</div>
 
 			<!-- File list with per-file type + title -->
-			<ul
-				v-if="selectedFiles.length > 0"
-				class="space-y-3 mb-4"
-			>
+			<ul v-if="selectedFiles.length > 0" class="space-y-3 mb-4">
 				<li
 					v-for="(entry, index) in selectedFiles"
 					:key="index"
@@ -529,8 +516,7 @@ function submit() {
 								v-model="entry.document_type"
 								class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs px-3 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500"
 								:class="{
-									'border-red-400 dark:border-red-500':
-										!entry.document_type,
+									'border-red-400 dark:border-red-500': !entry.document_type,
 								}"
 							>
 								<option value="" disabled>Select type</option>
@@ -585,8 +571,7 @@ function submit() {
 				v-if="selectedFiles.length > 0 && hasIncompleteFiles"
 				class="text-xs text-amber-600 dark:text-amber-400 mb-3"
 			>
-				Please fill in the document type and title for every file before
-				saving.
+				Please fill in the document type and title for every file before saving.
 			</p>
 
 			<!-- Step 2 actions -->
@@ -608,10 +593,7 @@ function submit() {
 					class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 					@click="submit"
 				>
-					<ArrowPathIcon
-						v-if="isSubmitting"
-						class="w-4 h-4 animate-spin"
-					/>
+					<ArrowPathIcon v-if="isSubmitting" class="w-4 h-4 animate-spin" />
 					{{ saveLabel }}
 				</button>
 			</div>

--- a/resources/js/Pages/Qualification/Add.vue
+++ b/resources/js/Pages/Qualification/Add.vue
@@ -1,12 +1,14 @@
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import axios from "axios";
 import {
 	ArrowPathIcon,
 	XMarkIcon,
 	DocumentIcon,
+	XCircleIcon,
 } from "@heroicons/vue/24/outline";
+import { CheckCircleIcon } from "@heroicons/vue/24/solid";
 
 const emit = defineEmits(["formSubmitted", "close"]);
 
@@ -14,12 +16,9 @@ const props = defineProps({
 	person: { type: Number, required: true },
 });
 
+// ── Options ──────────────────────────────────────────────────────────────────
 const qualificationLevels = ref([]);
 const documentTypes = ref([]);
-const isSubmitting = ref(false);
-const selectedFile = ref(null);
-const previewUrl = ref(null);
-const previewFileType = ref(null);
 
 onMounted(async () => {
 	const [levelsRes, typesRes] = await Promise.all([
@@ -30,56 +29,170 @@ onMounted(async () => {
 	documentTypes.value = typesRes.data;
 });
 
-function onFileInput(files) {
-	if (files && files.length > 0) {
-		const f = files[0].file;
-		selectedFile.value = f;
-		previewUrl.value = URL.createObjectURL(f);
-		previewFileType.value = f.type;
-	} else {
-		selectedFile.value = null;
-		previewUrl.value = null;
-		previewFileType.value = null;
-	}
+// ── Wizard state ──────────────────────────────────────────────────────────────
+const currentStep = ref(1);
+const isSubmitting = ref(false);
+
+// ── Shared form state (persists across steps) ─────────────────────────────────
+const form = ref({
+	course: "",
+	level: "",
+	qualification: "",
+	qualification_number: "",
+	institution: "",
+	year: "",
+	document_type: "",
+});
+
+// ── Step-1 validation errors ──────────────────────────────────────────────────
+const step1Errors = ref({});
+
+// ── Step-2: selected files ────────────────────────────────────────────────────
+const selectedFiles = ref([]);
+
+function onFileInput(event) {
+	const files = Array.from(event.target.files || []);
+	selectedFiles.value = [...selectedFiles.value, ...files];
+	// Reset the input so the same file can be added again if needed
+	event.target.value = "";
 }
 
-function submitHandler(data, node) {
-	isSubmitting.value = true;
+function removeFile(index) {
+	selectedFiles.value = selectedFiles.value.filter((_, i) => i !== index);
+}
 
-	const formData = new FormData();
-	formData.append("person_id", String(props.person));
-	formData.append("course", data.course ?? "");
-	formData.append("level", data.level ?? "");
-	formData.append("qualification", data.qualification ?? "");
-	formData.append("qualification_number", data.qualification_number ?? "");
-	formData.append("institution", data.institution ?? "");
-	formData.append("year", data.year ?? "");
+function formatSize(bytes) {
+	return (bytes / 1024).toFixed(0) + " KB";
+}
 
-	if (data.file_name && data.file_name.length > 0) {
-		formData.append("file_name", data.file_name[0].file);
-		formData.append("document_type", data.document_type ?? "");
-		if (data.document_title) {
-			formData.append("document_title", data.document_title);
-		}
+// ── Step 1 → 2 ───────────────────────────────────────────────────────────────
+const step1FormRef = ref(null);
+
+async function goToStep2() {
+	step1Errors.value = {};
+	// Trigger FormKit validation
+	const valid = await step1FormRef.value.node.submit();
+	if (valid === false) {
+		return;
+	}
+	currentStep.value = 2;
+}
+
+function goBackToStep1() {
+	currentStep.value = 1;
+}
+
+// ── Save button label ─────────────────────────────────────────────────────────
+const saveLabel = computed(() => {
+	if (isSubmitting.value) {
+		return "Saving...";
+	}
+	const n = selectedFiles.value.length;
+	if (n === 0) {
+		return "Save qualification";
+	}
+	return `Save with ${n} document${n === 1 ? "" : "s"}`;
+});
+
+// ── Submit ────────────────────────────────────────────────────────────────────
+function buildFormData() {
+	const fd = new FormData();
+	fd.append("person_id", String(props.person));
+	fd.append("course", form.value.course ?? "");
+	fd.append("level", form.value.level ?? "");
+	fd.append("qualification", form.value.qualification ?? "");
+	fd.append(
+		"qualification_number",
+		form.value.qualification_number ?? "",
+	);
+	fd.append("institution", form.value.institution ?? "");
+	fd.append("year", form.value.year ?? "");
+
+	if (selectedFiles.value.length > 0) {
+		fd.append("document_type", form.value.document_type ?? "");
+		selectedFiles.value.forEach((file) => {
+			fd.append("file_name[]", file);
+		});
 	}
 
-	router.post(route("qualification.store"), formData, {
+	return fd;
+}
+
+// Step-1 field names — used to route server errors back to step 1
+const step1Fields = new Set([
+	"person_id",
+	"course",
+	"level",
+	"qualification",
+	"qualification_number",
+	"institution",
+	"year",
+]);
+
+function handleServerErrors(errors) {
+	const s1 = {};
+	const s2 = {};
+	Object.entries(errors).forEach(([key, message]) => {
+		const baseKey = key.split(".")[0];
+		if (step1Fields.has(baseKey)) {
+			s1[key] = message;
+		} else {
+			s2[key] = message;
+		}
+	});
+
+	// If any step-1 errors, go back and surface them
+	if (Object.keys(s1).length > 0) {
+		step1Errors.value = s1;
+		currentStep.value = 1;
+	}
+
+	// Step-2 errors are surfaced via the serverErrors ref on step 2
+	step2Errors.value = s2;
+}
+
+const step2Errors = ref({});
+
+function submit() {
+	isSubmitting.value = true;
+	step2Errors.value = {};
+
+	router.post(route("qualification.store"), buildFormData(), {
 		forceFormData: true,
 		preserveScroll: true,
 		onSuccess: () => {
-			node.reset();
-			selectedFile.value = null;
-			previewUrl.value = null;
-			previewFileType.value = null;
+			// Reset everything
+			form.value = {
+				course: "",
+				level: "",
+				qualification: "",
+				qualification_number: "",
+				institution: "",
+				year: "",
+				document_type: "",
+			};
+			selectedFiles.value = [];
+			currentStep.value = 1;
+			step1Errors.value = {};
+			step2Errors.value = {};
 			emit("formSubmitted");
 		},
-		onError: (errors) => {
-			node.setErrors([""], errors);
-		},
+		onError: handleServerErrors,
 		onFinish: () => {
 			isSubmitting.value = false;
 		},
 	});
+}
+
+// "Skip — save without documents" from step 1 submits directly
+async function saveWithoutDocuments() {
+	step1Errors.value = {};
+	const valid = await step1FormRef.value.node.submit();
+	if (valid === false) {
+		return;
+	}
+	selectedFiles.value = [];
+	submit();
 }
 </script>
 
@@ -94,8 +207,8 @@ function submitHandler(data, node) {
 					Add Qualification
 				</h2>
 				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-					Degree, diploma, certificate, or training. Optional certificate
-					upload.
+					Degree, diploma, certificate, or training. Optional
+					certificate upload.
 				</p>
 			</div>
 			<button
@@ -108,24 +221,111 @@ function submitHandler(data, node) {
 			</button>
 		</header>
 
-		<FormKit
-			type="form"
-			:disabled="isSubmitting"
-			:actions="false"
-			@submit="submitHandler"
-		>
-			<FormKit type="hidden" name="person_id" :value="props.person" />
+		<!-- Step indicator -->
+		<div class="flex items-center gap-3 mb-6">
+			<!-- Step 1 -->
+			<div class="flex items-center gap-2">
+				<div
+					class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors"
+					:class="
+						currentStep === 1
+							? 'bg-emerald-600 border-emerald-600 text-white'
+							: 'bg-emerald-50 dark:bg-emerald-900/30 border-emerald-500 text-emerald-600 dark:text-emerald-400'
+					"
+				>
+					<CheckCircleIcon
+						v-if="currentStep === 2"
+						class="w-4 h-4"
+					/>
+					<span v-else>1</span>
+				</div>
+				<span
+					class="text-xs font-semibold"
+					:class="
+						currentStep === 1
+							? 'text-emerald-700 dark:text-emerald-400'
+							: 'text-gray-400 dark:text-gray-500'
+					"
+					>Details</span
+				>
+			</div>
 
-			<!-- Qualification Details section -->
-			<div>
+			<!-- Connector -->
+			<div
+				class="flex-1 h-px transition-colors"
+				:class="
+					currentStep === 2
+						? 'bg-emerald-400'
+						: 'bg-gray-200 dark:bg-gray-700'
+				"
+			/>
+
+			<!-- Step 2 -->
+			<div class="flex items-center gap-2">
+				<div
+					class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors"
+					:class="
+						currentStep === 2
+							? 'bg-emerald-600 border-emerald-600 text-white'
+							: 'border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500'
+					"
+				>
+					2
+				</div>
+				<span
+					class="text-xs font-semibold"
+					:class="
+						currentStep === 2
+							? 'text-emerald-700 dark:text-emerald-400'
+							: 'text-gray-400 dark:text-gray-500'
+					"
+					>Documents</span
+				>
+			</div>
+		</div>
+
+		<!-- ── STEP 1: Qualification details ─────────────────────────────── -->
+		<div v-show="currentStep === 1">
+			<FormKit
+				ref="step1FormRef"
+				type="form"
+				:disabled="isSubmitting"
+				:actions="false"
+				@submit="goToStep2"
+			>
 				<h3
 					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3"
 				>
 					Qualification details
 				</h3>
+
+				<!-- Server errors for step-1 fields -->
+				<div
+					v-if="Object.keys(step1Errors).length"
+					class="mb-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 text-xs text-red-700 dark:text-red-400 space-y-1"
+				>
+					<p v-for="(msg, key) in step1Errors" :key="key">
+						{{ msg }}
+					</p>
+				</div>
+
+				<!-- Row 1: Institution (full width) -->
+				<FormKit
+					id="institution"
+					v-model="form.institution"
+					type="text"
+					name="institution"
+					label="Institution"
+					placeholder="e.g. University of Ghana"
+					validation="length:0,100"
+					validation-visibility="submit"
+				/>
+
+				<!-- Row 2: Course | Level -->
 				<div class="sm:grid sm:grid-cols-2 sm:gap-x-4">
 					<FormKit
 						id="course"
+						v-model="form.course"
 						type="text"
 						name="course"
 						label="Course"
@@ -135,6 +335,7 @@ function submitHandler(data, node) {
 					/>
 					<FormKit
 						id="level"
+						v-model="form.level"
 						type="select"
 						name="level"
 						label="Level"
@@ -146,8 +347,13 @@ function submitHandler(data, node) {
 							}))
 						"
 					/>
+				</div>
+
+				<!-- Row 3: Qualification | Qualification Number -->
+				<div class="sm:grid sm:grid-cols-2 sm:gap-x-4">
 					<FormKit
 						id="qualification"
+						v-model="form.qualification"
 						type="text"
 						name="qualification"
 						label="Qualification name"
@@ -157,6 +363,7 @@ function submitHandler(data, node) {
 					/>
 					<FormKit
 						id="qualification_number"
+						v-model="form.qualification_number"
 						type="text"
 						name="qualification_number"
 						label="Qualification number"
@@ -164,17 +371,15 @@ function submitHandler(data, node) {
 						validation="length:0,10"
 						validation-visibility="submit"
 					/>
-					<FormKit
-						id="institution"
-						type="text"
-						name="institution"
-						label="Institution"
-						placeholder="e.g. University of Ghana"
-						validation="length:0,100"
-						validation-visibility="submit"
-					/>
+				</div>
+
+				<!-- Row 4: Year (narrow) -->
+				<div
+					class="w-1/2 sm:w-1/3 xl:w-1/4"
+				>
 					<FormKit
 						id="year"
+						v-model="form.year"
 						type="text"
 						name="year"
 						label="Year of graduation"
@@ -183,109 +388,161 @@ function submitHandler(data, node) {
 						validation-visibility="submit"
 					/>
 				</div>
+
+				<!-- Step 1 actions -->
+				<div
+					class="flex justify-between items-center mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+				>
+					<button
+						type="button"
+						class="text-sm font-semibold text-gray-600 dark:text-gray-300 hover:underline px-3 py-2 transition-colors"
+						@click="emit('close')"
+					>
+						Cancel
+					</button>
+
+					<div class="flex items-center gap-3">
+						<button
+							type="button"
+							class="text-sm text-emerald-600 dark:text-emerald-400 hover:underline px-2 py-2 transition-colors"
+							:disabled="isSubmitting"
+							@click="saveWithoutDocuments"
+						>
+							Save without document
+						</button>
+						<button
+							type="submit"
+							:disabled="isSubmitting"
+							class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Next: Add documents
+						</button>
+					</div>
+				</div>
+			</FormKit>
+		</div>
+
+		<!-- ── STEP 2: Supporting documents ──────────────────────────────── -->
+		<div v-show="currentStep === 2">
+			<div class="flex items-baseline justify-between mb-3">
+				<h3
+					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+				>
+					Supporting documents
+				</h3>
+				<span class="text-[11px] italic text-gray-500 dark:text-gray-400"
+					>Optional — you can add or change documents later.</span
+				>
 			</div>
 
-			<!-- Supporting Document section -->
+			<!-- Server errors for step-2 fields -->
 			<div
-				class="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700"
+				v-if="Object.keys(step2Errors).length"
+				class="mb-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 text-xs text-red-700 dark:text-red-400 space-y-1"
 			>
-				<div class="flex items-baseline justify-between mb-3">
-					<h3
-						class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-					>
-						Supporting document
-					</h3>
-					<span
-						class="text-[11px] italic text-gray-500 dark:text-gray-400"
-						>Optional — you can add or change a document later.</span
-					>
-				</div>
+				<p v-for="(msg, key) in step2Errors" :key="key">
+					{{ msg }}
+				</p>
+			</div>
 
-				<div class="sm:grid sm:grid-cols-2 sm:gap-x-4">
-					<FormKit
-						id="document_type"
-						type="select"
-						name="document_type"
-						label="Document type"
-						placeholder="Select type"
-						:options="documentTypes"
+			<!-- Document type -->
+			<FormKit
+				v-model="form.document_type"
+				type="select"
+				name="document_type"
+				label="Document type"
+				placeholder="Select type"
+				:options="documentTypes"
+				:validation="
+					selectedFiles.length > 0 ? 'required' : ''
+				"
+				validation-visibility="submit"
+			/>
+
+			<!-- File picker -->
+			<div class="mt-1 mb-3">
+				<label
+					class="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1"
+					>Files</label
+				>
+				<label
+					class="inline-flex items-center gap-2 cursor-pointer rounded-lg border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/30 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 hover:border-emerald-400 transition-colors px-4 py-3 text-sm text-gray-600 dark:text-gray-400"
+				>
+					<DocumentIcon class="h-4 w-4 text-gray-400" />
+					Choose files (PDF, JPG, PNG — max 2 MB each)
+					<input
+						type="file"
+						multiple
+						accept=".pdf,.jpg,.jpeg,.png"
+						class="sr-only"
+						@change="onFileInput"
 					/>
-					<FormKit
-						id="document_title"
-						type="text"
-						name="document_title"
-						label="Document title"
-						placeholder="Auto-filled from filename if blank"
-						validation="length:0,100"
-					/>
-				</div>
+				</label>
+			</div>
 
-				<FormKit
-					id="file_name"
-					type="file"
-					name="file_name"
-					label="File"
-					accept=".pdf,.jpg,.jpeg,.png"
-					help="Accepted formats: PDF, JPG, PNG (max 2 MB)."
-					@input="onFileInput"
-				/>
-
-				<!-- Inline file preview -->
-				<div
-					v-if="selectedFile"
-					class="mt-2 flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-2.5"
+			<!-- File list -->
+			<ul
+				v-if="selectedFiles.length > 0"
+				class="space-y-2 mb-4"
+			>
+				<li
+					v-for="(file, index) in selectedFiles"
+					:key="index"
+					class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-2.5"
 				>
 					<div
-						class="w-10 h-10 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center overflow-hidden flex-shrink-0"
+						class="w-9 h-9 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center flex-shrink-0"
 					>
-						<img
-							v-if="previewFileType?.startsWith('image/')"
-							:src="previewUrl"
-							alt=""
-							class="w-full h-full object-cover"
-						/>
-						<DocumentIcon
-							v-else
-							class="h-5 w-5 text-gray-400"
-						/>
+						<DocumentIcon class="h-4 w-4 text-gray-400" />
 					</div>
 					<div class="flex-1 min-w-0 text-xs">
 						<p
 							class="font-semibold text-gray-900 dark:text-gray-100 truncate"
 						>
-							{{ selectedFile.name }}
+							{{ file.name }}
 						</p>
 						<p class="text-gray-500 dark:text-gray-400">
-							{{ (selectedFile.size / 1024).toFixed(0) }} KB &middot;
-							{{ selectedFile.type || "unknown type" }}
+							{{ formatSize(file.size) }} &middot;
+							{{ file.type || "unknown type" }}
 						</p>
 					</div>
-				</div>
-			</div>
+					<button
+						type="button"
+						class="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
+						:aria-label="`Remove ${file.name}`"
+						@click="removeFile(index)"
+					>
+						<XCircleIcon class="h-5 w-5" />
+					</button>
+				</li>
+			</ul>
 
-			<!-- Actions -->
+			<!-- Step 2 actions -->
 			<div
-				class="flex justify-end gap-2 mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+				class="flex justify-between items-center mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
 			>
 				<button
 					type="button"
 					class="text-sm font-semibold text-gray-600 dark:text-gray-300 hover:underline px-3 py-2 transition-colors"
-					@click="emit('close')"
+					:disabled="isSubmitting"
+					@click="goBackToStep1"
 				>
-					Cancel
+					← Back
 				</button>
+
 				<button
-					type="submit"
+					type="button"
 					:disabled="isSubmitting"
 					class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+					@click="submit"
 				>
 					<ArrowPathIcon
 						v-if="isSubmitting"
 						class="w-4 h-4 animate-spin"
 					/>
-					{{ isSubmitting ? "Saving..." : "Save qualification" }}
+					{{ saveLabel }}
 				</button>
 			</div>
-		</FormKit>
+		</div>
 	</main>
 </template>

--- a/resources/js/Pages/Qualification/Add.vue
+++ b/resources/js/Pages/Qualification/Add.vue
@@ -1,29 +1,76 @@
 <script setup>
-import { router } from "@inertiajs/vue3";
 import { ref, onMounted } from "vue";
+import { router } from "@inertiajs/vue3";
 import axios from "axios";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
+import {
+	ArrowPathIcon,
+	XMarkIcon,
+	DocumentIcon,
+} from "@heroicons/vue/24/outline";
 
-const emit = defineEmits(["formSubmitted"]);
+const emit = defineEmits(["formSubmitted", "close"]);
 
-defineProps({
-	person: Number,
+const props = defineProps({
+	person: { type: Number, required: true },
 });
 
 const qualificationLevels = ref([]);
+const documentTypes = ref([]);
 const isSubmitting = ref(false);
+const selectedFile = ref(null);
+const previewUrl = ref(null);
+const previewFileType = ref(null);
 
 onMounted(async () => {
-	const { data } = await axios.get(route("qualification-level.index"));
-	qualificationLevels.value = data;
+	const [levelsRes, typesRes] = await Promise.all([
+		axios.get(route("qualification-level.index")),
+		axios.get(route("document-types")),
+	]);
+	qualificationLevels.value = levelsRes.data;
+	documentTypes.value = typesRes.data;
 });
 
-const submitHandler = (data, node) => {
+function onFileInput(files) {
+	if (files && files.length > 0) {
+		const f = files[0].file;
+		selectedFile.value = f;
+		previewUrl.value = URL.createObjectURL(f);
+		previewFileType.value = f.type;
+	} else {
+		selectedFile.value = null;
+		previewUrl.value = null;
+		previewFileType.value = null;
+	}
+}
+
+function submitHandler(data, node) {
 	isSubmitting.value = true;
-	router.post(route("qualification.store"), data, {
+
+	const formData = new FormData();
+	formData.append("person_id", String(props.person));
+	formData.append("course", data.course ?? "");
+	formData.append("level", data.level ?? "");
+	formData.append("qualification", data.qualification ?? "");
+	formData.append("qualification_number", data.qualification_number ?? "");
+	formData.append("institution", data.institution ?? "");
+	formData.append("year", data.year ?? "");
+
+	if (data.file_name && data.file_name.length > 0) {
+		formData.append("file_name", data.file_name[0].file);
+		formData.append("document_type", data.document_type ?? "");
+		if (data.document_title) {
+			formData.append("document_title", data.document_title);
+		}
+	}
+
+	router.post(route("qualification.store"), formData, {
+		forceFormData: true,
 		preserveScroll: true,
 		onSuccess: () => {
 			node.reset();
+			selectedFile.value = null;
+			previewUrl.value = null;
+			previewFileType.value = null;
 			emit("formSubmitted");
 		},
 		onError: (errors) => {
@@ -33,112 +80,212 @@ const submitHandler = (data, node) => {
 			isSubmitting.value = false;
 		},
 	});
-};
+}
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
-		<h1 class="text-2xl pb-4 dark:text-gray-100">Add Qualification</h1>
+	<main
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm"
+	>
+		<!-- Header -->
+		<header class="flex justify-between items-start mb-5">
+			<div>
+				<h2 class="text-lg font-bold text-gray-900 dark:text-gray-50">
+					Add Qualification
+				</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					Degree, diploma, certificate, or training. Optional certificate
+					upload.
+				</p>
+			</div>
+			<button
+				type="button"
+				class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+				@click="emit('close')"
+			>
+				<XMarkIcon class="h-5 w-5" />
+				<span class="sr-only">Close</span>
+			</button>
+		</header>
+
 		<FormKit
 			type="form"
 			:disabled="isSubmitting"
+			:actions="false"
 			@submit="submitHandler"
 		>
-			<FormKit id="person_id" type="hidden" name="person_id" :value="person" />
-			<FormKit
-				id="institution"
-				type="text"
-				name="institution"
-				label="Institution"
-				validation="string|length:2,100"
-				validation-visibility="submit"
-			/>
-			<div class="sm:flex gap-4">
-				<FormKit
-					id="course"
-					type="text"
-					name="course"
-					label="Course"
-					validation="required|string|length:2,100"
-					validation-visibility="submit"
-				/>
-				<FormKit
-					id="level"
-					type="select"
-					name="level"
-					label="Level"
-					placeholder="Select level"
-					:options="
-						qualificationLevels.map((l) => ({
-							label: l.label,
-							value: l.value,
-						}))
-					"
-					validation-visibility="submit"
-				/>
-			</div>
-			<div class="sm:flex gap-4">
-				<FormKit
-					id="qualification"
-					type="text"
-					name="qualification"
-					label="Qualification"
-					validation="string|length:2,100"
-					validation-visibility="submit"
-				/>
-				<div>
+			<FormKit type="hidden" name="person_id" :value="props.person" />
+
+			<!-- Qualification Details section -->
+			<div>
+				<h3
+					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3"
+				>
+					Qualification details
+				</h3>
+				<div class="sm:grid sm:grid-cols-2 sm:gap-x-4">
+					<FormKit
+						id="course"
+						type="text"
+						name="course"
+						label="Course"
+						placeholder="e.g. BSc Accounting"
+						validation="required|length:2,100"
+						validation-visibility="submit"
+					/>
+					<FormKit
+						id="level"
+						type="select"
+						name="level"
+						label="Level"
+						placeholder="Select level"
+						:options="
+							qualificationLevels.map((l) => ({
+								label: l.label,
+								value: l.value,
+							}))
+						"
+					/>
+					<FormKit
+						id="qualification"
+						type="text"
+						name="qualification"
+						label="Qualification name"
+						placeholder="e.g. Bachelor of Science"
+						validation="length:0,100"
+						validation-visibility="submit"
+					/>
 					<FormKit
 						id="qualification_number"
 						type="text"
 						name="qualification_number"
-						label="Qualification Number"
-						validation="string|length:2,100"
+						label="Qualification number"
+						placeholder="Certificate ID"
+						validation="length:0,10"
+						validation-visibility="submit"
+					/>
+					<FormKit
+						id="institution"
+						type="text"
+						name="institution"
+						label="Institution"
+						placeholder="e.g. University of Ghana"
+						validation="length:0,100"
+						validation-visibility="submit"
+					/>
+					<FormKit
+						id="year"
+						type="text"
+						name="year"
+						label="Year of graduation"
+						placeholder="e.g. 2015"
+						validation="length:0,4|matches:/^[0-9]*$/"
 						validation-visibility="submit"
 					/>
 				</div>
 			</div>
-			<div class="w-1/2 sm:w-1/3 xl:w-1/4">
-				<FormKit
-					id="year"
-					type="text"
-					name="year"
-					label="Year of Graduation"
-					validation="string|length:2,100"
-					validation-visibility="submit"
-				/>
-			</div>
 
-			<!-- Document upload info -->
+			<!-- Supporting Document section -->
 			<div
-				class="mt-4 p-4 bg-blue-50 dark:bg-blue-900/30 rounded-md border border-blue-200 dark:border-blue-800"
+				class="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700"
 			>
-				<p class="text-sm text-blue-700 dark:text-blue-300">
-					<span class="font-medium">Note:</span> You can upload supporting
-					documents (certificates, transcripts) after saving this qualification
-					by editing it.
-				</p>
+				<div class="flex items-baseline justify-between mb-3">
+					<h3
+						class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						Supporting document
+					</h3>
+					<span
+						class="text-[11px] italic text-gray-500 dark:text-gray-400"
+						>Optional — you can add or change a document later.</span
+					>
+				</div>
+
+				<div class="sm:grid sm:grid-cols-2 sm:gap-x-4">
+					<FormKit
+						id="document_type"
+						type="select"
+						name="document_type"
+						label="Document type"
+						placeholder="Select type"
+						:options="documentTypes"
+					/>
+					<FormKit
+						id="document_title"
+						type="text"
+						name="document_title"
+						label="Document title"
+						placeholder="Auto-filled from filename if blank"
+						validation="length:0,100"
+					/>
+				</div>
+
+				<FormKit
+					id="file_name"
+					type="file"
+					name="file_name"
+					label="File"
+					accept=".pdf,.jpg,.jpeg,.png"
+					help="Accepted formats: PDF, JPG, PNG (max 2 MB)."
+					@input="onFileInput"
+				/>
+
+				<!-- Inline file preview -->
+				<div
+					v-if="selectedFile"
+					class="mt-2 flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-2.5"
+				>
+					<div
+						class="w-10 h-10 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center overflow-hidden flex-shrink-0"
+					>
+						<img
+							v-if="previewFileType?.startsWith('image/')"
+							:src="previewUrl"
+							alt=""
+							class="w-full h-full object-cover"
+						/>
+						<DocumentIcon
+							v-else
+							class="h-5 w-5 text-gray-400"
+						/>
+					</div>
+					<div class="flex-1 min-w-0 text-xs">
+						<p
+							class="font-semibold text-gray-900 dark:text-gray-100 truncate"
+						>
+							{{ selectedFile.name }}
+						</p>
+						<p class="text-gray-500 dark:text-gray-400">
+							{{ (selectedFile.size / 1024).toFixed(0) }} KB &middot;
+							{{ selectedFile.type || "unknown type" }}
+						</p>
+					</div>
+				</div>
 			</div>
 
-			<!-- Custom submit button with loading state -->
-			<template #submit>
+			<!-- Actions -->
+			<div
+				class="flex justify-end gap-2 mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+			>
+				<button
+					type="button"
+					class="text-sm font-semibold text-gray-600 dark:text-gray-300 hover:underline px-3 py-2 transition-colors"
+					@click="emit('close')"
+				>
+					Cancel
+				</button>
 				<button
 					type="submit"
 					:disabled="isSubmitting"
-					class="mt-4 inline-flex items-center justify-center px-4 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-sm text-white tracking-widest hover:bg-green-500 active:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+					class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 				>
 					<ArrowPathIcon
 						v-if="isSubmitting"
-						class="w-4 h-4 mr-2 animate-spin"
+						class="w-4 h-4 animate-spin"
 					/>
-					{{ isSubmitting ? "Saving..." : "Create" }}
+					{{ isSubmitting ? "Saving..." : "Save qualification" }}
 				</button>
-			</template>
+			</div>
 		</FormKit>
 	</main>
 </template>
-
-<style scoped>
-.formkit-outer {
-	@apply w-full;
-}
-</style>

--- a/resources/js/Pages/Qualification/AttachDocument.vue
+++ b/resources/js/Pages/Qualification/AttachDocument.vue
@@ -202,17 +202,18 @@ function submit() {
 						<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
 							<select
 								v-model="entry.document_type"
-								class="rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm py-1 px-2"
+								class="rounded border border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-500 text-sm py-1 px-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 dark:focus:ring-emerald-400 dark:focus:border-emerald-400"
 								:class="{
 									'border-red-400 dark:border-red-500':
 										!entry.document_type,
 								}"
 							>
-								<option value="">Select type</option>
+								<option value="" class="text-gray-900 dark:bg-gray-900 dark:text-gray-100">Select type</option>
 								<option
 									v-for="t in documentTypes"
 									:key="t.value"
 									:value="t.value"
+									class="text-gray-900 dark:bg-gray-900 dark:text-gray-100"
 								>
 									{{ t.label }}
 								</option>
@@ -221,7 +222,7 @@ function submit() {
 								v-model.trim="entry.document_title"
 								type="text"
 								placeholder="Title"
-								class="rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm py-1 px-2"
+								class="rounded border border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-500 text-sm py-1 px-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 dark:focus:ring-emerald-400 dark:focus:border-emerald-400"
 								:class="{
 									'border-red-400 dark:border-red-500':
 										!entry.document_title,

--- a/resources/js/Pages/Qualification/AttachDocument.vue
+++ b/resources/js/Pages/Qualification/AttachDocument.vue
@@ -115,7 +115,7 @@ function submit() {
 
 <template>
 	<main
-		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-2xl"
+		class="bg-white dark:bg-gray-800 rounded-2xl p-5 sm:p-6 shadow-sm max-w-2xl"
 	>
 		<header class="flex justify-between items-start mb-5">
 			<div>
@@ -204,11 +204,15 @@ function submit() {
 								v-model="entry.document_type"
 								class="rounded border border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-500 text-sm py-1 px-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 dark:focus:ring-emerald-400 dark:focus:border-emerald-400"
 								:class="{
-									'border-red-400 dark:border-red-500':
-										!entry.document_type,
+									'border-red-400 dark:border-red-500': !entry.document_type,
 								}"
 							>
-								<option value="" class="text-gray-900 dark:bg-gray-900 dark:text-gray-100">Select type</option>
+								<option
+									value=""
+									class="text-gray-900 dark:bg-gray-900 dark:text-gray-100"
+								>
+									Select type
+								</option>
 								<option
 									v-for="t in documentTypes"
 									:key="t.value"
@@ -224,8 +228,7 @@ function submit() {
 								placeholder="Title"
 								class="rounded border border-gray-300 bg-white text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-500 text-sm py-1 px-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 dark:focus:ring-emerald-400 dark:focus:border-emerald-400"
 								:class="{
-									'border-red-400 dark:border-red-500':
-										!entry.document_title,
+									'border-red-400 dark:border-red-500': !entry.document_title,
 								}"
 							/>
 						</div>
@@ -266,9 +269,7 @@ function submit() {
 			<button
 				type="button"
 				:disabled="
-					isSubmitting ||
-					selectedFiles.length === 0 ||
-					hasIncompleteFiles
+					isSubmitting || selectedFiles.length === 0 || hasIncompleteFiles
 				"
 				class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 				@click="submit"

--- a/resources/js/Pages/Qualification/AttachDocument.vue
+++ b/resources/js/Pages/Qualification/AttachDocument.vue
@@ -1,146 +1,280 @@
 <script setup>
+import { ref, computed, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
-import { onMounted, ref } from "vue";
 import axios from "axios";
-import { ArrowPathIcon } from "@heroicons/vue/20/solid";
-import QualificationEvidence from "./partials/QualificationEvidence.vue";
+import {
+	ArrowPathIcon,
+	XMarkIcon,
+	DocumentIcon,
+	XCircleIcon,
+} from "@heroicons/vue/24/outline";
 
 const emit = defineEmits(["formSubmitted", "close"]);
 
 const props = defineProps({
-	qualification: {
-		type: Object,
-		required: true,
-	},
+	qualification: { type: Object, required: true },
 });
 
-const document = ref(null);
 const documentTypes = ref([]);
 const isSubmitting = ref(false);
 
 onMounted(async () => {
-	document.value = props.qualification.documents
-		? props.qualification.documents[0]
-		: null;
-
 	const { data } = await axios.get(route("document-types"));
 	documentTypes.value = data;
 });
 
-const submitHandler = (data, node) => {
-	// Check if file is selected
-	if (!data.file_name || data.file_name.length === 0) {
-		node.setErrors(["Please select a file to upload"]);
+// selectedFiles: [{ file, document_type, document_title, url, preview_type }]
+const selectedFiles = ref([]);
+
+function titleFromFilename(name) {
+	return String(name).replace(/\.[^.]+$/, "");
+}
+
+function onFileInput(event) {
+	const files = Array.from(event.target.files || []);
+	const entries = files.map((f) => ({
+		file: f,
+		document_type: "",
+		document_title: titleFromFilename(f.name),
+		url: URL.createObjectURL(f),
+		preview_type: f.type,
+	}));
+	selectedFiles.value = [...selectedFiles.value, ...entries];
+	event.target.value = "";
+}
+
+function removeFile(index) {
+	const entry = selectedFiles.value[index];
+	if (entry?.url) {
+		URL.revokeObjectURL(entry.url);
+	}
+	selectedFiles.value = selectedFiles.value.filter((_, i) => i !== index);
+}
+
+function formatSize(bytes) {
+	return (bytes / 1024).toFixed(0) + " KB";
+}
+
+const hasIncompleteFiles = computed(() =>
+	selectedFiles.value.some(
+		(e) => !e.document_type || !(e.document_title ?? "").trim(),
+	),
+);
+
+const saveLabel = computed(() => {
+	if (isSubmitting.value) {
+		return "Saving...";
+	}
+	const n = selectedFiles.value.length;
+	if (n === 0) {
+		return "Attach documents";
+	}
+	return `Attach ${n} document${n === 1 ? "" : "s"}`;
+});
+
+const serverErrors = ref({});
+
+function submit() {
+	if (selectedFiles.value.length === 0 || hasIncompleteFiles.value) {
 		return;
 	}
 
+	serverErrors.value = {};
 	isSubmitting.value = true;
 
-	const formData = new FormData();
-	formData.append("file_name", data.file_name[0].file);
-	formData.append("document_type", data.document_type);
-	formData.append(
-		"document_title",
-		data.document_title ?? data.file_name[0].name.split(".")[0],
-	);
-	formData.append("document_status", "P");
-	formData.append("file_type", data.file_name[0].file.type);
+	const fd = new FormData();
+	selectedFiles.value.forEach((entry) => {
+		fd.append("file_name[]", entry.file);
+		fd.append("document_type[]", entry.document_type);
+		fd.append("document_title[]", entry.document_title);
+	});
 
 	router.post(
-		route("qualification-document.update", {
+		route("qualification-document.store", {
 			qualification: props.qualification.id,
 		}),
-		formData,
+		fd,
 		{
+			forceFormData: true,
 			preserveScroll: true,
 			onSuccess: () => {
+				selectedFiles.value.forEach((e) => e.url && URL.revokeObjectURL(e.url));
+				selectedFiles.value = [];
 				emit("formSubmitted");
 			},
 			onError: (errors) => {
-				const errorMsg = {
-					document_type: errors.document_type ?? "",
-					document_title: errors.document_title ?? "",
-					file_name: errors.file_name ?? "",
-				};
-				node.setErrors(["Please fix the errors below"], errorMsg);
+				serverErrors.value = errors;
 			},
 			onFinish: () => {
 				isSubmitting.value = false;
 			},
 		},
 	);
-};
+}
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
-		<div class="flex justify-between items-center pb-4">
-			<h1 class="text-2xl dark:text-gray-100">Attach Document</h1>
+	<main
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-2xl"
+	>
+		<header class="flex justify-between items-start mb-5">
+			<div>
+				<h2 class="text-lg font-bold text-gray-900 dark:text-gray-50">
+					Attach documents
+				</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					{{ qualification.qualification || qualification.course }}
+					<span v-if="qualification.institution">
+						— {{ qualification.institution }}</span
+					>
+					<span v-if="qualification.year">, {{ qualification.year }}</span>
+				</p>
+			</div>
 			<button
 				type="button"
-				class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+				class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
 				@click="emit('close')"
 			>
+				<XMarkIcon class="h-5 w-5" />
 				<span class="sr-only">Close</span>
-				<svg
-					class="h-6 w-6"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke-width="1.5"
-					stroke="currentColor"
-				>
-					<path
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						d="M6 18L18 6M6 6l12 12"
-					/>
-				</svg>
 			</button>
-		</div>
+		</header>
 
-		<div class="mb-4 p-3 bg-gray-200 dark:bg-gray-600 rounded-md">
-			<p class="text-sm text-gray-700 dark:text-gray-200">
-				<span class="font-medium">Qualification:</span>
-				{{ qualification.qualification || qualification.course }}
-			</p>
-			<p class="text-sm text-gray-500 dark:text-gray-300">
-				{{ qualification.institution }} ({{ qualification.year }})
-			</p>
-		</div>
-
-		<FormKit
-			type="form"
-			id="attachDocument"
-			:disabled="isSubmitting"
-			@submit="submitHandler"
+		<!-- Server errors summary -->
+		<div
+			v-if="Object.keys(serverErrors).length"
+			class="mb-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3 text-xs text-red-700 dark:text-red-400 space-y-1"
 		>
-			<QualificationEvidence
-				:document="document"
-				:document-types="documentTypes"
-			/>
+			<p v-for="(msg, key) in serverErrors" :key="key">{{ msg }}</p>
+		</div>
 
-			<template #submit>
-				<div class="flex justify-end gap-3 mt-4">
+		<!-- File picker -->
+		<div class="mb-3">
+			<label
+				class="inline-flex items-center gap-2 cursor-pointer rounded-lg border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/30 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 hover:border-emerald-400 transition-colors px-4 py-3 text-sm text-gray-600 dark:text-gray-400"
+			>
+				<DocumentIcon class="h-4 w-4 text-gray-400" />
+				Choose files (PDF, JPG, PNG — max 2 MB each)
+				<input
+					type="file"
+					multiple
+					accept=".pdf,.jpg,.jpeg,.png"
+					class="sr-only"
+					@change="onFileInput"
+				/>
+			</label>
+		</div>
+
+		<!-- Per-file rows with preview -->
+		<ul v-if="selectedFiles.length > 0" class="space-y-3 mb-4">
+			<li
+				v-for="(entry, index) in selectedFiles"
+				:key="index"
+				class="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-3"
+			>
+				<div class="flex items-start gap-3">
+					<!-- Preview -->
+					<div
+						class="w-16 h-16 rounded bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 flex items-center justify-center overflow-hidden flex-shrink-0"
+					>
+						<img
+							v-if="entry.preview_type?.startsWith('image/')"
+							:src="entry.url"
+							alt=""
+							class="w-full h-full object-cover"
+						/>
+						<DocumentIcon v-else class="h-6 w-6 text-gray-400" />
+					</div>
+
+					<!-- Metadata -->
+					<div class="flex-1 min-w-0 space-y-2">
+						<div>
+							<p
+								class="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate"
+							>
+								{{ entry.file.name }}
+							</p>
+							<p class="text-[11px] text-gray-500 dark:text-gray-400">
+								{{ formatSize(entry.file.size) }} ·
+								{{ entry.file.type || "unknown type" }}
+							</p>
+						</div>
+						<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+							<select
+								v-model="entry.document_type"
+								class="rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm py-1 px-2"
+								:class="{
+									'border-red-400 dark:border-red-500':
+										!entry.document_type,
+								}"
+							>
+								<option value="">Select type</option>
+								<option
+									v-for="t in documentTypes"
+									:key="t.value"
+									:value="t.value"
+								>
+									{{ t.label }}
+								</option>
+							</select>
+							<input
+								v-model.trim="entry.document_title"
+								type="text"
+								placeholder="Title"
+								class="rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 text-sm py-1 px-2"
+								:class="{
+									'border-red-400 dark:border-red-500':
+										!entry.document_title,
+								}"
+							/>
+						</div>
+					</div>
+
+					<!-- Remove -->
 					<button
 						type="button"
-						class="inline-flex items-center justify-center px-4 py-2 bg-gray-300 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-sm text-gray-700 dark:text-gray-200 tracking-widest hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150"
-						@click="emit('close')"
+						class="text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors flex-shrink-0"
+						:aria-label="`Remove ${entry.file.name}`"
+						@click="removeFile(index)"
 					>
-						Cancel
-					</button>
-					<button
-						type="submit"
-						:disabled="isSubmitting"
-						class="inline-flex items-center justify-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-sm text-white tracking-widest hover:bg-blue-500 active:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
-					>
-						<ArrowPathIcon
-							v-if="isSubmitting"
-							class="w-4 h-4 mr-2 animate-spin"
-						/>
-						{{ isSubmitting ? "Uploading..." : "Upload Document" }}
+						<XCircleIcon class="h-5 w-5" />
 					</button>
 				</div>
-			</template>
-		</FormKit>
+			</li>
+		</ul>
+
+		<div
+			v-if="hasIncompleteFiles"
+			class="mb-3 text-[11px] text-amber-700 dark:text-amber-300"
+		>
+			Each file needs a document type and title before you can save.
+		</div>
+
+		<!-- Footer -->
+		<div
+			class="flex justify-end gap-2 mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+		>
+			<button
+				type="button"
+				class="text-sm font-semibold text-gray-600 dark:text-gray-300 hover:underline px-3 py-2 transition-colors"
+				:disabled="isSubmitting"
+				@click="emit('close')"
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				:disabled="
+					isSubmitting ||
+					selectedFiles.length === 0 ||
+					hasIncompleteFiles
+				"
+				class="inline-flex items-center gap-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-bold text-white shadow-sm disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				@click="submit"
+			>
+				<ArrowPathIcon v-if="isSubmitting" class="w-4 h-4 animate-spin" />
+				{{ saveLabel }}
+			</button>
+		</div>
 	</main>
 </template>

--- a/resources/js/Pages/Qualification/View.vue
+++ b/resources/js/Pages/Qualification/View.vue
@@ -81,7 +81,7 @@ function confirmDeleteDocument() {
 
 <template>
 	<main
-		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-3xl"
+		class="bg-white dark:bg-gray-800 rounded-2xl p-5 sm:p-6 shadow-sm max-w-3xl"
 	>
 		<header class="flex justify-between items-start mb-5">
 			<div>
@@ -161,9 +161,7 @@ function confirmDeleteDocument() {
 
 					<!-- Confirming state: inline prompt -->
 					<div v-else class="flex items-center gap-2">
-						<span
-							class="text-xs text-red-600 dark:text-red-400 font-medium"
-						>
+						<span class="text-xs text-red-600 dark:text-red-400 font-medium">
 							Delete this document?
 						</span>
 						<button

--- a/resources/js/Pages/Qualification/View.vue
+++ b/resources/js/Pages/Qualification/View.vue
@@ -1,155 +1,221 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
+import { router } from "@inertiajs/vue3";
 import { XMarkIcon } from "@heroicons/vue/24/outline";
 import DocumentPreview from "./partials/DocumentPreview.vue";
 
 const emit = defineEmits(["close"]);
 
 const props = defineProps({
-    qualification: { type: Object, required: true },
+	qualification: { type: Object, required: true },
 });
 
 const documents = computed(() => props.qualification.documents ?? []);
 const currentDoc = ref(0);
+const confirming = ref(false);
+
+// Reset confirm state whenever the current document changes.
+watch(currentDoc, () => {
+	confirming.value = false;
+});
 
 const detailRows = computed(() =>
-    [
-        { key: "Course", value: props.qualification.course },
-        { key: "Qualification name", value: props.qualification.qualification },
-        {
-            key: "Qualification number",
-            value: props.qualification.qualification_number,
-        },
-        { key: "Institution", value: props.qualification.institution },
-        { key: "Level", value: props.qualification.level },
-        { key: "Year", value: props.qualification.year },
-    ].filter((r) => r.value),
+	[
+		{ key: "Course", value: props.qualification.course },
+		{ key: "Qualification name", value: props.qualification.qualification },
+		{
+			key: "Qualification number",
+			value: props.qualification.qualification_number,
+		},
+		{ key: "Institution", value: props.qualification.institution },
+		{ key: "Level", value: props.qualification.level },
+		{ key: "Year", value: props.qualification.year },
+	].filter((r) => r.value),
 );
 
 function statusClass(status) {
-    const tone = (status ?? "").toLowerCase();
-    if (tone.includes("approved")) {
-        return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200";
-    }
-    if (tone.includes("pending")) {
-        return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
-    }
-    if (tone.includes("rejected")) {
-        return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
-    }
-    return "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200";
+	const tone = (status ?? "").toLowerCase();
+	if (tone.includes("approved")) {
+		return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200";
+	}
+	if (tone.includes("pending")) {
+		return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
+	}
+	if (tone.includes("rejected")) {
+		return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
+	}
+	return "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200";
 }
 
 function docUrl(doc) {
-    return doc?.file_name ? `/storage/qualifications/${doc.file_name}` : null;
+	return doc?.file_name ? `/storage/qualifications/${doc.file_name}` : null;
+}
+
+function confirmDeleteDocument() {
+	const doc = documents.value[currentDoc.value];
+	if (!doc) {
+		return;
+	}
+
+	router.delete(
+		route("qualification-document.destroy", {
+			qualification: props.qualification.id,
+			document: doc.id,
+		}),
+		{
+			preserveScroll: true,
+			onSuccess: () => {
+				if (
+					currentDoc.value >= documents.value.length - 1 &&
+					currentDoc.value > 0
+				) {
+					currentDoc.value -= 1;
+				}
+				router.reload({ only: ["qualifications"] });
+				confirming.value = false;
+			},
+		},
+	);
 }
 </script>
 
 <template>
-    <main
-        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-3xl"
-    >
-        <header class="flex justify-between items-start mb-5">
-            <div>
-                <h2 class="text-lg font-bold text-gray-900 dark:text-gray-50">
-                    Qualification details
-                </h2>
-                <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                    Read-only preview of your qualification and attached
-                    documents.
-                </p>
-            </div>
-            <button
-                type="button"
-                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
-                @click="emit('close')"
-            >
-                <XMarkIcon class="h-5 w-5" />
-                <span class="sr-only">Close</span>
-            </button>
-        </header>
+	<main
+		class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-3xl"
+	>
+		<header class="flex justify-between items-start mb-5">
+			<div>
+				<h2 class="text-lg font-bold text-gray-900 dark:text-gray-50">
+					Qualification details
+				</h2>
+				<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+					Read-only preview of your qualification and attached documents.
+				</p>
+			</div>
+			<button
+				type="button"
+				class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+				@click="emit('close')"
+			>
+				<XMarkIcon class="h-5 w-5" />
+				<span class="sr-only">Close</span>
+			</button>
+		</header>
 
-        <!-- Details -->
-        <section>
-            <div class="flex items-start justify-between mb-3">
-                <h3
-                    class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
-                >
-                    Details
-                </h3>
-                <span
-                    v-if="qualification.status"
-                    :class="[
-                        'text-[11px] font-semibold px-2.5 py-1 rounded-full',
-                        statusClass(qualification.status),
-                    ]"
-                >
-                    {{ qualification.status }}
-                </span>
-            </div>
-            <dl
-                class="divide-y divide-gray-100 dark:divide-gray-700 text-sm"
-            >
-                <div
-                    v-for="row in detailRows"
-                    :key="row.key"
-                    class="flex justify-between gap-2 py-1.5"
-                >
-                    <dt class="text-gray-500 dark:text-gray-400 shrink-0">
-                        {{ row.key }}
-                    </dt>
-                    <dd
-                        class="min-w-0 text-right font-medium text-gray-900 dark:text-gray-100 truncate"
-                    >
-                        {{ row.value }}
-                    </dd>
-                </div>
-            </dl>
-        </section>
+		<!-- Details -->
+		<section>
+			<div class="flex items-start justify-between mb-3">
+				<h3
+					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+				>
+					Details
+				</h3>
+				<span
+					v-if="qualification.status"
+					:class="[
+						'text-[11px] font-semibold px-2.5 py-1 rounded-full',
+						statusClass(qualification.status),
+					]"
+				>
+					{{ qualification.status }}
+				</span>
+			</div>
+			<dl class="divide-y divide-gray-100 dark:divide-gray-700 text-sm">
+				<div
+					v-for="row in detailRows"
+					:key="row.key"
+					class="flex justify-between gap-2 py-1.5"
+				>
+					<dt class="text-gray-500 dark:text-gray-400 shrink-0">
+						{{ row.key }}
+					</dt>
+					<dd
+						class="min-w-0 text-right font-medium text-gray-900 dark:text-gray-100 truncate"
+					>
+						{{ row.value }}
+					</dd>
+				</div>
+			</dl>
+		</section>
 
-        <!-- Documents -->
-        <section
-            class="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700"
-        >
-            <h3
-                class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3"
-            >
-                Documents ({{ documents.length }})
-            </h3>
-            <div
-                v-if="documents.length === 0"
-                class="text-sm text-gray-500 dark:text-gray-400 py-2"
-            >
-                No documents attached.
-            </div>
-            <DocumentPreview
-                v-else
-                :url="docUrl(documents[currentDoc])"
-                :type="documents[currentDoc]?.file_type"
-                :title="
-                    documents[currentDoc]?.document_title ||
-                    documents[currentDoc]?.document_type
-                "
-                :current-index="currentDoc"
-                :total-count="documents.length"
-                @prev="currentDoc = Math.max(0, currentDoc - 1)"
-                @next="
-                    currentDoc = Math.min(documents.length - 1, currentDoc + 1)
-                "
-            />
-        </section>
+		<!-- Documents -->
+		<section class="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700">
+			<div class="flex items-center justify-between mb-3">
+				<h3
+					class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+				>
+					Documents ({{ documents.length }})
+				</h3>
 
-        <!-- Footer -->
-        <div
-            class="flex justify-end mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
-        >
-            <button
-                type="button"
-                class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors"
-                @click="emit('close')"
-            >
-                Close
-            </button>
-        </div>
-    </main>
+				<!-- Delete control — only for editable qualifications with documents -->
+				<template v-if="qualification.can_edit && documents.length > 0">
+					<!-- Normal state: show Delete button -->
+					<button
+						v-if="!confirming"
+						type="button"
+						class="text-red-600 dark:text-red-400 hover:underline text-xs font-semibold"
+						@click="confirming = true"
+					>
+						Delete this document
+					</button>
+
+					<!-- Confirming state: inline prompt -->
+					<div v-else class="flex items-center gap-2">
+						<span
+							class="text-xs text-red-600 dark:text-red-400 font-medium"
+						>
+							Delete this document?
+						</span>
+						<button
+							type="button"
+							class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+							@click="confirming = false"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							class="inline-flex items-center rounded bg-red-600 hover:bg-red-700 px-2 py-0.5 text-xs font-semibold text-white transition-colors"
+							@click="confirmDeleteDocument"
+						>
+							Confirm delete
+						</button>
+					</div>
+				</template>
+			</div>
+
+			<div
+				v-if="documents.length === 0"
+				class="text-sm text-gray-500 dark:text-gray-400 py-2"
+			>
+				No documents attached.
+			</div>
+			<DocumentPreview
+				v-else
+				:url="docUrl(documents[currentDoc])"
+				:type="documents[currentDoc]?.file_type"
+				:title="
+					documents[currentDoc]?.document_title ||
+					documents[currentDoc]?.document_type
+				"
+				:current-index="currentDoc"
+				:total-count="documents.length"
+				@prev="currentDoc = Math.max(0, currentDoc - 1)"
+				@next="currentDoc = Math.min(documents.length - 1, currentDoc + 1)"
+			/>
+		</section>
+
+		<!-- Footer -->
+		<div
+			class="flex justify-end mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+		>
+			<button
+				type="button"
+				class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors"
+				@click="emit('close')"
+			>
+				Close
+			</button>
+		</div>
+	</main>
 </template>

--- a/resources/js/Pages/Qualification/View.vue
+++ b/resources/js/Pages/Qualification/View.vue
@@ -1,0 +1,155 @@
+<script setup>
+import { ref, computed } from "vue";
+import { XMarkIcon } from "@heroicons/vue/24/outline";
+import DocumentPreview from "./partials/DocumentPreview.vue";
+
+const emit = defineEmits(["close"]);
+
+const props = defineProps({
+    qualification: { type: Object, required: true },
+});
+
+const documents = computed(() => props.qualification.documents ?? []);
+const currentDoc = ref(0);
+
+const detailRows = computed(() =>
+    [
+        { key: "Course", value: props.qualification.course },
+        { key: "Qualification name", value: props.qualification.qualification },
+        {
+            key: "Qualification number",
+            value: props.qualification.qualification_number,
+        },
+        { key: "Institution", value: props.qualification.institution },
+        { key: "Level", value: props.qualification.level },
+        { key: "Year", value: props.qualification.year },
+    ].filter((r) => r.value),
+);
+
+function statusClass(status) {
+    const tone = (status ?? "").toLowerCase();
+    if (tone.includes("approved")) {
+        return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200";
+    }
+    if (tone.includes("pending")) {
+        return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
+    }
+    if (tone.includes("rejected")) {
+        return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
+    }
+    return "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200";
+}
+
+function docUrl(doc) {
+    return doc?.file_name ? `/storage/qualifications/${doc.file_name}` : null;
+}
+</script>
+
+<template>
+    <main
+        class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl p-5 sm:p-6 shadow-sm max-w-3xl"
+    >
+        <header class="flex justify-between items-start mb-5">
+            <div>
+                <h2 class="text-lg font-bold text-gray-900 dark:text-gray-50">
+                    Qualification details
+                </h2>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Read-only preview of your qualification and attached
+                    documents.
+                </p>
+            </div>
+            <button
+                type="button"
+                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                @click="emit('close')"
+            >
+                <XMarkIcon class="h-5 w-5" />
+                <span class="sr-only">Close</span>
+            </button>
+        </header>
+
+        <!-- Details -->
+        <section>
+            <div class="flex items-start justify-between mb-3">
+                <h3
+                    class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                >
+                    Details
+                </h3>
+                <span
+                    v-if="qualification.status"
+                    :class="[
+                        'text-[11px] font-semibold px-2.5 py-1 rounded-full',
+                        statusClass(qualification.status),
+                    ]"
+                >
+                    {{ qualification.status }}
+                </span>
+            </div>
+            <dl
+                class="divide-y divide-gray-100 dark:divide-gray-700 text-sm"
+            >
+                <div
+                    v-for="row in detailRows"
+                    :key="row.key"
+                    class="flex justify-between gap-2 py-1.5"
+                >
+                    <dt class="text-gray-500 dark:text-gray-400 shrink-0">
+                        {{ row.key }}
+                    </dt>
+                    <dd
+                        class="min-w-0 text-right font-medium text-gray-900 dark:text-gray-100 truncate"
+                    >
+                        {{ row.value }}
+                    </dd>
+                </div>
+            </dl>
+        </section>
+
+        <!-- Documents -->
+        <section
+            class="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700"
+        >
+            <h3
+                class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-3"
+            >
+                Documents ({{ documents.length }})
+            </h3>
+            <div
+                v-if="documents.length === 0"
+                class="text-sm text-gray-500 dark:text-gray-400 py-2"
+            >
+                No documents attached.
+            </div>
+            <DocumentPreview
+                v-else
+                :url="docUrl(documents[currentDoc])"
+                :type="documents[currentDoc]?.file_type"
+                :title="
+                    documents[currentDoc]?.document_title ||
+                    documents[currentDoc]?.document_type
+                "
+                :current-index="currentDoc"
+                :total-count="documents.length"
+                @prev="currentDoc = Math.max(0, currentDoc - 1)"
+                @next="
+                    currentDoc = Math.min(documents.length - 1, currentDoc + 1)
+                "
+            />
+        </section>
+
+        <!-- Footer -->
+        <div
+            class="flex justify-end mt-6 pt-4 border-t border-gray-100 dark:border-gray-700"
+        >
+            <button
+                type="button"
+                class="inline-flex items-center rounded-lg bg-emerald-600 hover:bg-emerald-700 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors"
+                @click="emit('close')"
+            >
+                Close
+            </button>
+        </div>
+    </main>
+</template>

--- a/resources/js/Pages/Staff/PersonQualifications.vue
+++ b/resources/js/Pages/Staff/PersonQualifications.vue
@@ -165,7 +165,12 @@ const attachDocument = (model) => {
 		<NewModal :show="openAttachModal" @close="toggleAttachModal()">
 			<AttachDocument
 				:qualification="qualificationModel"
-				@form-submitted="toggleAttachModal()"
+				@form-submitted="
+					() => {
+						toggleAttachModal();
+						router.reload();
+					}
+				"
 				@close="toggleAttachModal()"
 			/>
 		</NewModal>

--- a/routes/web.php
+++ b/routes/web.php
@@ -405,6 +405,7 @@ Route::get('/document-statuses', function () {
 })->middleware(['auth', 'password_changed'])->name('document-statuses');
 
 Route::controller(QualificationDocumentController::class)->middleware(['auth', 'password_changed'])->group(function () {
+    Route::post('/qualification/{qualification}/document/store', 'store')->name('qualification-document.store');
     Route::post('/qualification/{qualification}/document', 'update')->name('qualification-document.update');
     Route::delete('/qualification/{qualification}/document', 'delete')->name('qualification-document.delete');
     Route::delete('/qualification/{qualification}/document/{document}', 'destroy')->name('qualification-document.destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -407,6 +407,7 @@ Route::get('/document-statuses', function () {
 Route::controller(QualificationDocumentController::class)->middleware(['auth', 'password_changed'])->group(function () {
     Route::post('/qualification/{qualification}/document', 'update')->name('qualification-document.update');
     Route::delete('/qualification/{qualification}/document', 'delete')->name('qualification-document.delete');
+    Route::delete('/qualification/{qualification}/document/{document}', 'destroy')->name('qualification-document.destroy');
 });
 
 // report

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ use App\Http\Controllers\PermissionController;
 use App\Http\Controllers\PersonAvatarController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\PersonRolesController;
+use App\Http\Controllers\PhotoApprovalController;
 use App\Http\Controllers\PositionController;
 use App\Http\Controllers\PromoteAllStaffController;
 use App\Http\Controllers\PromoteStaffController;
@@ -167,6 +168,18 @@ Route::delete('person/{person}/avatar/delete', [PersonAvatarController::class, '
 Route::middleware(['auth', 'password_changed'])
     ->get('/my-profile', [MyProfileController::class, 'show'])
     ->name('my-profile.show');
+
+Route::middleware(['auth', 'password_changed'])->group(function () {
+    Route::get('/staff-photo-approvals', [PhotoApprovalController::class, 'index'])
+        ->middleware('can:approve staff photo')
+        ->name('photo-approvals.index');
+    Route::post('/staff-photo-approvals/{person}/approve', [PhotoApprovalController::class, 'approve'])
+        ->middleware('can:approve staff photo')
+        ->name('photo-approvals.approve');
+    Route::post('/staff-photo-approvals/{person}/reject', [PhotoApprovalController::class, 'reject'])
+        ->middleware('can:approve staff photo')
+        ->name('photo-approvals.reject');
+});
 
 // Institution
 Route::controller(InstitutionController::class)->middleware(['auth', 'password_changed'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\InstitutionStatusController;
 use App\Http\Controllers\JobCategoryController;
 use App\Http\Controllers\JobController;
 use App\Http\Controllers\MaritalStatusController;
+use App\Http\Controllers\MyProfileController;
 use App\Http\Controllers\NationalityController;
 use App\Http\Controllers\NoteController;
 use App\Http\Controllers\OfficeController;
@@ -160,6 +161,10 @@ Route::get('person/{person}/roles', [PersonRolesController::class, 'show'])->nam
 Route::get('person/{person}/dependent', [PersonRolesController::class, 'dependent'])->name('person-roles.dependent');
 Route::post('person/{person}/avatar', [PersonAvatarController::class, 'update'])->middleware(['auth', 'password_changed'])->name('person.avatar.update');
 Route::delete('person/{person}/avatar/delete', [PersonAvatarController::class, 'delete'])->middleware(['auth', 'password_changed'])->name('person.avatar.delete');
+
+Route::middleware(['auth', 'password_changed'])
+    ->get('/my-profile', [MyProfileController::class, 'show'])
+    ->name('my-profile.show');
 
 // Institution
 Route::controller(InstitutionController::class)->middleware(['auth', 'password_changed'])->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -154,6 +154,7 @@ Route::controller(PersonController::class)->middleware(['auth', 'password_change
     Route::delete('/person/{person}/contact/{contact}', 'deleteContact')->name('person.contact.delete');
     Route::post('/person/{person}/address', 'addAddress')->name('person.address.create');
     Route::patch('/person/{person}/address/{address}', 'updateAddress')->middleware('can:update contacts')->name('person.address.update');
+    Route::post('/person/{person}/address/change', 'changeAddress')->middleware('can:update contacts')->name('person.address.change');
     Route::delete('/person/{person}/address/{address}', 'deleteAddress')->name('person.address.delete');
     // Route::get('/person/avatar', 'avatar')->name('person.ava');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -153,6 +153,7 @@ Route::controller(PersonController::class)->middleware(['auth', 'password_change
     Route::post('/person/{person}/contact/{contact}', 'updateContact')->name('person.contact.update');
     Route::delete('/person/{person}/contact/{contact}', 'deleteContact')->name('person.contact.delete');
     Route::post('/person/{person}/address', 'addAddress')->name('person.address.create');
+    Route::patch('/person/{person}/address/{address}', 'updateAddress')->middleware('can:update contacts')->name('person.address.update');
     Route::delete('/person/{person}/address/{address}', 'deleteAddress')->name('person.address.delete');
     // Route::get('/person/avatar', 'avatar')->name('person.ava');
 });

--- a/tests/Feature/Contacts/ContactAuthorizationTest.php
+++ b/tests/Feature/Contacts/ContactAuthorizationTest.php
@@ -80,6 +80,11 @@ class ContactAuthorizationTest extends TestCase
         $person = Person::factory()->create();
         $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
         $user->givePermissionTo('delete contacts');
+        Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::PHONE->value,
+            'contact' => '0244000001',
+        ]);
         $contact = Contact::factory()->create([
             'person_id' => $person->id,
             'contact_type' => ContactTypeEnum::PHONE->value,
@@ -91,5 +96,23 @@ class ContactAuthorizationTest extends TestCase
             ->assertRedirect();
 
         $this->assertSoftDeleted('contacts', ['id' => $contact->id]);
+    }
+
+    public function test_contact_destroy_route_also_blocks_deleting_last_phone(): void
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('delete contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::PHONE->value,
+            'contact' => '0244123456',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('contact.destroy', ['contact' => $contact->id]))
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertNotSoftDeleted('contacts', ['id' => $contact->id]);
     }
 }

--- a/tests/Feature/Contacts/ContactAuthorizationTest.php
+++ b/tests/Feature/Contacts/ContactAuthorizationTest.php
@@ -133,4 +133,25 @@ class ContactAuthorizationTest extends TestCase
 
         $this->assertNotSoftDeleted('contacts', ['id' => $contact->id]);
     }
+
+    public function test_contact_update_route_also_blocks_updating_audit_gov_gh_email(): void
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('update contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => 'staff@audit.gov.gh',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('contact.update', ['contact' => $contact->id]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'someone-else@gmail.com',
+            ])
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertSame('staff@audit.gov.gh', $contact->fresh()->contact);
+    }
 }

--- a/tests/Feature/Contacts/ContactAuthorizationTest.php
+++ b/tests/Feature/Contacts/ContactAuthorizationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature\Contacts;
+
+use App\Enums\ContactTypeEnum;
+use App\Models\Contact;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContactAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_update_own_contact(): void
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('update contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => 'old@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('contact.update', ['contact' => $contact->id]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'new@example.org',
+            ])
+            ->assertRedirect();
+
+        $this->assertSame('new@example.org', $contact->fresh()->contact);
+    }
+
+    public function test_user_cannot_update_another_persons_contact(): void
+    {
+        $me = Person::factory()->create();
+        $someone = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $me->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('update contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $someone->id,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => 'theirs@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('contact.update', ['contact' => $contact->id]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'hijacked@example.org',
+            ])
+            ->assertForbidden();
+
+        $this->assertSame('theirs@example.org', $contact->fresh()->contact);
+    }
+
+    public function test_user_cannot_delete_another_persons_contact(): void
+    {
+        $me = Person::factory()->create();
+        $someone = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $me->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('delete contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $someone->id,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => 'theirs@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('contact.destroy', ['contact' => $contact->id]))
+            ->assertForbidden();
+
+        $this->assertNotNull($contact->fresh());
+    }
+
+    public function test_user_can_delete_own_contact(): void
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('delete contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::PHONE->value,
+            'contact' => '0244123456',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('contact.destroy', ['contact' => $contact->id]))
+            ->assertRedirect();
+
+        $this->assertSoftDeleted('contacts', ['id' => $contact->id]);
+    }
+}

--- a/tests/Feature/Contacts/ContactAuthorizationTest.php
+++ b/tests/Feature/Contacts/ContactAuthorizationTest.php
@@ -115,4 +115,22 @@ class ContactAuthorizationTest extends TestCase
 
         $this->assertNotSoftDeleted('contacts', ['id' => $contact->id]);
     }
+
+    public function test_contact_destroy_route_also_blocks_deleting_audit_gov_gh_email(): void
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->givePermissionTo('delete contacts');
+        $contact = Contact::factory()->create([
+            'person_id' => $person->id,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => 'staff@audit.gov.gh',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('contact.destroy', ['contact' => $contact->id]))
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertNotSoftDeleted('contacts', ['id' => $contact->id]);
+    }
 }

--- a/tests/Feature/MyProfile/CompletionBannerDataTest.php
+++ b/tests/Feature/MyProfile/CompletionBannerDataTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\Institution;
+use App\Models\InstitutionPerson;
+use App\Models\Qualification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Guards the shared-prop contract that the CompletionBanner component
+ * reads from. The banner has no server-rendered output, but its
+ * `shouldShow` predicate depends entirely on `auth.user.person_id`,
+ * `auth.has_photo`, and `auth.qualifications_count` being present on
+ * the admin landing page (`institution.show`). If any of those three
+ * disappears, the banner silently stops nagging users who haven't
+ * completed their profiles — we catch that here.
+ */
+class CompletionBannerDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_institution_landing_exposes_banner_props_when_profile_incomplete(): void
+    {
+        $institution = Institution::factory()->create();
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('super-administrator');
+
+        $this->actingAs($user)
+            ->get(route('institution.show', $institution))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.user.person_id', $staff->person_id)
+                ->where('auth.has_photo', false)
+                ->where('auth.qualifications_count', 0)
+            );
+    }
+
+    public function test_institution_landing_banner_props_reflect_completed_profile(): void
+    {
+        $institution = Institution::factory()->create();
+        $staff = $this->createActiveStaff();
+        $staff->person->update(['image' => 'avatars/example.jpg']);
+        Qualification::factory()->create(['person_id' => $staff->person_id]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('super-administrator');
+
+        $this->actingAs($user)
+            ->get(route('institution.show', $institution))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.has_photo', true)
+                ->where('auth.qualifications_count', 1)
+            );
+    }
+
+    public function test_institution_landing_returns_null_banner_props_for_unlinked_user(): void
+    {
+        $institution = Institution::factory()->create();
+        $user = User::factory()->create(['person_id' => null]);
+        $user->assignRole('super-administrator');
+
+        $this->actingAs($user)
+            ->get(route('institution.show', $institution))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.user.person_id', null)
+                ->where('auth.has_photo', null)
+                ->where('auth.qualifications_count', null)
+            );
+    }
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/MyProfile/MyProfileAddressChangeTest.php
+++ b/tests/Feature/MyProfile/MyProfileAddressChangeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\Address;
+use App\Models\InstitutionPerson;
+use App\Models\Person;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileAddressChangeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_staff_can_change_own_address_and_previous_is_archived(): void
+    {
+        $user = $this->staffUser();
+        $person = Person::find($user->person_id);
+
+        $oldAddress = $this->createAddressForPerson($person);
+
+        $this->actingAs($user)
+            ->post(route('person.address.change', ['person' => $person->id]), [
+                'address_line_1' => '99 New Street',
+                'address_line_2' => null,
+                'city' => 'NewCity',
+                'region' => null,
+                'country' => 'GH',
+                'post_code' => null,
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        // Old address should now have a valid_end date
+        $this->assertNotNull($oldAddress->fresh()->valid_end);
+        $this->assertEquals(now()->toDateString(), $oldAddress->fresh()->valid_end);
+
+        // New active address should exist
+        $this->assertDatabaseHas('addresses', [
+            'addressable_type' => (new Person)->getMorphClass(),
+            'addressable_id' => $person->id,
+            'address_line_1' => '99 New Street',
+            'city' => 'NewCity',
+            'valid_end' => null,
+        ]);
+    }
+
+    public function test_address_change_requires_address_line_1_city_and_country(): void
+    {
+        $user = $this->staffUser();
+        $person = Person::find($user->person_id);
+
+        $this->createAddressForPerson($person);
+        $countBefore = $person->address()->count();
+
+        $this->actingAs($user)
+            ->post(route('person.address.change', ['person' => $person->id]), [
+                'address_line_1' => '',
+                'city' => '',
+                'country' => '',
+            ])
+            ->assertSessionHasErrors(['address_line_1', 'city', 'country']);
+
+        // No new row should have been created
+        $this->assertEquals($countBefore, $person->address()->count());
+    }
+
+    public function test_staff_cannot_change_another_persons_address(): void
+    {
+        $me = $this->staffUser();
+
+        $other = InstitutionPerson::factory()->create();
+        $otherPerson = Person::find($other->person_id);
+        $otherAddress = $this->createAddressForPerson($otherPerson);
+
+        $this->actingAs($me)
+            ->post(route('person.address.change', ['person' => $otherPerson->id]), [
+                'address_line_1' => 'Hacker Lane',
+                'city' => 'HackCity',
+                'country' => 'GH',
+            ])
+            ->assertForbidden();
+
+        // Other person's address should remain unchanged
+        $this->assertNull($otherAddress->fresh()->valid_end);
+        $this->assertDatabaseMissing('addresses', [
+            'addressable_id' => $otherPerson->id,
+            'address_line_1' => 'Hacker Lane',
+        ]);
+    }
+
+    public function test_address_change_when_no_active_address_exists_creates_first_one(): void
+    {
+        $user = $this->staffUser();
+        $person = Person::find($user->person_id);
+
+        // Confirm no addresses exist
+        $this->assertEquals(0, $person->address()->count());
+
+        $this->actingAs($user)
+            ->post(route('person.address.change', ['person' => $person->id]), [
+                'address_line_1' => '1 First Ave',
+                'address_line_2' => null,
+                'city' => 'FirstCity',
+                'region' => null,
+                'country' => 'GH',
+                'post_code' => null,
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('addresses', [
+            'addressable_type' => (new Person)->getMorphClass(),
+            'addressable_id' => $person->id,
+            'address_line_1' => '1 First Ave',
+            'city' => 'FirstCity',
+            'valid_end' => null,
+        ]);
+
+        $this->assertEquals(1, $person->address()->count());
+    }
+
+    private function staffUser(): User
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('staff');
+
+        return $user;
+    }
+
+    private function createAddressForPerson(Person $person): Address
+    {
+        return $person->address()->create([
+            'address_line_1' => '1 Original Road',
+            'address_line_2' => null,
+            'city' => 'OriginalCity',
+            'region' => 'OriginalRegion',
+            'country' => 'GH',
+            'post_code' => '00100',
+        ]);
+    }
+}

--- a/tests/Feature/MyProfile/MyProfileAddressUpdateTest.php
+++ b/tests/Feature/MyProfile/MyProfileAddressUpdateTest.php
@@ -66,6 +66,29 @@ class MyProfileAddressUpdateTest extends TestCase
         ]);
     }
 
+    public function test_address_update_requires_address_line_1_city_and_country(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->givePermissionTo(Permission::firstOrCreate(['name' => 'update contacts']));
+
+        $address = $this->createAddressForPerson($staff->person);
+
+        $this->actingAs($user)
+            ->patch(route('person.address.update', ['person' => $staff->person_id, 'address' => $address->id]), [
+                'address_line_1' => '',
+                'city' => '',
+                'country' => '',
+            ])
+            ->assertSessionHasErrors(['address_line_1', 'city', 'country']);
+
+        // Row should remain unchanged
+        $this->assertDatabaseHas('addresses', [
+            'id' => $address->id,
+            'address_line_1' => '1 Original Road',
+        ]);
+    }
+
     public function test_unauthenticated_user_is_redirected_to_login(): void
     {
         $staff = $this->createActiveStaff();

--- a/tests/Feature/MyProfile/MyProfileAddressUpdateTest.php
+++ b/tests/Feature/MyProfile/MyProfileAddressUpdateTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\Address;
+use App\Models\InstitutionPerson;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class MyProfileAddressUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_update_their_own_address(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->givePermissionTo(Permission::firstOrCreate(['name' => 'update contacts']));
+
+        $address = $this->createAddressForPerson($staff->person);
+
+        $this->actingAs($user)
+            ->patch(route('person.address.update', ['person' => $staff->person_id, 'address' => $address->id]), [
+                'address_line_1' => '123 Updated St',
+                'address_line_2' => null,
+                'city' => 'UpdatedCity',
+                'region' => 'UpdatedRegion',
+                'country' => 'GH',
+                'post_code' => '00233',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('addresses', [
+            'id' => $address->id,
+            'address_line_1' => '123 Updated St',
+            'city' => 'UpdatedCity',
+        ]);
+    }
+
+    public function test_stranger_cannot_update_another_persons_address(): void
+    {
+        $owner = $this->createActiveStaff();
+        $address = $this->createAddressForPerson($owner->person);
+
+        $stranger = $this->createActiveStaff();
+        $strangerUser = User::factory()->create(['person_id' => $stranger->person_id]);
+        $strangerUser->givePermissionTo(Permission::firstOrCreate(['name' => 'update contacts']));
+
+        $this->actingAs($strangerUser)
+            ->patch(route('person.address.update', ['person' => $owner->person_id, 'address' => $address->id]), [
+                'address_line_1' => 'Hacked St',
+                'address_line_2' => null,
+                'city' => 'HackedCity',
+                'region' => null,
+                'country' => 'GH',
+                'post_code' => null,
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('addresses', [
+            'id' => $address->id,
+            'address_line_1' => 'Hacked St',
+        ]);
+    }
+
+    public function test_unauthenticated_user_is_redirected_to_login(): void
+    {
+        $staff = $this->createActiveStaff();
+        $address = $this->createAddressForPerson($staff->person);
+
+        $this->patch(route('person.address.update', ['person' => $staff->person_id, 'address' => $address->id]), [
+            'address_line_1' => '123 Updated St',
+            'address_line_2' => null,
+            'city' => 'UpdatedCity',
+            'region' => null,
+            'country' => 'GH',
+            'post_code' => null,
+        ])
+            ->assertRedirect(route('login'));
+    }
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+
+    private function createAddressForPerson(Person $person): Address
+    {
+        return $person->address()->create([
+            'address_line_1' => '1 Original Road',
+            'address_line_2' => null,
+            'city' => 'OriginalCity',
+            'region' => 'OriginalRegion',
+            'country' => 'GH',
+            'post_code' => '00100',
+        ]);
+    }
+}

--- a/tests/Feature/MyProfile/MyProfileContactEditTest.php
+++ b/tests/Feature/MyProfile/MyProfileContactEditTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Enums\ContactTypeEnum;
+use App\Models\Contact;
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileContactEditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_my_profile_payload_exposes_contacts_and_address(): void
+    {
+        $staff = $this->createActiveStaff();
+        $this->createEmailContact($staff->person_id, 'me@example.org');
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page
+                ->has('contacts')
+                ->where('contacts.0.contact', 'me@example.org')
+            );
+    }
+
+    /**
+     * Mirrors the helper used across all MyProfile tests.
+     */
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+
+    private function createEmailContact(int $personId, string $email): void
+    {
+        Contact::factory()->create([
+            'person_id' => $personId,
+            'contact_type' => ContactTypeEnum::EMAIL->value,
+            'contact' => $email,
+            'valid_end' => null,
+        ]);
+    }
+}

--- a/tests/Feature/MyProfile/MyProfileContactMutationTest.php
+++ b/tests/Feature/MyProfile/MyProfileContactMutationTest.php
@@ -189,6 +189,100 @@ class MyProfileContactMutationTest extends TestCase
         $this->assertNull(Contact::find($email->id));
     }
 
+    public function test_cannot_delete_audit_gov_gh_email(): void
+    {
+        $user = $this->staffUser();
+        $email = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'me@audit.gov.gh',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $email->id,
+            ]))
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertNotNull(Contact::find($email->id));
+    }
+
+    public function test_can_delete_audit_gov_gh_email_with_case_differences(): void
+    {
+        $user = $this->staffUser();
+        $email = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'Me@AUDIT.GOV.GH',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $email->id,
+            ]))
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertNotNull(Contact::find($email->id));
+    }
+
+    public function test_can_delete_non_org_email(): void
+    {
+        $user = $this->staffUser();
+        $email = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'me@gmail.com',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $email->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($email->id));
+    }
+
+    public function test_can_delete_email_whose_domain_contains_audit_gov_gh_substring(): void
+    {
+        $user = $this->staffUser();
+
+        // Subdomain — not a match
+        $subdomainEmail = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'me@sub.audit.gov.gh',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $subdomainEmail->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($subdomainEmail->id));
+
+        // audit.gov.gh as local part — also not a match
+        $localPartEmail = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'audit.gov.gh@notreal.com',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $localPartEmail->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($localPartEmail->id));
+    }
+
     private function staffUser(): User
     {
         $staff = InstitutionPerson::factory()->create();

--- a/tests/Feature/MyProfile/MyProfileContactMutationTest.php
+++ b/tests/Feature/MyProfile/MyProfileContactMutationTest.php
@@ -283,6 +283,28 @@ class MyProfileContactMutationTest extends TestCase
         $this->assertNull(Contact::find($localPartEmail->id));
     }
 
+    public function test_cannot_update_audit_gov_gh_email(): void
+    {
+        $user = $this->staffUser();
+        $protected = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'me@audit.gov.gh',
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('person.contact.update', [
+                'person' => $user->person_id,
+                'contact' => $protected->id,
+            ]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'me@gmail.com',
+            ])
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertSame('me@audit.gov.gh', $protected->fresh()->contact);
+    }
+
     private function staffUser(): User
     {
         $staff = InstitutionPerson::factory()->create();

--- a/tests/Feature/MyProfile/MyProfileContactMutationTest.php
+++ b/tests/Feature/MyProfile/MyProfileContactMutationTest.php
@@ -101,6 +101,94 @@ class MyProfileContactMutationTest extends TestCase
         $this->assertNull(Contact::find($contact->id));
     }
 
+    public function test_cannot_delete_last_phone_contact(): void
+    {
+        $user = $this->staffUser();
+        $phone = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::PHONE,
+            'contact' => '0244000001',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $phone->id,
+            ]))
+            ->assertSessionHasErrors(['contact']);
+
+        $this->assertNotNull(Contact::find($phone->id));
+    }
+
+    public function test_can_delete_phone_when_another_active_phone_exists(): void
+    {
+        $user = $this->staffUser();
+        Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::PHONE,
+            'contact' => '0244000001',
+        ]);
+        $secondPhone = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::PHONE,
+            'contact' => '0244000002',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $secondPhone->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($secondPhone->id));
+    }
+
+    public function test_can_delete_expired_phone_even_if_no_other_active_phone(): void
+    {
+        $user = $this->staffUser();
+        $activePhone = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::PHONE,
+            'contact' => '0244000001',
+        ]);
+        $expiredPhone = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::PHONE,
+            'contact' => '0244000099',
+            'valid_end' => now()->subDay(),
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $expiredPhone->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($expiredPhone->id));
+        $this->assertNotNull(Contact::find($activePhone->id));
+    }
+
+    public function test_can_delete_email_with_no_other_email(): void
+    {
+        $user = $this->staffUser();
+        $email = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'only@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $email->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($email->id));
+    }
+
     private function staffUser(): User
     {
         $staff = InstitutionPerson::factory()->create();

--- a/tests/Feature/MyProfile/MyProfileContactMutationTest.php
+++ b/tests/Feature/MyProfile/MyProfileContactMutationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Enums\ContactTypeEnum;
+use App\Models\Contact;
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileContactMutationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_staff_can_add_own_contact(): void
+    {
+        $user = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('person.contact.create', ['person' => $user->person_id]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'me@example.org',
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseHas('contacts', [
+            'person_id' => $user->person_id,
+            'contact' => 'me@example.org',
+        ]);
+    }
+
+    public function test_staff_can_update_own_contact(): void
+    {
+        $user = $this->staffUser();
+        $contact = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'old@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('person.contact.update', [
+                'person' => $user->person_id,
+                'contact' => $contact->id,
+            ]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'new@example.org',
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertSame('new@example.org', $contact->fresh()->contact);
+    }
+
+    public function test_staff_cannot_update_another_persons_contact(): void
+    {
+        $me = $this->staffUser();
+        $other = InstitutionPerson::factory()->create();
+        $theirContact = Contact::create([
+            'person_id' => $other->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'theirs@example.org',
+        ]);
+
+        $this->actingAs($me)
+            ->post(route('person.contact.update', [
+                'person' => $other->person_id,
+                'contact' => $theirContact->id,
+            ]), [
+                'contact_type' => ContactTypeEnum::EMAIL->value,
+                'contact' => 'hijacked@example.org',
+            ])
+            ->assertForbidden();
+
+        $this->assertSame('theirs@example.org', $theirContact->fresh()->contact);
+    }
+
+    public function test_staff_can_delete_own_contact(): void
+    {
+        $user = $this->staffUser();
+        $contact = Contact::create([
+            'person_id' => $user->person_id,
+            'contact_type' => ContactTypeEnum::EMAIL,
+            'contact' => 'me@example.org',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('person.contact.delete', [
+                'person' => $user->person_id,
+                'contact' => $contact->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Contact::find($contact->id));
+    }
+
+    private function staffUser(): User
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('staff');
+
+        return $user;
+    }
+}

--- a/tests/Feature/MyProfile/MyProfilePhotoUploadTest.php
+++ b/tests/Feature/MyProfile/MyProfilePhotoUploadTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MyProfilePhotoUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_staff_can_upload_own_photo(): void
+    {
+        Storage::fake('public');
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $staff->person_id]), [
+                'image' => UploadedFile::fake()->image('me.jpg', 400, 400)->size(500),
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNotNull($staff->person->fresh()->image);
+    }
+
+    public function test_staff_cannot_upload_photo_for_another_person(): void
+    {
+        Storage::fake('public');
+        $me = $this->createActiveStaff();
+        $someone = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $me->person_id]);
+
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $someone->person_id]), [
+                'image' => UploadedFile::fake()->image('me.jpg'),
+            ])
+            ->assertForbidden();
+    }
+
+    /**
+     * Mirrors the helper in MyProfileShowTest — creates an InstitutionPerson
+     * that the `active()` scope returns.
+     */
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/MyProfile/MyProfilePhotoUploadTest.php
+++ b/tests/Feature/MyProfile/MyProfilePhotoUploadTest.php
@@ -6,7 +6,9 @@ use App\Models\InstitutionPerson;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
 
 class MyProfilePhotoUploadTest extends TestCase
@@ -16,6 +18,12 @@ class MyProfilePhotoUploadTest extends TestCase
     public function test_authenticated_staff_can_upload_own_photo(): void
     {
         Storage::fake('public');
+        Notification::fake();
+
+        // Upload now lands in pending_image (not image) until an admin approves.
+        // Create the permission so notification sending does not fail.
+        Permission::firstOrCreate(['name' => 'approve staff photo']);
+
         $staff = $this->createActiveStaff();
         $user = User::factory()->create(['person_id' => $staff->person_id]);
 
@@ -25,7 +33,11 @@ class MyProfilePhotoUploadTest extends TestCase
             ])
             ->assertSessionDoesntHaveErrors();
 
-        $this->assertNotNull($staff->person->fresh()->image);
+        $person = $staff->person->fresh();
+
+        // Photo lands as pending — approved image stays null until admin approves.
+        $this->assertNotNull($person->pending_image);
+        $this->assertNull($person->image);
     }
 
     public function test_staff_cannot_upload_photo_for_another_person(): void

--- a/tests/Feature/MyProfile/MyProfileQualificationTest.php
+++ b/tests/Feature/MyProfile/MyProfileQualificationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileQualificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_staff_user_does_not_receive_approve_permission_in_page_props(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page
+                ->where(
+                    'auth.permissions',
+                    fn ($permissions) => ! collect($permissions)->contains('approve staff qualification'),
+                )
+            );
+    }
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/MyProfile/MyProfileQualificationTest.php
+++ b/tests/Feature/MyProfile/MyProfileQualificationTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\MyProfile;
 
 use App\Models\InstitutionPerson;
+use App\Models\Qualification;
 use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -11,10 +13,15 @@ class MyProfileQualificationTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+    }
+
     public function test_staff_user_does_not_receive_approve_permission_in_page_props(): void
     {
-        $staff = $this->createActiveStaff();
-        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user = $this->staffUserWithProfile();
 
         $this->actingAs($user)
             ->get(route('my-profile.show'))
@@ -26,7 +33,42 @@ class MyProfileQualificationTest extends TestCase
             );
     }
 
-    private function createActiveStaff(): InstitutionPerson
+    public function test_staff_role_user_can_edit_own_pending_qualification(): void
+    {
+        $user = $this->staffUserWithProfile();
+        $qualification = Qualification::factory()->pending()->create([
+            'person_id' => $user->person_id,
+        ]);
+
+        $this->actingAs($user)
+            ->patch(route('qualification.update', ['qualification' => $qualification->id]), [
+                'course' => 'Updated course title',
+                'institution' => $qualification->institution,
+                'qualification' => $qualification->qualification,
+                'qualification_number' => $qualification->qualification_number,
+                'level' => $qualification->level,
+                'year' => $qualification->year,
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertSame('Updated course title', $qualification->fresh()->course);
+    }
+
+    public function test_staff_role_user_can_delete_own_pending_qualification(): void
+    {
+        $user = $this->staffUserWithProfile();
+        $qualification = Qualification::factory()->pending()->create([
+            'person_id' => $user->person_id,
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('qualification.delete', ['qualification' => $qualification->id]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Qualification::find($qualification->id));
+    }
+
+    private function staffUserWithProfile(): User
     {
         $staff = InstitutionPerson::factory()->create();
         $staff->statuses()->create([
@@ -35,6 +77,9 @@ class MyProfileQualificationTest extends TestCase
             'institution_id' => $staff->institution_id,
         ]);
 
-        return $staff;
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('staff');
+
+        return $user;
     }
 }

--- a/tests/Feature/MyProfile/MyProfileShowTest.php
+++ b/tests/Feature/MyProfile/MyProfileShowTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyProfileShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('my-profile.show'))->assertRedirect(route('login'));
+    }
+
+    public function test_authenticated_user_without_person_id_gets_403(): void
+    {
+        $user = User::factory()->create(['person_id' => null]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertForbidden();
+    }
+
+    public function test_authenticated_staff_user_sees_their_profile(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('MyProfile/Index')
+                ->has('person')
+                ->has('staff')
+                ->has('qualifications')
+                ->where('person.id', $staff->person_id)
+            );
+    }
+
+    public function test_user_with_no_active_staff_record_sees_404(): void
+    {
+        // Create a person with no InstitutionPerson (active staff) record.
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertNotFound();
+    }
+
+    /**
+     * Mirrors the helper introduced in StaffProfileProviderTest — creates an
+     * InstitutionPerson that the `active()` scope returns.
+     */
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/MyProfile/SharedPropsTest.php
+++ b/tests/Feature/MyProfile/SharedPropsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\Qualification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SharedPropsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_auth_props_include_person_id_has_photo_and_qualifications_count(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.user.person_id', $staff->person_id)
+                ->where('auth.has_photo', false)
+                ->where('auth.qualifications_count', 0)
+            );
+    }
+
+    public function test_has_photo_flips_true_when_person_image_is_set(): void
+    {
+        $staff = $this->createActiveStaff();
+        $staff->person->update(['image' => 'avatars/example.jpg']);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.has_photo', true));
+    }
+
+    public function test_qualifications_count_reflects_stored_qualifications(): void
+    {
+        $staff = $this->createActiveStaff();
+        Qualification::factory()->count(3)->create(['person_id' => $staff->person_id]);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.qualifications_count', 3));
+    }
+
+    public function test_props_are_null_for_users_without_person_id(): void
+    {
+        $user = User::factory()->create(['person_id' => null]);
+
+        // my-profile.show 403s for users without a person_id (no Inertia response).
+        // Use the change-password page which is always reachable by any auth'd user.
+        $this->actingAs($user)
+            ->get(route('change-password.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('auth.has_photo', null)
+                ->where('auth.qualifications_count', null)
+            );
+    }
+
+    /**
+     * Mirrors the helper from MyProfileShowTest — creates an InstitutionPerson
+     * that the `active()` scope returns.
+     */
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/MyProfile/StaffLandingRedirectTest.php
+++ b/tests/Feature/MyProfile/StaffLandingRedirectTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\MyProfile;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class StaffLandingRedirectTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::findOrCreate('staff');
+    }
+
+    public function test_staff_only_user_is_redirected_to_my_profile(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+        $user->assignRole('staff');
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertRedirect(route('my-profile.show'));
+    }
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+}

--- a/tests/Feature/PhotoApproval/PhotoApprovalTest.php
+++ b/tests/Feature/PhotoApproval/PhotoApprovalTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Tests\Feature\PhotoApproval;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use App\Notifications\PhotoApprovedNotification;
+use App\Notifications\PhotoPendingApprovalNotification;
+use App\Notifications\PhotoRejectedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class PhotoApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+
+    private function createApproverUser(): User
+    {
+        Permission::firstOrCreate(['name' => 'approve staff photo']);
+
+        $approver = User::factory()->create();
+        $approver->givePermissionTo('approve staff photo');
+
+        return $approver;
+    }
+
+    private function createStaffUser(InstitutionPerson $staff): User
+    {
+        return User::factory()->create(['person_id' => $staff->person_id]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Upload tests
+    // -----------------------------------------------------------------------
+
+    public function test_uploading_a_photo_stores_it_as_pending(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $user = $this->createStaffUser($staff);
+        $approver = $this->createApproverUser();
+
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $staff->person_id]), [
+                'image' => UploadedFile::fake()->image('photo.jpg', 400, 400)->size(500),
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $person = $staff->person->fresh();
+
+        // pending_image is set, approved image is NOT changed.
+        $this->assertNotNull($person->pending_image);
+        $this->assertNull($person->image);
+        $this->assertNotNull($person->pending_image_at);
+
+        // File exists in storage.
+        Storage::disk('public')->assertExists($person->pending_image);
+
+        // Approvers were notified.
+        Notification::assertSentTo($approver, PhotoPendingApprovalNotification::class);
+    }
+
+    public function test_uploading_while_one_is_pending_replaces_the_pending_file(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $user = $this->createStaffUser($staff);
+        $this->createApproverUser();
+
+        // First upload.
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $staff->person_id]), [
+                'image' => UploadedFile::fake()->image('first.jpg', 400, 400)->size(300),
+            ]);
+
+        $firstPendingPath = $staff->person->fresh()->pending_image;
+        $this->assertNotNull($firstPendingPath);
+
+        // Second upload.
+        $this->actingAs($user)
+            ->post(route('person.avatar.update', ['person' => $staff->person_id]), [
+                'image' => UploadedFile::fake()->image('second.jpg', 400, 400)->size(300),
+            ]);
+
+        $person = $staff->person->fresh();
+
+        // First file deleted from storage.
+        Storage::disk('public')->assertMissing($firstPendingPath);
+
+        // New pending file is different.
+        $this->assertNotNull($person->pending_image);
+        $this->assertNotEquals($firstPendingPath, $person->pending_image);
+        Storage::disk('public')->assertExists($person->pending_image);
+    }
+
+    // -----------------------------------------------------------------------
+    // Queue access tests
+    // -----------------------------------------------------------------------
+
+    public function test_only_approvers_can_see_the_queue(): void
+    {
+        Storage::fake('public');
+
+        $approver = $this->createApproverUser();
+        $nonApprover = User::factory()->create();
+
+        // Approver can access.
+        $this->actingAs($approver)
+            ->get(route('photo-approvals.index'))
+            ->assertOk();
+
+        // Non-approver is forbidden.
+        $this->actingAs($nonApprover)
+            ->get(route('photo-approvals.index'))
+            ->assertForbidden();
+    }
+
+    // -----------------------------------------------------------------------
+    // Approve tests
+    // -----------------------------------------------------------------------
+
+    public function test_approve_moves_pending_into_image(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $staffUser = $this->createStaffUser($staff);
+        $approver = $this->createApproverUser();
+
+        // Give staff a pending image.
+        $pendingPath = 'avatars/pending.jpg';
+        Storage::disk('public')->put($pendingPath, 'fake-image-content');
+        $staff->person->update([
+            'pending_image' => $pendingPath,
+            'pending_image_at' => now(),
+        ]);
+
+        $this->actingAs($approver)
+            ->post(route('photo-approvals.approve', ['person' => $staff->person_id]))
+            ->assertRedirect();
+
+        $person = $staff->person->fresh();
+
+        // Pending cleared; approved image set.
+        $this->assertNull($person->pending_image);
+        $this->assertNull($person->pending_image_at);
+        $this->assertEquals($pendingPath, $person->image);
+
+        // Approval metadata recorded.
+        $this->assertEquals($approver->id, $person->image_approved_by);
+        $this->assertNotNull($person->image_approved_at);
+
+        // Staff user notified.
+        Notification::assertSentTo($staffUser, PhotoApprovedNotification::class);
+    }
+
+    public function test_approve_deletes_previous_approved_file_from_storage(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $this->createStaffUser($staff);
+        $approver = $this->createApproverUser();
+
+        // Create both an existing approved and a pending file.
+        $oldApprovedPath = 'avatars/old-approved.jpg';
+        $pendingPath = 'avatars/new-pending.jpg';
+        Storage::disk('public')->put($oldApprovedPath, 'old-content');
+        Storage::disk('public')->put($pendingPath, 'new-content');
+
+        $staff->person->update([
+            'image' => $oldApprovedPath,
+            'pending_image' => $pendingPath,
+            'pending_image_at' => now(),
+        ]);
+
+        $this->actingAs($approver)
+            ->post(route('photo-approvals.approve', ['person' => $staff->person_id]));
+
+        // Old approved file was deleted.
+        Storage::disk('public')->assertMissing($oldApprovedPath);
+
+        // New file now lives in image field.
+        $this->assertEquals($pendingPath, $staff->person->fresh()->image);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reject tests
+    // -----------------------------------------------------------------------
+
+    public function test_reject_clears_pending_and_removes_file(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $staffUser = $this->createStaffUser($staff);
+        $approver = $this->createApproverUser();
+
+        // Seed an approved image and a pending image.
+        $approvedPath = 'avatars/approved.jpg';
+        $pendingPath = 'avatars/pending.jpg';
+        Storage::disk('public')->put($approvedPath, 'approved-content');
+        Storage::disk('public')->put($pendingPath, 'pending-content');
+
+        $staff->person->update([
+            'image' => $approvedPath,
+            'pending_image' => $pendingPath,
+            'pending_image_at' => now(),
+        ]);
+
+        $this->actingAs($approver)
+            ->post(route('photo-approvals.reject', ['person' => $staff->person_id]))
+            ->assertRedirect();
+
+        $person = $staff->person->fresh();
+
+        // Pending cleared.
+        $this->assertNull($person->pending_image);
+        $this->assertNull($person->pending_image_at);
+
+        // Pending file deleted; approved file untouched.
+        Storage::disk('public')->assertMissing($pendingPath);
+        Storage::disk('public')->assertExists($approvedPath);
+
+        // Approved image unchanged.
+        $this->assertEquals($approvedPath, $person->image);
+
+        // Staff user notified.
+        Notification::assertSentTo($staffUser, PhotoRejectedNotification::class);
+    }
+
+    // -----------------------------------------------------------------------
+    // Authorization tests
+    // -----------------------------------------------------------------------
+
+    public function test_non_approver_cannot_approve_or_reject(): void
+    {
+        Storage::fake('public');
+
+        $staff = $this->createActiveStaff();
+        $nonApprover = User::factory()->create();
+
+        $staff->person->update([
+            'pending_image' => 'avatars/pending.jpg',
+            'pending_image_at' => now(),
+        ]);
+
+        $this->actingAs($nonApprover)
+            ->post(route('photo-approvals.approve', ['person' => $staff->person_id]))
+            ->assertForbidden();
+
+        $this->actingAs($nonApprover)
+            ->post(route('photo-approvals.reject', ['person' => $staff->person_id]))
+            ->assertForbidden();
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge case tests
+    // -----------------------------------------------------------------------
+
+    public function test_approving_a_person_with_no_pending_photo_returns_422(): void
+    {
+        Storage::fake('public');
+        Notification::fake();
+
+        $staff = $this->createActiveStaff();
+        $approver = $this->createApproverUser();
+
+        // Ensure no pending image.
+        $staff->person->update(['pending_image' => null, 'pending_image_at' => null]);
+
+        $this->actingAs($approver)
+            ->post(route('photo-approvals.approve', ['person' => $staff->person_id]))
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/Qualification/DestroyQualificationDocumentTest.php
+++ b/tests/Feature/Qualification/DestroyQualificationDocumentTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Qualification;
+
+use App\Models\Document;
+use App\Models\Person;
+use App\Models\Qualification;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class DestroyQualificationDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_staff_can_delete_own_pending_qualification_document(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+        $path = Storage::disk('qualifications-documents')->put('/', UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'));
+        $document = $qualification->documents()->create([
+            'document_type' => 'A',
+            'document_title' => 'Certificate',
+            'document_status' => 'P',
+            'file_name' => $path,
+            'file_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('qualification-document.destroy', [
+                'qualification' => $qualification->id,
+                'document' => $document->id,
+            ]))
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertNull(Document::find($document->id));
+        $this->assertFalse(Storage::disk('qualifications-documents')->exists($path));
+    }
+
+    public function test_staff_cannot_delete_another_persons_qualification_document(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$me] = $this->staffUser();
+        $other = Person::factory()->create();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $other->id]);
+        $document = $qualification->documents()->create([
+            'document_type' => 'A',
+            'document_title' => 'Certificate',
+            'document_status' => 'P',
+            'file_name' => 'theirs.pdf',
+            'file_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($me)
+            ->delete(route('qualification-document.destroy', [
+                'qualification' => $qualification->id,
+                'document' => $document->id,
+            ]))
+            ->assertForbidden();
+
+        $this->assertNotNull(Document::find($document->id));
+    }
+
+    public function test_staff_cannot_delete_document_on_approved_qualification(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->approved()->create(['person_id' => $person->id]);
+        $document = $qualification->documents()->create([
+            'document_type' => 'A',
+            'document_title' => 'Certificate',
+            'document_status' => 'P',
+            'file_name' => 'mine.pdf',
+            'file_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('qualification-document.destroy', [
+                'qualification' => $qualification->id,
+                'document' => $document->id,
+            ]))
+            ->assertForbidden();
+
+        $this->assertNotNull(Document::find($document->id));
+    }
+
+    public function test_returns_404_when_document_does_not_belong_to_qualification(): void
+    {
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+        $otherQualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+        $document = $otherQualification->documents()->create([
+            'document_type' => 'A',
+            'document_title' => 'Wrong parent',
+            'document_status' => 'P',
+            'file_name' => 'other.pdf',
+            'file_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('qualification-document.destroy', [
+                'qualification' => $qualification->id,
+                'document' => $document->id,
+            ]))
+            ->assertNotFound();
+    }
+
+    /**
+     * @return array{User, Person}
+     */
+    private function staffUser(): array
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->assignRole('staff');
+
+        return [$user, $person];
+    }
+}

--- a/tests/Feature/Qualification/StoreQualificationDocumentTest.php
+++ b/tests/Feature/Qualification/StoreQualificationDocumentTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature\Qualification;
+
+use App\Models\Document;
+use App\Models\Person;
+use App\Models\Qualification;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class StoreQualificationDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_owner_of_pending_qualification_can_attach_multiple_documents(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+
+        $this->actingAs($user)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('degree.pdf', 200, 'application/pdf'),
+                    UploadedFile::fake()->create('transcript.pdf', 150, 'application/pdf'),
+                    UploadedFile::fake()->create('photo.jpg', 100, 'image/jpeg'),
+                ],
+                'document_type' => ['A', 'T', 'P'],
+                'document_title' => ['Degree Certificate', 'Official Transcript', 'Professional Certificate'],
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $qualification->refresh();
+        $this->assertCount(3, $qualification->documents);
+
+        $types = $qualification->documents->pluck('document_type')->toArray();
+        $this->assertContains('A', $types);
+        $this->assertContains('T', $types);
+        $this->assertContains('P', $types);
+
+        $titles = $qualification->documents->pluck('document_title')->toArray();
+        $this->assertContains('Degree Certificate', $titles);
+        $this->assertContains('Official Transcript', $titles);
+        $this->assertContains('Professional Certificate', $titles);
+
+        $qualification->documents->each(function (Document $doc) {
+            $this->assertSame('P', $doc->document_status);
+            $this->assertNotEmpty($doc->file_name);
+            Storage::disk('qualifications-documents')->assertExists($doc->file_name);
+        });
+    }
+
+    public function test_attach_preserves_existing_documents(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+
+        // Pre-existing document
+        $existingPath = Storage::disk('qualifications-documents')->put('/', UploadedFile::fake()->create('existing.pdf', 100, 'application/pdf'));
+        $existing = $qualification->documents()->create([
+            'document_type' => 'A',
+            'document_title' => 'Original Certificate',
+            'document_status' => 'P',
+            'file_name' => $existingPath,
+            'file_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('new1.pdf', 200, 'application/pdf'),
+                    UploadedFile::fake()->create('new2.pdf', 150, 'application/pdf'),
+                ],
+                'document_type' => ['T', 'P'],
+                'document_title' => ['New Transcript', 'New Certificate'],
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $qualification->refresh();
+        $this->assertCount(3, $qualification->documents);
+
+        // Existing document is untouched
+        $this->assertNotNull(Document::find($existing->id));
+        $refreshed = Document::find($existing->id);
+        $this->assertSame('Original Certificate', $refreshed->document_title);
+        $this->assertSame($existingPath, $refreshed->file_name);
+    }
+
+    public function test_staff_cannot_attach_to_another_persons_qualification(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$me] = $this->staffUser();
+        $other = Person::factory()->create();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $other->id]);
+
+        $this->actingAs($me)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
+                'document_type' => ['A'],
+                'document_title' => ['Stolen Certificate'],
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_cannot_attach_documents_to_approved_qualification(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->approved()->create(['person_id' => $person->id]);
+
+        $this->actingAs($me = $user)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
+                'document_type' => ['A'],
+                'document_title' => ['My Certificate'],
+            ])
+            ->assertForbidden();
+
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_type_and_title_are_required_per_file(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+        $qualification = Qualification::factory()->pending()->create(['person_id' => $person->id]);
+
+        // Missing document_type for first file
+        $this->actingAs($user)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
+                'document_type' => [''],
+                'document_title' => ['My Certificate'],
+            ])
+            ->assertSessionHasErrors(['document_type.0']);
+
+        $this->assertDatabaseCount('documents', 0);
+
+        // Missing document_title for first file
+        $this->actingAs($user)
+            ->post(route('qualification-document.store', ['qualification' => $qualification->id]), [
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
+                'document_type' => ['A'],
+                'document_title' => [''],
+            ])
+            ->assertSessionHasErrors(['document_title.0']);
+
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    /**
+     * @return array{User, Person}
+     */
+    private function staffUser(): array
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create(['person_id' => $person->id, 'password_change_at' => now()]);
+        $user->assignRole('staff');
+
+        return [$user, $person];
+    }
+}

--- a/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
+++ b/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature\Qualification;
+
+use App\Models\Person;
+use App\Models\Qualification;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class StoreQualificationWithDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesAndPermissionsSeeder::class);
+        Notification::fake();
+    }
+
+    public function test_creates_qualification_without_document(): void
+    {
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'institution' => 'University of Ghana',
+                'year' => '2015',
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseCount('qualifications', 1);
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_creates_qualification_with_attached_document(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'institution' => 'University of Ghana',
+                'year' => '2015',
+                'document_type' => 'A', // AcademicCertificate
+                'document_title' => 'Degree certificate',
+                'file_name' => UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $qualification = Qualification::first();
+        $this->assertNotNull($qualification);
+        $this->assertCount(1, $qualification->documents);
+
+        $doc = $qualification->documents->first();
+        $this->assertSame('Degree certificate', $doc->document_title);
+        $this->assertSame('A', $doc->document_type);
+        $this->assertNotEmpty($doc->file_name);
+        $this->assertSame('P', $doc->document_status);
+    }
+
+    public function test_document_fields_without_file_are_ignored(): void
+    {
+        [$user, $person] = $this->staffUser();
+
+        // Sending document_type and document_title without a file — should be ignored,
+        // not cause validation errors, and not create a document row.
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'document_type' => 'A',
+                'document_title' => 'Degree certificate',
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $this->assertDatabaseCount('qualifications', 1);
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_file_without_document_type_is_rejected(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'file_name' => UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+            ])
+            ->assertSessionHasErrors(['document_type']);
+
+        $this->assertDatabaseCount('qualifications', 0);
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_invalid_file_type_is_rejected(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'document_type' => 'A',
+                'file_name' => UploadedFile::fake()->create('malware.exe', 200, 'application/octet-stream'),
+            ])
+            ->assertSessionHasErrors(['file_name']);
+
+        $this->assertDatabaseCount('qualifications', 0);
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_document_title_auto_filled_from_filename_when_blank(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'document_type' => 'A',
+                // No document_title — should be derived from filename
+                'file_name' => UploadedFile::fake()->create('my-degree-cert.pdf', 200, 'application/pdf'),
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $doc = Qualification::first()->documents->first();
+        $this->assertSame('my-degree-cert', $doc->document_title);
+    }
+
+    /**
+     * @return array{User, Person}
+     */
+    private function staffUser(): array
+    {
+        $person = Person::factory()->create();
+        $user = User::factory()->create([
+            'person_id' => $person->id,
+            'password_change_at' => now(),
+        ]);
+        $user->assignRole('staff');
+
+        return [$user, $person];
+    }
+}

--- a/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
+++ b/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
@@ -40,7 +40,7 @@ class StoreQualificationWithDocumentTest extends TestCase
         $this->assertDatabaseCount('documents', 0);
     }
 
-    public function test_creates_qualification_with_attached_document(): void
+    public function test_creates_qualification_with_single_attached_document(): void
     {
         Storage::fake('qualifications-documents');
         [$user, $person] = $this->staffUser();
@@ -52,8 +52,9 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'institution' => 'University of Ghana',
                 'year' => '2015',
                 'document_type' => 'A', // AcademicCertificate
-                'document_title' => 'Degree certificate',
-                'file_name' => UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
             ])
             ->assertSessionDoesntHaveErrors();
 
@@ -62,24 +63,59 @@ class StoreQualificationWithDocumentTest extends TestCase
         $this->assertCount(1, $qualification->documents);
 
         $doc = $qualification->documents->first();
-        $this->assertSame('Degree certificate', $doc->document_title);
+        $this->assertSame('cert', $doc->document_title);
         $this->assertSame('A', $doc->document_type);
         $this->assertNotEmpty($doc->file_name);
         $this->assertSame('P', $doc->document_status);
+    }
+
+    public function test_creates_qualification_with_multiple_attached_documents(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'institution' => 'University of Ghana',
+                'year' => '2015',
+                'document_type' => 'A', // AcademicCertificate
+                'file_name' => [
+                    UploadedFile::fake()->create('degree.pdf', 200, 'application/pdf'),
+                    UploadedFile::fake()->create('transcript.pdf', 150, 'application/pdf'),
+                    UploadedFile::fake()->create('certificate.jpg', 100, 'image/jpeg'),
+                ],
+            ])
+            ->assertSessionDoesntHaveErrors();
+
+        $qualification = Qualification::first();
+        $this->assertNotNull($qualification);
+        $this->assertCount(3, $qualification->documents);
+
+        $qualification->documents->each(function ($doc) {
+            $this->assertSame('A', $doc->document_type);
+            $this->assertSame('P', $doc->document_status);
+            $this->assertNotEmpty($doc->file_name);
+        });
+
+        $titles = $qualification->documents->pluck('document_title')->toArray();
+        $this->assertContains('degree', $titles);
+        $this->assertContains('transcript', $titles);
+        $this->assertContains('certificate', $titles);
     }
 
     public function test_document_fields_without_file_are_ignored(): void
     {
         [$user, $person] = $this->staffUser();
 
-        // Sending document_type and document_title without a file — should be ignored,
+        // Sending document_type without a file — should be ignored,
         // not cause validation errors, and not create a document row.
         $this->actingAs($user)
             ->post(route('qualification.store'), [
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
                 'document_type' => 'A',
-                'document_title' => 'Degree certificate',
             ])
             ->assertSessionDoesntHaveErrors();
 
@@ -96,7 +132,9 @@ class StoreQualificationWithDocumentTest extends TestCase
             ->post(route('qualification.store'), [
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
-                'file_name' => UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
             ])
             ->assertSessionHasErrors(['document_type']);
 
@@ -114,15 +152,17 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
                 'document_type' => 'A',
-                'file_name' => UploadedFile::fake()->create('malware.exe', 200, 'application/octet-stream'),
+                'file_name' => [
+                    UploadedFile::fake()->create('malware.exe', 200, 'application/octet-stream'),
+                ],
             ])
-            ->assertSessionHasErrors(['file_name']);
+            ->assertSessionHasErrors(['file_name.0']);
 
         $this->assertDatabaseCount('qualifications', 0);
         $this->assertDatabaseCount('documents', 0);
     }
 
-    public function test_document_title_auto_filled_from_filename_when_blank(): void
+    public function test_document_title_auto_filled_from_filename(): void
     {
         Storage::fake('qualifications-documents');
         [$user, $person] = $this->staffUser();
@@ -132,8 +172,9 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
                 'document_type' => 'A',
-                // No document_title — should be derived from filename
-                'file_name' => UploadedFile::fake()->create('my-degree-cert.pdf', 200, 'application/pdf'),
+                'file_name' => [
+                    UploadedFile::fake()->create('my-degree-cert.pdf', 200, 'application/pdf'),
+                ],
             ])
             ->assertSessionDoesntHaveErrors();
 

--- a/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
+++ b/tests/Feature/Qualification/StoreQualificationWithDocumentTest.php
@@ -51,10 +51,11 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'course' => 'BSc Accounting',
                 'institution' => 'University of Ghana',
                 'year' => '2015',
-                'document_type' => 'A', // AcademicCertificate
                 'file_name' => [
                     UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
                 ],
+                'document_type' => ['A'], // AcademicCertificate
+                'document_title' => ['Certificate of Completion'],
             ])
             ->assertSessionDoesntHaveErrors();
 
@@ -63,7 +64,7 @@ class StoreQualificationWithDocumentTest extends TestCase
         $this->assertCount(1, $qualification->documents);
 
         $doc = $qualification->documents->first();
-        $this->assertSame('cert', $doc->document_title);
+        $this->assertSame('Certificate of Completion', $doc->document_title);
         $this->assertSame('A', $doc->document_type);
         $this->assertNotEmpty($doc->file_name);
         $this->assertSame('P', $doc->document_status);
@@ -80,12 +81,13 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'course' => 'BSc Accounting',
                 'institution' => 'University of Ghana',
                 'year' => '2015',
-                'document_type' => 'A', // AcademicCertificate
                 'file_name' => [
                     UploadedFile::fake()->create('degree.pdf', 200, 'application/pdf'),
                     UploadedFile::fake()->create('transcript.pdf', 150, 'application/pdf'),
                     UploadedFile::fake()->create('certificate.jpg', 100, 'image/jpeg'),
                 ],
+                'document_type' => ['A', 'T', 'P'], // AcademicCertificate, Transcript, ProfessionalCertificate
+                'document_title' => ['Degree Certificate', 'Official Transcript', 'Professional Certificate'],
             ])
             ->assertSessionDoesntHaveErrors();
 
@@ -94,28 +96,33 @@ class StoreQualificationWithDocumentTest extends TestCase
         $this->assertCount(3, $qualification->documents);
 
         $qualification->documents->each(function ($doc) {
-            $this->assertSame('A', $doc->document_type);
             $this->assertSame('P', $doc->document_status);
             $this->assertNotEmpty($doc->file_name);
         });
 
+        $types = $qualification->documents->pluck('document_type')->toArray();
+        $this->assertContains('A', $types);
+        $this->assertContains('T', $types);
+        $this->assertContains('P', $types);
+
         $titles = $qualification->documents->pluck('document_title')->toArray();
-        $this->assertContains('degree', $titles);
-        $this->assertContains('transcript', $titles);
-        $this->assertContains('certificate', $titles);
+        $this->assertContains('Degree Certificate', $titles);
+        $this->assertContains('Official Transcript', $titles);
+        $this->assertContains('Professional Certificate', $titles);
     }
 
     public function test_document_fields_without_file_are_ignored(): void
     {
         [$user, $person] = $this->staffUser();
 
-        // Sending document_type without a file — should be ignored,
-        // not cause validation errors, and not create a document row.
+        // Sending document_type / document_title arrays without any file —
+        // should be ignored, not cause validation errors, and not create a document row.
         $this->actingAs($user)
             ->post(route('qualification.store'), [
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
-                'document_type' => 'A',
+                'document_type' => [],
+                'document_title' => [],
             ])
             ->assertSessionDoesntHaveErrors();
 
@@ -135,8 +142,30 @@ class StoreQualificationWithDocumentTest extends TestCase
                 'file_name' => [
                     UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
                 ],
+                // no document_type supplied
             ])
             ->assertSessionHasErrors(['document_type']);
+
+        $this->assertDatabaseCount('qualifications', 0);
+        $this->assertDatabaseCount('documents', 0);
+    }
+
+    public function test_file_without_document_title_is_rejected(): void
+    {
+        Storage::fake('qualifications-documents');
+        [$user, $person] = $this->staffUser();
+
+        $this->actingAs($user)
+            ->post(route('qualification.store'), [
+                'person_id' => $person->id,
+                'course' => 'BSc Accounting',
+                'file_name' => [
+                    UploadedFile::fake()->create('cert.pdf', 200, 'application/pdf'),
+                ],
+                'document_type' => ['A'],
+                // no document_title supplied
+            ])
+            ->assertSessionHasErrors(['document_title']);
 
         $this->assertDatabaseCount('qualifications', 0);
         $this->assertDatabaseCount('documents', 0);
@@ -151,35 +180,16 @@ class StoreQualificationWithDocumentTest extends TestCase
             ->post(route('qualification.store'), [
                 'person_id' => $person->id,
                 'course' => 'BSc Accounting',
-                'document_type' => 'A',
                 'file_name' => [
                     UploadedFile::fake()->create('malware.exe', 200, 'application/octet-stream'),
                 ],
+                'document_type' => ['A'],
+                'document_title' => ['Malware File'],
             ])
             ->assertSessionHasErrors(['file_name.0']);
 
         $this->assertDatabaseCount('qualifications', 0);
         $this->assertDatabaseCount('documents', 0);
-    }
-
-    public function test_document_title_auto_filled_from_filename(): void
-    {
-        Storage::fake('qualifications-documents');
-        [$user, $person] = $this->staffUser();
-
-        $this->actingAs($user)
-            ->post(route('qualification.store'), [
-                'person_id' => $person->id,
-                'course' => 'BSc Accounting',
-                'document_type' => 'A',
-                'file_name' => [
-                    UploadedFile::fake()->create('my-degree-cert.pdf', 200, 'application/pdf'),
-                ],
-            ])
-            ->assertSessionDoesntHaveErrors();
-
-        $doc = Qualification::first()->documents->first();
-        $this->assertSame('my-degree-cert', $doc->document_title);
     }
 
     /**

--- a/tests/Unit/Services/StaffProfileProviderTest.php
+++ b/tests/Unit/Services/StaffProfileProviderTest.php
@@ -2,7 +2,12 @@
 
 namespace Tests\Unit\Services;
 
+use App\Enums\ContactTypeEnum;
 use App\Models\InstitutionPerson;
+use App\Models\Job;
+use App\Models\Person;
+use App\Models\Qualification;
+use App\Models\Unit;
 use App\Models\User;
 use App\Services\StaffProfileProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -76,5 +81,80 @@ class StaffProfileProviderTest extends TestCase
         $this->assertArrayHasKey('ranks', $payload['staff']);
         $this->assertArrayHasKey('units', $payload['staff']);
         $this->assertArrayHasKey('dependents', $payload['staff']);
+    }
+
+    public function test_payload_maps_nested_relations_when_populated(): void
+    {
+        $staff = $this->createActiveStaff();
+        $person = $staff->person;
+
+        // Contact
+        $contact = $person->contacts()->create([
+            'contact_type' => ContactTypeEnum::PHONE->value,
+            'contact' => '0241234567',
+        ]);
+
+        // Address (polymorphic)
+        $person->address()->create([
+            'address_line_1' => '123 Test Street',
+            'city' => 'Accra',
+            'country' => 'GH',
+        ]);
+
+        // Rank — attach via job_staff pivot
+        $job = Job::factory()->create(['name' => 'Senior Test Officer']);
+        $staff->ranks()->attach($job->id, [
+            'start_date' => now()->subYears(2)->toDateString(),
+        ]);
+
+        // Unit — attach via staff_unit pivot
+        $unit = Unit::factory()->create(['name' => 'Test Division Unit']);
+        $staff->units()->attach($unit->id, [
+            'start_date' => now()->subYear()->toDateString(),
+        ]);
+
+        // Qualification (belongs to person)
+        Qualification::factory()->approved()->create([
+            'person_id' => $person->id,
+            'qualification' => 'Bachelor of Science',
+        ]);
+
+        // Dependent — DependentFactory definition is empty, so we create inline.
+        // A dependent requires a linked Person for name mapping.
+        $depPerson = Person::factory()->create([
+            'first_name' => 'Jane',
+            'surname' => 'Doe',
+        ]);
+        $staff->dependents()->create([
+            'person_id' => $depPerson->id,
+            'relation' => 'Spouse',
+        ]);
+
+        $payload = (new StaffProfileProvider)->forPerson($person->id);
+
+        // Contacts
+        $this->assertNotNull($payload['contacts']);
+        $this->assertSame('0241234567', $payload['contacts'][0]['contact']);
+
+        // Address
+        $this->assertNotNull($payload['address']);
+        $this->assertSame('Accra', $payload['address']['city']);
+
+        // Ranks
+        $this->assertNotEmpty($payload['staff']['ranks']);
+        $this->assertSame('Senior Test Officer', $payload['staff']['ranks'][0]['name']);
+
+        // Units
+        $this->assertNotEmpty($payload['staff']['units']);
+        $this->assertSame('Test Division Unit', $payload['staff']['units'][0]['unit_name']);
+
+        // Qualifications
+        $this->assertNotEmpty($payload['qualifications']);
+        $this->assertSame('Bachelor of Science', $payload['qualifications'][0]['qualification']);
+
+        // Dependents
+        $this->assertNotEmpty($payload['staff']['dependents']);
+        $depFullName = $payload['staff']['dependents'][0]['name'];
+        $this->assertStringContainsString('Doe', $depFullName);
     }
 }

--- a/tests/Unit/Services/StaffProfileProviderTest.php
+++ b/tests/Unit/Services/StaffProfileProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\InstitutionPerson;
+use App\Models\User;
+use App\Services\StaffProfileProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffProfileProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actingAs(User::factory()->create());
+    }
+
+    private function createActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $staff->institution_id,
+        ]);
+
+        return $staff;
+    }
+
+    public function test_returns_null_when_no_active_institution_person_exists(): void
+    {
+        $provider = new StaffProfileProvider;
+
+        $this->assertNull($provider->forPerson(999_999));
+    }
+
+    public function test_returns_payload_with_expected_top_level_keys(): void
+    {
+        $staff = $this->createActiveStaff();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertIsArray($payload);
+        $this->assertSame(
+            ['person', 'qualifications', 'contacts', 'address', 'staff'],
+            array_keys($payload),
+        );
+    }
+
+    public function test_person_block_contains_expected_fields(): void
+    {
+        $staff = $this->createActiveStaff();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertArrayHasKey('id', $payload['person']);
+        $this->assertArrayHasKey('name', $payload['person']);
+        $this->assertArrayHasKey('initials', $payload['person']);
+        $this->assertArrayHasKey('image', $payload['person']);
+        $this->assertArrayHasKey('identities', $payload['person']);
+    }
+
+    public function test_staff_block_contains_expected_employment_fields(): void
+    {
+        $staff = $this->createActiveStaff();
+
+        $payload = (new StaffProfileProvider)->forPerson($staff->person_id);
+
+        $this->assertArrayHasKey('staff_id', $payload['staff']);
+        $this->assertArrayHasKey('staff_number', $payload['staff']);
+        $this->assertArrayHasKey('file_number', $payload['staff']);
+        $this->assertArrayHasKey('hire_date', $payload['staff']);
+        $this->assertArrayHasKey('ranks', $payload['staff']);
+        $this->assertArrayHasKey('units', $payload['staff']);
+        $this->assertArrayHasKey('dependents', $payload['staff']);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a dedicated staff self-service profile at `/my-profile` built around photo upload and qualification management as the two first-run actions, plus follow-on cards for personal details, contact info, address, employment, and dependents. Extracts shared profile-payload logic into a reusable service, hardens authorization on several existing endpoints, and layers in an admin approval workflow for profile photos.

63 commits · 63 files changed (+8409/-448) · 535+ tests (~70 new) · full suite green · prod build green.

Spec: `docs/superpowers/specs/2026-04-17-staff-my-profile-redesign-design.md`
Plan: `docs/superpowers/plans/2026-04-17-staff-my-profile-redesign.md`

## What's in this PR

### New page: `/my-profile`
- `MyProfileController` + route, staff-only users land here instead of the admin staff show after login
- Shared Inertia props: `auth.user.person_id`, `auth.has_photo`, `auth.qualifications_count` (coalesced into one `Person::withCount` query per request)
- Dismissible completion banner on the admin landing for users with a linked person but an incomplete profile (7-day localStorage TTL)
- New nav link gated by `person_id`

### Architecture
- `App\Services\StaffProfileProvider` extracts the ~240-line inlined eager-load + mapping from `InstitutionPersonController@show` into a service consumed by both admin and self-service pages. Payload shape is preserved exactly so the admin view is unaffected.

### Components (`resources/js/Components/MyProfile/`)
- `IdentityStrip` + `ProfileProgress` — header with 4-checkpoint progress chip (photo, ≥1 qualification, ≥1 phone, valid address). Hover/click reveals a checklist popover with per-item hints.
- `PhotoCard` — drag-and-drop upload, inline preview, remove confirm, pending-review badge for the new admin-approval flow.
- `QualificationsCard` — two-step Add wizard, multi-file Attach, View modal with per-document preview + delete.
- `PersonalDetailsCard` — DOB, gender, nationality, religion, identities.
- `ContactCard` — per-contact edit/delete/add, supports multiple of the same type. `@audit.gov.gh` emails are pinned first and protected from edit/delete.
- `AddressCard` — in-place Edit AND a Change flow that archives the current address and creates a new one (history preserved via `valid_end`).
- `DependentsCard` — read-only table with contextual empty/filled copy.

### Qualifications redesign
- Add modal is now a two-step wizard: Details → Supporting documents. Step 1 uses the original field order; step 2 supports multi-file with per-file document_type + document_title, inline previews, and a "Save without document" escape.
- New `POST /qualification/{qualification}/document/store` endpoint appends multiple documents in one request (the legacy `update` endpoint is untouched and still serves the admin flow).
- View modal replaces inline Edit on My Profile. Shows qualification fields + navigable document preview. Owners of pending qualifications can delete individual documents via a new `DELETE /qualification/{qualification}/document/{document}` endpoint.

### Photo admin approval
- New columns on `people`: `pending_image`, `pending_image_at`, `image_approved_by`, `image_approved_at`.
- Uploads now land as pending; the approved `image` stays live everywhere. New `PhotoApprovalController` drives a `/staff-photo-approvals` queue page with Approve / Reject actions.
- Three notification classes (`PhotoPendingApprovalNotification`, `PhotoApprovedNotification`, `PhotoRejectedNotification`) mirror the qualification pattern.
- New permission `approve staff photo` granted to `admin-user` and `hr-user`.

### Authorization & permissions hardening
- `ContactController::update`/`destroy` now invoke `ContactPolicy` (was returning `true` unconditionally).
- `PersonController::addContact`/`updateContact`/`deleteContact` pivot routes enforce ownership.
- New `AddressPolicy` + `PATCH /person/{person}/address/{address}` + `POST /person/{person}/address/change` routes with policy checks.
- `staff` role gains `update contacts`, `edit staff qualification`, `delete staff qualification` permissions.
- Qualifications protect against deleting the last active phone and any `@audit.gov.gh` email.
- `QualificationDocumentController::destroy` enforces `canBeEditedBy || approve staff qualification`.

### Test coverage (~70 new tests)
- `StaffProfileProviderTest`, `MyProfileShowTest`, `SharedPropsTest`, `StaffLandingRedirectTest`, `MyProfilePhotoUploadTest`, `MyProfileQualificationTest`, `MyProfileContactEditTest`, `MyProfileContactMutationTest`, `MyProfileAddressUpdateTest`, `MyProfileAddressChangeTest`, `ContactAuthorizationTest`, `CompletionBannerDataTest`, `StoreQualificationWithDocumentTest`, `StoreQualificationDocumentTest`, `DestroyQualificationDocumentTest`, `PhotoApprovalTest`.

## Deferred to a follow-up spec

- Email-change verification via tokenised link (will be next PR)
- Phone-change verification via SMS OTP (requires picking a vendor; no installed)

## Test plan

- [ ] `php artisan migrate` — adds photo-approval columns to `people`
- [ ] `php artisan db:seed --class=RolesAndPermissionsSeeder && php artisan permission:cache-reset` — creates `approve staff photo` permission and re-syncs role permissions
- [ ] `php artisan storage:link` — confirm already in place (not needed for fresh installs, required for old envs without it)
- [ ] `npm run build`
- [ ] `php artisan test` — full suite green (520+ tests)
- [ ] Log in as a staff-only user → should redirect to `/my-profile`
- [ ] Upload a photo → see "Pending review" amber chip; approved `image` unchanged everywhere else
- [ ] Add a qualification with multiple attached documents in one step → all land on the qualification
- [ ] View a qualification → cycle through document previews; delete one → card refreshes
- [ ] Edit and change an address (in-place correction vs. new address with history)
- [ ] Multi-type contacts: add, edit, delete — verify last phone and `@audit.gov.gh` email can't be deleted/edited
- [ ] Log in as `admin-user` or `hr-user` → "Photo approvals" appears in nav → open queue → Approve + Reject flows work; staff receives the matching notification
- [ ] Mobile layout stacks cleanly; dark mode legible throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)