### PR TITLE
Fix: Unit show rank distribution accuracy and filter hydration

### DIFF
--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -13,6 +13,7 @@ use App\Models\Unit;
 use App\Services\UnitHierarchy;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Maatwebsite\Excel\Facades\Excel;
@@ -310,13 +311,31 @@ class UnitController extends Controller
     {
         return Job::query()
             ->select('jobs.id', 'jobs.name')
-            ->selectRaw('COUNT(DISTINCT job_staff.id) as staff_count')
-            ->join('job_staff', 'jobs.id', '=', 'job_staff.job_id')
+            ->selectRaw('COUNT(DISTINCT institution_person.id) as staff_count')
+            ->join('job_staff', function ($join) {
+                $join->on('jobs.id', '=', 'job_staff.job_id')
+                    ->whereNull('job_staff.end_date')
+                    ->whereNull('job_staff.deleted_at');
+            })
+            ->join('institution_person', 'institution_person.id', '=', 'job_staff.staff_id')
+            ->join('staff_unit', function ($join) use ($allIds) {
+                $join->on('staff_unit.staff_id', '=', 'institution_person.id')
+                    ->whereIn('staff_unit.unit_id', $allIds)
+                    ->whereNull('staff_unit.end_date')
+                    ->whereNull('staff_unit.deleted_at');
+            })
             ->join('job_categories', 'jobs.job_category_id', '=', 'job_categories.id')
-            ->join('staff_unit', 'staff_unit.staff_id', '=', 'job_staff.staff_id')
-            ->whereIn('staff_unit.unit_id', $allIds)
-            ->whereNull('job_staff.end_date')
-            ->whereNull('staff_unit.end_date')
+            ->whereExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('status')
+                    ->whereColumn('status.staff_id', 'institution_person.id')
+                    ->whereNull('status.deleted_at')
+                    ->where('status.status', 'A')
+                    ->where(function ($inner) {
+                        $inner->whereNull('status.end_date')
+                            ->orWhere('status.end_date', '>', now());
+                    });
+            })
             ->groupBy('jobs.id', 'jobs.name', 'job_categories.level')
             ->orderBy('job_categories.level')
             ->get()
@@ -366,10 +385,14 @@ class UnitController extends Controller
             $query->search($filters['search']);
         }
         if (! empty($filters['job_category_id'])) {
-            $query->whereHas('ranks', fn ($q) => $q->where('job_category_id', $filters['job_category_id']));
+            $query->whereHas('ranks', fn ($q) => $q
+                ->where('job_category_id', $filters['job_category_id'])
+                ->whereNull('job_staff.end_date'));
         }
         if (! empty($filters['rank_id'])) {
-            $query->whereHas('ranks', fn ($q) => $q->where('jobs.id', $filters['rank_id']));
+            $query->whereHas('ranks', fn ($q) => $q
+                ->where('jobs.id', $filters['rank_id'])
+                ->whereNull('job_staff.end_date'));
         }
         if (! empty($filters['sub_unit_id'])) {
             $query->whereHas('units', fn ($q) => $q->where('units.id', $filters['sub_unit_id']));

--- a/app/Http/Requests/StaffDirectoryFilterRequest.php
+++ b/app/Http/Requests/StaffDirectoryFilterRequest.php
@@ -11,6 +11,20 @@ class StaffDirectoryFilterRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $integerFields = ['job_category_id', 'rank_id', 'sub_unit_id', 'age_from', 'age_to', 'page'];
+        $data = $this->all();
+
+        foreach ($integerFields as $field) {
+            if (array_key_exists($field, $data) && is_numeric($data[$field])) {
+                $data[$field] = (int) $data[$field];
+            }
+        }
+
+        $this->replace($data);
+    }
+
     /**
      * @return array<string, array<int, string>>
      */

--- a/tests/Feature/Unit/ShowTest.php
+++ b/tests/Feature/Unit/ShowTest.php
@@ -107,6 +107,53 @@ class ShowTest extends TestCase
         );
     }
 
