### PR TITLE
feat: add staff statistics API endpoint

### DIFF
--- a/app/Http/Controllers/StaffStatisticsController.php
+++ b/app/Http/Controllers/StaffStatisticsController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\OfficeTypeEnum;
+use App\Enums\QualificationLevelEnum;
+use App\Enums\QualificationStatusEnum;
+use App\Enums\StaffTypeEnum;
+use App\Models\InstitutionPerson;
+use App\Models\Office;
+use App\Models\Qualification;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
+
+class StaffStatisticsController extends Controller
+{
+    /**
+     * Return aggregate staff statistics.
+     */
+    public function index(): JsonResponse
+    {
+        $statistics = Cache::remember('staff_statistics', 3600, fn () => [
+            'total_staff' => $this->totalStaff(),
+            'regional_offices' => $this->officeCountByType(OfficeTypeEnum::REGIONAL),
+            'district_offices' => $this->officeCountByType(OfficeTypeEnum::DISTRICT),
+            'field_staff' => $this->fieldStaff(),
+            'professionals' => $this->professionals(),
+            'professions' => $this->professions(),
+        ]);
+
+        return response()->json($statistics);
+    }
+
+    /**
+     * Count of currently active staff.
+     */
+    protected function totalStaff(): int
+    {
+        return InstitutionPerson::query()->active()->count();
+    }
+
+    /**
+     * Count of offices for a given type.
+     */
+    protected function officeCountByType(OfficeTypeEnum $type): int
+    {
+        return Office::query()->where('type', $type)->count();
+    }
+
+    /**
+     * Count of active field staff (audit staff).
+     *
+     * Field staff are identified by their current StaffType being either
+     * Field (FS) or Field Support Service (FSS).
+     */
+    protected function fieldStaff(): int
+    {
+        return InstitutionPerson::query()
+            ->active()
+            ->whereHas('type', function ($query) {
+                $query->whereIn('staff_type', [
+                    StaffTypeEnum::Field->value,
+                    StaffTypeEnum::SupportService->value,
+                ]);
+                $query->where(function ($dateQuery) {
+                    $dateQuery->whereNull('end_date');
+                    $dateQuery->orWhere('end_date', '>', now());
+                });
+            })
+            ->count();
+    }
+
+    /**
+     * Count of active staff who hold at least one approved
+     * professional-level qualification.
+     */
+    protected function professionals(): int
+    {
+        return InstitutionPerson::query()
+            ->active()
+            ->whereHas('person.qualifications', function ($query) {
+                $query->where('level', QualificationLevelEnum::Professional->value);
+                $query->where('status', QualificationStatusEnum::Approved->value);
+            })
+            ->count();
+    }
+
+    /**
+     * Count of distinct professions held by staff, derived from
+     * approved professional-level qualifications.
+     */
+    protected function professions(): int
+    {
+        return Qualification::query()
+            ->where('level', QualificationLevelEnum::Professional->value)
+            ->where('status', QualificationStatusEnum::Approved->value)
+            ->whereNotNull('course')
+            ->where('course', '<>', '')
+            ->distinct()
+            ->count('course');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\StaffSearchOptionsController;
+use App\Http\Controllers\StaffStatisticsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -16,3 +17,8 @@ Route::middleware('auth:sanctum')->prefix('staff-search')->group(function () {
     Route::get('/units', [StaffSearchOptionsController::class, 'units'])->name('api.staff-search.units');
     Route::get('/departments', [StaffSearchOptionsController::class, 'departments'])->name('api.staff-search.departments');
 });
+
+// Staff statistics
+Route::middleware('auth:sanctum')
+    ->get('/staff-statistics', [StaffStatisticsController::class, 'index'])
+    ->name('api.staff-statistics');

--- a/tests/Feature/StaffStatisticsApiTest.php
+++ b/tests/Feature/StaffStatisticsApiTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\DistrictTypeEnum;
+use App\Enums\OfficeTypeEnum;
+use App\Enums\QualificationLevelEnum;
+use App\Enums\StaffTypeEnum;
+use App\Models\District;
+use App\Models\Institution;
+use App\Models\InstitutionPerson;
+use App\Models\Office;
+use App\Models\Qualification;
+use App\Models\Region;
+use App\Models\StaffType;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class StaffStatisticsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Institution $institution;
+
+    protected District $district;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::forget('staff_statistics');
+
+        $this->user = User::factory()->create();
+        $this->institution = Institution::factory()->create();
+
+        Model::unguarded(function () {
+            $region = Region::create([
+                'name' => 'Test Region',
+                'capital' => 'Test Capital',
+            ]);
+
+            $this->district = District::create([
+                'name' => 'Test District',
+                'region_id' => $region->id,
+                'capital' => 'Test District Capital',
+                'district_type' => DistrictTypeEnum::DISTRICT,
+            ]);
+        });
+    }
+
+    public function test_endpoint_requires_authentication(): void
+    {
+        $response = $this->get('/api/staff-statistics');
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_endpoint_returns_expected_json_structure(): void
+    {
+        $response = $this->actingAs($this->user)->get('/api/staff-statistics');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'total_staff',
+                'regional_offices',
+                'district_offices',
+                'field_staff',
+                'professionals',
+                'professions',
+            ]);
+    }
+
+    public function test_endpoint_returns_correct_statistics(): void
+    {
+        // Offices: 2 regional, 3 district, 1 headquarters
+        Office::create(['name' => 'Greater Accra Regional', 'type' => OfficeTypeEnum::REGIONAL, 'district_id' => $this->district->id]);
+        Office::create(['name' => 'Ashanti Regional', 'type' => OfficeTypeEnum::REGIONAL, 'district_id' => $this->district->id]);
+        Office::create(['name' => 'Tema District', 'type' => OfficeTypeEnum::DISTRICT, 'district_id' => $this->district->id]);
+        Office::create(['name' => 'Kumasi District', 'type' => OfficeTypeEnum::DISTRICT, 'district_id' => $this->district->id]);
+        Office::create(['name' => 'Cape Coast District', 'type' => OfficeTypeEnum::DISTRICT, 'district_id' => $this->district->id]);
+        Office::create(['name' => 'HQ', 'type' => OfficeTypeEnum::HEADQUARTERS, 'district_id' => $this->district->id]);
+
+        // 4 active staff
+        $activeStaff = collect();
+        for ($i = 0; $i < 4; $i++) {
+            $staff = InstitutionPerson::factory()->create(['institution_id' => $this->institution->id]);
+            $staff->statuses()->create([
+                'status' => 'A',
+                'start_date' => now()->subYear(),
+                'end_date' => null,
+                'institution_id' => $this->institution->id,
+            ]);
+            $activeStaff->push($staff);
+        }
+
+        // 1 separated/non-active staff (status != A)
+        $separated = InstitutionPerson::factory()->create(['institution_id' => $this->institution->id]);
+        $separated->statuses()->create([
+            'status' => 'E',
+            'start_date' => now()->subMonth(),
+            'end_date' => null,
+            'institution_id' => $this->institution->id,
+        ]);
+
+        // 2 of the active staff are field staff (FS), 1 is FSS
+        StaffType::create([
+            'staff_id' => $activeStaff[0]->id,
+            'staff_type' => StaffTypeEnum::Field->value,
+            'start_date' => now()->subYear(),
+            'end_date' => null,
+        ]);
+        StaffType::create([
+            'staff_id' => $activeStaff[1]->id,
+            'staff_type' => StaffTypeEnum::Field->value,
+            'start_date' => now()->subYear(),
+            'end_date' => null,
+        ]);
+        StaffType::create([
+            'staff_id' => $activeStaff[2]->id,
+            'staff_type' => StaffTypeEnum::SupportService->value,
+            'start_date' => now()->subYear(),
+            'end_date' => null,
+        ]);
+        StaffType::create([
+            'staff_id' => $activeStaff[3]->id,
+            'staff_type' => StaffTypeEnum::Supporting->value,
+            'start_date' => now()->subYear(),
+            'end_date' => null,
+        ]);
+
+        // 2 active staff have professional qualifications across 2 distinct professions
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Professional)->create([
+            'person_id' => $activeStaff[0]->person_id,
+            'course' => 'Accountancy',
+        ]);
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Professional)->create([
+            'person_id' => $activeStaff[1]->person_id,
+            'course' => 'Auditing',
+        ]);
+        // Duplicate profession - should not increase distinct count
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Professional)->create([
+            'person_id' => $activeStaff[2]->person_id,
+            'course' => 'Accountancy',
+        ]);
+        // Non-professional qualification should be ignored
+        Qualification::factory()->approved()->atLevel(QualificationLevelEnum::Degree)->create([
+            'person_id' => $activeStaff[3]->person_id,
+            'course' => 'Engineering',
+        ]);
+        // Pending professional qualification should be ignored
+        Qualification::factory()->pending()->atLevel(QualificationLevelEnum::Professional)->create([
+            'person_id' => $activeStaff[3]->person_id,
+            'course' => 'Law',
+        ]);
+
+        Cache::forget('staff_statistics');
+
+        $response = $this->actingAs($this->user)->get('/api/staff-statistics');
+
+        $response->assertStatus(200)
+            ->assertExactJson([
+                'total_staff' => 4,
+                'regional_offices' => 2,
+                'district_offices' => 3,
+                'field_staff' => 3,
+                'professionals' => 3,
+                'professions' => 2,
+            ]);
+    }
+}


### PR DESCRIPTION
Adds GET /api/staff-statistics returning total active staff, regional
and district office counts, field/audit staff count, professionals
count, and the number of distinct professions. Cached for 1 hour
following the existing staff-search options pattern.

https://claude.ai/code/session_013zGUivZcK58ahaqNg4fWb2