### PR TITLE
fix: run test suite inside Sail by exposing DB_HOST to the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       LARAVEL_SAIL: 1
       XDEBUG_MODE: "${SAIL_XDEBUG_MODE:-off}"
       XDEBUG_CONFIG: "${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}"
+      DB_HOST: "${DB_HOST:-mysql}"
     volumes:
       - ".:/var/www/html"
     networks:


### PR DESCRIPTION
## Summary

`sail artisan test` failed with `SQLSTATE[HY000] [2002] Connection refused` for every database test.

**Root cause:** `phpunit.xml` hardcodes `DB_HOST=127.0.0.1`, which only resolves when tests run on the host (Docker maps the port to localhost). Running tests inside the Sail app container makes `127.0.0.1` point at the app container itself, where no MySQL listens.

**Fix:** Expose `DB_HOST=mysql` as a real environment variable on the `laravel.test` service. PHPUnit's `<env name="DB_HOST" value="127.0.0.1"/>` has no `force` attribute, so it's a default that only applies when the variable isn't already set:
- **In Sail** → the real env var `mysql` wins.
- **On the host** → no real env var, so `127.0.0.1` applies.

Both workflows pass with no `phpunit.xml` change.

> [!NOTE]
> Requires recreating the container to pick up the new env var: `sail up -d`.

## Test plan
- `sail artisan test` — **579 passed (2042 assertions)**
- `php artisan test` (host) — still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)