+    public function test_rank_distribution_excludes_separated_staff(): void
+    {
+        $root = Unit::factory()->create(['unit_id' => null]);
+        $child = Unit::factory()->create(['unit_id' => $root->id, 'institution_id' => $root->institution_id]);
+        $rank = Job::factory()->create(['name' => 'Officer']);
+
+        $this->makeActiveStaff($root, 'M', $rank);
+        $this->makeActiveStaff($child, 'F', $rank);
+
+        $separated = $this->makeActiveStaff($child, 'M', $rank);
+        $separated->statuses()->update(['status' => 'S']);
+
+        $response = $this->actingAs($this->user)->get(route('unit.show', ['unit' => $root->id]));
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('stats.total', 2)
+            ->has('rank_distribution', 1)
+            ->where('rank_distribution.0.count', 2)
+        );
+    }
+
+    public function test_rank_distribution_ignores_soft_deleted_rank_and_unit_assignments(): void
+    {
+        $root = Unit::factory()->create(['unit_id' => null]);
+        $child = Unit::factory()->create(['unit_id' => $root->id, 'institution_id' => $root->institution_id]);
+        $rank = Job::factory()->create(['name' => 'Officer']);
+
+        $this->makeActiveStaff($root, 'M', $rank);
+
+        $withDeletedRank = $this->makeActiveStaff($child, 'F', $rank);
+        $withDeletedRank->ranks()->newPivotQuery()
+            ->where('staff_id', $withDeletedRank->id)
+            ->update(['deleted_at' => now()]);
+
+        $withDeletedUnit = $this->makeActiveStaff($child, 'M', $rank);
+        $withDeletedUnit->units()->newPivotQuery()
+            ->where('staff_id', $withDeletedUnit->id)
+            ->update(['deleted_at' => now()]);
+
+        $response = $this->actingAs($this->user)->get(route('unit.show', ['unit' => $root->id]));
+
+        $response->assertInertia(fn ($page) => $page
+            ->has('rank_distribution', 1)
+            ->where('rank_distribution.0.count', 1)
+        );
+    }
+
     public function test_initial_staff_page_uses_paginator_shape(): void
     {
         $unit = Unit::factory()->create();

--- a/tests/Feature/Unit/StaffDirectoryTest.php
+++ b/tests/Feature/Unit/StaffDirectoryTest.php
@@ -117,6 +117,49 @@ class StaffDirectoryTest extends TestCase
         );
     }
 
+    public function test_rank_filter_matches_only_current_rank_holders(): void
+    {
+        $unit = Unit::factory()->create();
+        $pastRank = Job::factory()->create();
+        $currentRank = Job::factory()->create();
+
+        $promoted = $this->makeActiveStaff($unit, null, $currentRank);
+        $promoted->ranks()->updateExistingPivot($currentRank->id, [], false);
+        $promoted->ranks()->attach($pastRank->id, [
+            'start_date' => now()->subYears(3),
+            'end_date' => now()->subYear(),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('unit.staff', ['unit' => $unit->id, 'rank_id' => $pastRank->id]));
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('staff.meta.total', 0)
+        );
+    }
+
+    public function test_category_filter_matches_only_current_rank_category(): void
+    {
+        $unit = Unit::factory()->create();
+        $pastCategory = \App\Models\JobCategory::factory()->create();
+        $currentCategory = \App\Models\JobCategory::factory()->create();
+        $pastRank = Job::factory()->create(['job_category_id' => $pastCategory->id]);
+        $currentRank = Job::factory()->create(['job_category_id' => $currentCategory->id]);
+
+        $promoted = $this->makeActiveStaff($unit, null, $currentRank);
+        $promoted->ranks()->attach($pastRank->id, [
+            'start_date' => now()->subYears(3),
+            'end_date' => now()->subYear(),
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('unit.staff', ['unit' => $unit->id, 'job_category_id' => $pastCategory->id]));
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('staff.meta.total', 0)
+        );
+    }
+
     public function test_filter_options_include_ranks_from_descendants(): void
     {
         $root = Unit::factory()->create(['unit_id' => null]);
@@ -130,6 +173,21 @@ class StaffDirectoryTest extends TestCase
         $response->assertInertia(fn ($page) => $page
             ->has('filter_options.ranks', 1)
             ->where('filter_options.ranks.0.label', 'Director')
+        );
+    }
+
+    public function test_filters_prop_has_integer_types_for_id_fields(): void
+    {
+        $unit = Unit::factory()->create();
+        $rank = Job::factory()->create();
+
+        $response = $this->actingAs($this->user)->get(
+            route('unit.show', ['unit' => $unit->id, 'rank_id' => $rank->id, 'age_from' => 25])
+        );
+
+        $response->assertInertia(fn ($page) => $page
+            ->where('filters.rank_id', $rank->id)
+            ->where('filters.age_from', 25)
         );
     }
 


### PR DESCRIPTION
## Summary
- **Rank distribution counts**: `buildRankDistribution` now filters by active status (via `status` whereExists), excludes soft-deleted `job_staff`/`staff_unit` rows, and counts DISTINCT `institution_person.id` — so per-rank totals line up with the overall "Total Staff" figure and stay cascaded across the unit + all descendants.
- **Rank / Job-category filters**: `loadStaffPage` now requires `job_staff.end_date IS NULL`, so the filters match only staff *currently* at the selected rank/category rather than anyone who has ever held it.
- **Filter hydration on refresh / shared links**: `StaffDirectoryFilterRequest::prepareForValidation` casts `job_category_id`, `rank_id`, `sub_unit_id`, `age_from`, `age_to`, and `page` to integers, so the `filters` prop delivered to Inertia matches `SearchSelect`'s strict-equality option values and the UI correctly reflects URL query parameters.

## Test plan
- [x] `php artisan test tests/Feature/Unit` (15 passed / 154 assertions)
- [x] New tests:
  - `rank distribution excludes separated staff`
  - `rank distribution ignores soft deleted rank and unit assignments`
  - `rank filter matches only current rank holders`
  - `category filter matches only current rank category`
  - `filters prop has integer types for id fields`
- [ ] Manual smoke test on Unit show: open a unit with mixed active/separated staff, confirm rank distribution totals = total staff stat; apply a rank/category filter then refresh — selected option stays highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)