### PR TITLE
feat: show user photo in top navigation

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -21,7 +21,7 @@ class HandleInertiaRequests extends Middleware
      * Laravel resolves middleware fresh per request, so this stays
      * request-scoped without leaking across users.
      *
-     * @var array{has_photo: bool, qualifications_count: int}|null|false
+     * @var array{has_photo: bool, qualifications_count: int, photo_url: ?string}|null|false
      */
     private array|false|null $profileFactsCache = false;
 
@@ -57,6 +57,7 @@ class HandleInertiaRequests extends Middleware
                 'isMultiRoleStaff' => fn () => $request->user()?->isMultiRoleStaff() ?? false,
                 'viewModeLabel' => fn () => $this->resolveViewModeLabel($request->user()),
                 'has_photo' => fn () => $this->profileFactsForCurrentUser($request)['has_photo'] ?? null,
+                'photo_url' => fn () => $this->profileFactsForCurrentUser($request)['photo_url'] ?? null,
                 'qualifications_count' => fn () => $this->profileFactsForCurrentUser($request)['qualifications_count'] ?? null,
             ],
             // 'permissions' => fn() => $request->user()?->getAllPermissions()->pluck('name'),
@@ -84,12 +85,12 @@ class HandleInertiaRequests extends Middleware
     }
 
     /**
-     * Return the authenticated user's photo-presence and qualification-count
-     * facts as a single associative array, or null when the request has no
-     * authenticated user linked to a Person. The result is memoized for the
-     * life of this request; the underlying query is one eager-loaded count.
+     * Return the authenticated user's photo-presence, qualification-count, and
+     * photo URL facts as a single associative array, or null when the request
+     * has no authenticated user linked to a Person. The result is memoized for
+     * the life of this request; the underlying query is one eager-loaded count.
      *
-     * @return array{has_photo: bool, qualifications_count: int}|null
+     * @return array{has_photo: bool, qualifications_count: int, photo_url: ?string}|null
      */
     private function profileFactsForCurrentUser(Request $request): ?array
     {
@@ -111,12 +112,14 @@ class HandleInertiaRequests extends Middleware
             return $this->profileFactsCache = [
                 'has_photo' => false,
                 'qualifications_count' => 0,
+                'photo_url' => null,
             ];
         }
 
         return $this->profileFactsCache = [
             'has_photo' => (bool) $person->image,
             'qualifications_count' => (int) $person->qualifications_count,
+            'photo_url' => $person->image ? '/storage/' . $person->image : null,
         ];
     }
 }

--- a/docs/superpowers/plans/2026-06-01-nav-user-photo.md
+++ b/docs/superpowers/plans/2026-06-01-nav-user-photo.md
@@ -1,0 +1,280 @@
+# User Photo in Top Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the authenticated user's profile photo in the top-right of the top navigation, next to their name, falling back to the existing placeholder image when no photo is set.
+
+**Architecture:** Add a `photo_url` to the shared Inertia `auth` data (sibling of `auth.user`, derived from the already-loaded `Person.image` with no new query), then bind it into the three authenticated layout menus with a placeholder fallback.
+
+**Tech Stack:** Laravel 11 (Inertia middleware), Vue 3 + Inertia.js, PHPUnit feature tests.
+
+---
+
+## File Structure
+
+- **Modify:** `app/Http/Middleware/HandleInertiaRequests.php` — add `photo_url` to shared `auth` data and to the `profileFactsForCurrentUser()` helper.
+- **Modify:** `tests/Feature/MyProfile/SharedPropsTest.php` — add two assertions for `auth.photo_url`.
+- **Modify:** `resources/js/Components/TopMenu.vue` — bind the existing `<img>` src to the photo URL (NewAuthenticated layout, 71 pages).
+- **Modify:** `resources/js/Layouts/HrAuthenticated.vue` — add a photo `<img>` to the dropdown trigger (12 pages).
+- **Modify:** `resources/js/Layouts/Authenticated.vue` — add a photo `<img>` to the dropdown trigger (1 page).
+
+Backend and its test ship first (Task 1), so the frontend tasks (Tasks 2-4) consume a prop that already exists and is tested.
+
+---
+
+## Task 1: Share `photo_url` from the Inertia middleware
+
+**Files:**
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php`
+- Test: `tests/Feature/MyProfile/SharedPropsTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two methods to `tests/Feature/MyProfile/SharedPropsTest.php`, after the existing `test_has_photo_flips_true_when_person_image_is_set` method (around line 38). They reuse the existing `createActiveStaff()` helper already in the file.
+
+```php
+    public function test_photo_url_is_storage_path_when_person_image_is_set(): void
+    {
+        $staff = $this->createActiveStaff();
+        $staff->person->update(['image' => 'avatars/example.jpg']);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.photo_url', '/storage/avatars/example.jpg'));
+    }
+
+    public function test_photo_url_is_null_when_person_has_no_image(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.photo_url', null));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `php artisan test --filter=SharedPropsTest`
+Expected: the two new tests FAIL because `auth.photo_url` is missing (Inertia assertion reports the prop does not exist / value mismatch). The four pre-existing tests still PASS.
+
+- [ ] **Step 3: Add `photo_url` to the `profileFactsForCurrentUser()` helper**
+
+In `app/Http/Middleware/HandleInertiaRequests.php`, update the helper so every return path includes a `photo_url` key.
+
+Update the PHPDoc return shape (currently `array{has_photo: bool, qualifications_count: int}|null`):
+
+```php
+     * @return array{has_photo: bool, qualifications_count: int, photo_url: ?string}|null
+```
+
+Change the "no `$person`" early return (currently returns `has_photo`/`qualifications_count` only):
+
+```php
+        if (! $person) {
+            return $this->profileFactsCache = [
+                'has_photo' => false,
+                'qualifications_count' => 0,
+                'photo_url' => null,
+            ];
+        }
+```
+
+Change the final return:
+
+```php
+        return $this->profileFactsCache = [
+            'has_photo' => (bool) $person->image,
+            'qualifications_count' => (int) $person->qualifications_count,
+            'photo_url' => $person->image ? '/storage/'.$person->image : null,
+        ];
+```
+
+(The `! $user || ! $user->person_id` path already returns `null`, so callers using `['photo_url'] ?? null` get `null` there — no change needed.)
+
+- [ ] **Step 4: Add `photo_url` to the shared `auth` block**
+
+In the same file, in the `share()` method, add this line immediately after the existing `'has_photo' => ...` line (currently line 59), inside the `'auth' => [ ... ]` array:
+
+```php
+                'photo_url' => fn () => $this->profileFactsForCurrentUser($request)['photo_url'] ?? null,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `php artisan test --filter=SharedPropsTest`
+Expected: all six tests PASS (four pre-existing + two new).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+vendor/bin/pint --dirty
+git add app/Http/Middleware/HandleInertiaRequests.php tests/Feature/MyProfile/SharedPropsTest.php
+git commit -m "feat: share user photo_url via Inertia auth props
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Show the photo in `TopMenu.vue` (NewAuthenticated, 71 pages)
+
+**Files:**
+- Modify: `resources/js/Components/TopMenu.vue`
+
+This layout already renders an `<img>` with the correct classes; only the `src` is hardcoded. There is no JS-level test harness for these layout components in this repo (the test coverage for this feature is the Inertia-prop test in Task 1). Verification here is a manual build + visual check.
+
+- [ ] **Step 1: Add a `photoUrl` computed**
+
+In `resources/js/Components/TopMenu.vue`, the script already has `import { computed } from "vue";`, `import { ... usePage } from "@inertiajs/vue3";`, `const page = usePage();`, and `const user = computed(() => page.props?.auth.user);` (around line 14). Add directly below the `user` line:
+
+```js
+const photoUrl = computed(() => page.props?.auth?.photo_url);
+```
+
+- [ ] **Step 2: Bind the `<img>` src**
+
+In the same file, find the profile-dropdown `<img>` (around lines 64-68):
+
+```vue
+						<img
+							class="h-8 w-8 rounded-full bg-gray-50"
+							src="/images/placeholder.webp"
+							alt=""
+						/>
+```
+
+Replace the `src="/images/placeholder.webp"` attribute with a bound src and an object-cover for non-square photos:
+
+```vue
+						<img
+							class="h-8 w-8 rounded-full bg-gray-50 object-cover"
+							:src="photoUrl || '/images/placeholder.webp'"
+							alt=""
+						/>
+```
+
+- [ ] **Step 3: Build the frontend to verify it compiles**
+
+Run: `npm run build`
+Expected: build completes with no errors referencing `TopMenu.vue`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Components/TopMenu.vue
+git commit -m "feat: show user photo in TopMenu nav avatar
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add the photo to `HrAuthenticated.vue` (12 pages)
+
+**Files:**
+- Modify: `resources/js/Layouts/HrAuthenticated.vue`
+
+This layout's dropdown trigger is currently text-only (`{{ user.name }}` + chevron). Add an avatar `<img>` before the name.
+
+- [ ] **Step 1: Add a `photoUrl` computed**
+
+In `resources/js/Layouts/HrAuthenticated.vue`, the script setup already has `import { computed } from "vue";`, `import { ... usePage } from "@inertiajs/vue3";`, `const page = usePage();`, and `const user = computed(() => page.props?.auth.user);` (line 11). Add directly below the `user` line:
+
+```js
+const photoUrl = computed(() => page.props?.auth?.photo_url);
+```
+
+- [ ] **Step 2: Add the `<img>` to the dropdown trigger button**
+
+In the same file, find the trigger button content (around line 80):
+
+```vue
+											{{ user.name }}
+```
+
+Insert the avatar image immediately before that `{{ user.name }}` line, so the button shows photo then name:
+
+```vue
+											<img
+												class="h-8 w-8 rounded-full object-cover mr-2 bg-gray-50"
+												:src="photoUrl || '/images/placeholder.webp'"
+												alt=""
+											/>
+											{{ user.name }}
+```
+
+- [ ] **Step 3: Build the frontend to verify it compiles**
+
+Run: `npm run build`
+Expected: build completes with no errors referencing `HrAuthenticated.vue`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Layouts/HrAuthenticated.vue
+git commit -m "feat: show user photo in HrAuthenticated nav
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add the photo to `Authenticated.vue` (1 page)
+
+**Files:**
+- Modify: `resources/js/Layouts/Authenticated.vue`
+
+Identical change to Task 3, in the other Breeze-style layout. Its trigger button content `{{ user.name }}` is around line 63.
+
+- [ ] **Step 1: Add a `photoUrl` computed**
+
+In `resources/js/Layouts/Authenticated.vue`, the script setup already has `import { ref, computed } from "vue";`, `import { Link, usePage } from "@inertiajs/vue3";`, `const page = usePage();`, and `const user = computed(() => page.props?.auth.user);` (line 11). Add directly below the `user` line:
+
+```js
+const photoUrl = computed(() => page.props?.auth?.photo_url);
+```
+
+- [ ] **Step 2: Add the `<img>` to the dropdown trigger button**
+
+In the same file, find the trigger button content (around line 63):
+
+```vue
+											{{ user.name }}
+```
+
+Insert the avatar image immediately before that `{{ user.name }}` line:
+
+```vue
+											<img
+												class="h-8 w-8 rounded-full object-cover mr-2 bg-gray-50"
+												:src="photoUrl || '/images/placeholder.webp'"
+												alt=""
+											/>
+											{{ user.name }}
+```
+
+- [ ] **Step 3: Build the frontend to verify it compiles**
+
+Run: `npm run build`
+Expected: build completes with no errors referencing `Authenticated.vue`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Layouts/Authenticated.vue
+git commit -m "feat: show user photo in Authenticated nav
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the affected backend test:** `php artisan test --filter=SharedPropsTest` → all six pass.
+- [ ] **Run Pint:** `vendor/bin/pint --dirty` → no changes needed (clean).
+- [ ] **Build:** `npm run build` → succeeds.
+- [ ] Confirm the four commits are present: `git log --oneline -4`.

--- a/docs/superpowers/specs/2026-06-01-nav-user-photo-design.md
+++ b/docs/superpowers/specs/2026-06-01-nav-user-photo-design.md
@@ -1,0 +1,95 @@
+# Design: User photo in top navigation
+
+**Date:** 2026-06-01
+**Branch:** `feat/nav-user-photo`
+
+## Goal
+
+Show the authenticated user's profile photo in the top-right of the top navigation
+bar, next to their name. When a user has not set a photo, fall back to the existing
+generic placeholder image.
+
+## Background
+
+The app has three authenticated layouts with a top-right user menu:
+
+| Layout | Pages | Current top-right state |
+|---|---|---|
+| `NewAuthenticated.vue` → `Components/TopMenu.vue` | 71 | Already renders an `<img>` next to the name, hardcoded to `/images/placeholder.webp` |
+| `HrAuthenticated.vue` | 12 | Text-only dropdown trigger: `{{ user.name }}` + chevron, no image |
+| `Authenticated.vue` | 1 | Text-only dropdown trigger: `{{ user.name }}` + chevron, no image |
+
+The authenticated user's photo lives on the related `Person` model in the `image`
+column (relative path such as `avatars/abc123.png`), served from the `public` disk
+at `/storage/{image}`. The shared Inertia `auth.user` data currently exposes only a
+`has_photo` boolean, not the photo URL.
+
+The existing helper `HandleInertiaRequests::profileFactsForCurrentUser()` already
+loads `$person->image` (it computes `has_photo` from it) and memoizes the result for
+the life of the request. Deriving a photo URL there adds **no new database work**.
+
+## Scope
+
+All three layouts get the photo. The no-photo fallback is the existing
+`/images/placeholder.webp` everywhere — no initials logic.
+
+## Design
+
+### Backend — shared Inertia data
+
+In `app/Http/Middleware/HandleInertiaRequests.php`:
+
+1. Extend `profileFactsForCurrentUser()` to also return a `photo_url` key:
+   - `'/storage/' . $person->image` when `$person->image` is set (matching the
+     existing convention in `PhotoApprovalController`).
+   - `null` when there is no photo, no `person`, or no authenticated user.
+   - Update the method's PHPDoc array shape to include `photo_url: ?string`.
+2. Add to the `auth.user`-level share block, next to `has_photo`:
+   ```php
+   'photo_url' => fn () => $this->profileFactsForCurrentUser($request)['photo_url'] ?? null,
+   ```
+
+`photo_url` is then globally available on every Inertia page with no extra HTTP
+request.
+
+### Frontend — the three menus
+
+In all three, the photo source uses the same fallback expression:
+`:src="user?.photo_url || '/images/placeholder.webp'"`.
+
+1. **`Components/TopMenu.vue`** — change the existing `<img>`'s hardcoded
+   `src="/images/placeholder.webp"` to the bound `:src` expression. The `<img>`,
+   its `h-8 w-8 rounded-full bg-gray-50` classes, and the `user` computed prop
+   already exist.
+
+2. **`Layouts/HrAuthenticated.vue`** — add an `<img class="h-8 w-8 rounded-full
+   object-cover mr-2">` inside the dropdown trigger button, before
+   `{{ user.name }}`, using the same `:src` expression. `user` is already available
+   in this layout.
+
+3. **`Layouts/Authenticated.vue`** — same addition as `HrAuthenticated.vue`.
+
+### Fallback behaviour
+
+When `photo_url` is `null` (user has no photo set), all three menus render
+`/images/placeholder.webp`, identical to today's behaviour in `TopMenu.vue`.
+
+## Testing
+
+A feature test against the shared Inertia data (following existing
+`HandleInertiaRequests` / Inertia-prop test conventions in `tests/Feature`):
+
+- **Has photo:** authenticated user whose `Person` has `image = 'avatars/x.png'` →
+  shared `auth.user.photo_url` equals `/storage/avatars/x.png`.
+- **No photo:** authenticated user whose `Person` has no `image` → `auth.user.photo_url`
+  is `null`.
+
+Run with `php artisan test --filter` on the new test, then `vendor/bin/pint --dirty`.
+
+## Out of scope
+
+- Initials-based avatar fallback (deferred; placeholder image is sufficient for now).
+- Photo upload/approval workflow changes (already exists via `PhotoCard.vue` /
+  `PhotoApprovalController`).
+- Showing photos for other users elsewhere in the UI (this is only the current
+  user's nav avatar).

--- a/docs/superpowers/specs/2026-06-01-nav-user-photo-design.md
+++ b/docs/superpowers/specs/2026-06-01-nav-user-photo-design.md
@@ -21,8 +21,8 @@ The app has three authenticated layouts with a top-right user menu:
 
 The authenticated user's photo lives on the related `Person` model in the `image`
 column (relative path such as `avatars/abc123.png`), served from the `public` disk
-at `/storage/{image}`. The shared Inertia `auth.user` data currently exposes only a
-`has_photo` boolean, not the photo URL.
+at `/storage/{image}`. The shared Inertia `auth` data currently exposes a `has_photo`
+boolean (at `auth.has_photo`, a sibling of `auth.user`), but not the photo URL.
 
 The existing helper `HandleInertiaRequests::profileFactsForCurrentUser()` already
 loads `$person->image` (it computes `has_photo` from it) and memoizes the result for
@@ -44,28 +44,30 @@ In `app/Http/Middleware/HandleInertiaRequests.php`:
      existing convention in `PhotoApprovalController`).
    - `null` when there is no photo, no `person`, or no authenticated user.
    - Update the method's PHPDoc array shape to include `photo_url: ?string`.
-2. Add to the `auth.user`-level share block, next to `has_photo`:
+2. Add to the `auth` share block, next to `has_photo` (i.e. at `auth.photo_url`,
+   a sibling of `auth.user` — matching the existing `has_photo` placement):
    ```php
    'photo_url' => fn () => $this->profileFactsForCurrentUser($request)['photo_url'] ?? null,
    ```
 
-`photo_url` is then globally available on every Inertia page with no extra HTTP
-request.
+`photo_url` is then globally available on every Inertia page at `auth.photo_url`
+with no extra HTTP request.
 
 ### Frontend — the three menus
 
-In all three, the photo source uses the same fallback expression:
-`:src="user?.photo_url || '/images/placeholder.webp'"`.
+The photo URL is read from `page.props.auth.photo_url` (a sibling of `auth.user`),
+and the photo source uses the same fallback expression in all three menus:
+`:src="photoUrl || '/images/placeholder.webp'"`, where
+`const photoUrl = computed(() => page.props?.auth?.photo_url)`.
 
-1. **`Components/TopMenu.vue`** — change the existing `<img>`'s hardcoded
-   `src="/images/placeholder.webp"` to the bound `:src` expression. The `<img>`,
-   its `h-8 w-8 rounded-full bg-gray-50` classes, and the `user` computed prop
-   already exist.
+1. **`Components/TopMenu.vue`** — add a `photoUrl` computed, then change the
+   existing `<img>`'s hardcoded `src="/images/placeholder.webp"` to the bound `:src`
+   expression. The `<img>` and its `h-8 w-8 rounded-full bg-gray-50` classes already
+   exist; `usePage`/`computed` are already imported.
 
-2. **`Layouts/HrAuthenticated.vue`** — add an `<img class="h-8 w-8 rounded-full
-   object-cover mr-2">` inside the dropdown trigger button, before
-   `{{ user.name }}`, using the same `:src` expression. `user` is already available
-   in this layout.
+2. **`Layouts/HrAuthenticated.vue`** — add a `photoUrl` computed and an `<img
+   class="h-8 w-8 rounded-full object-cover mr-2">` inside the dropdown trigger
+   button, before `{{ user.name }}`, using the same `:src` expression.
 
 3. **`Layouts/Authenticated.vue`** — same addition as `HrAuthenticated.vue`.
 
@@ -76,15 +78,14 @@ When `photo_url` is `null` (user has no photo set), all three menus render
 
 ## Testing
 
-A feature test against the shared Inertia data (following existing
-`HandleInertiaRequests` / Inertia-prop test conventions in `tests/Feature`):
+Two new test methods added to `tests/Feature/MyProfile/SharedPropsTest.php`, reusing
+its existing `createActiveStaff()` helper and assertion style:
 
-- **Has photo:** authenticated user whose `Person` has `image = 'avatars/x.png'` →
-  shared `auth.user.photo_url` equals `/storage/avatars/x.png`.
-- **No photo:** authenticated user whose `Person` has no `image` → `auth.user.photo_url`
-  is `null`.
+- **Has photo:** staff whose `Person` has `image = 'avatars/example.jpg'` → shared
+  `auth.photo_url` equals `/storage/avatars/example.jpg`.
+- **No photo:** staff whose `Person` has no `image` → `auth.photo_url` is `null`.
 
-Run with `php artisan test --filter` on the new test, then `vendor/bin/pint --dirty`.
+Run with `php artisan test --filter=SharedPropsTest`, then `vendor/bin/pint --dirty`.
 
 ## Out of scope
 

--- a/resources/js/Components/TopMenu.vue
+++ b/resources/js/Components/TopMenu.vue
@@ -12,6 +12,7 @@ const isDark = useDark();
 const toggleDark = useToggle(isDark);
 const page = usePage();
 const user = computed(() => page.props?.auth.user);
+const photoUrl = computed(() => page.props?.auth?.photo_url);
 defineProps({
 	userNavigation: Array,
 });
@@ -62,8 +63,8 @@ defineProps({
 				<MenuButton class="-m-1.5 flex items-center p-1.5">
 					<span class="sr-only">Open user menu</span>
 					<img
-						class="h-8 w-8 rounded-full bg-gray-50"
-						src="/images/placeholder.webp"
+						class="h-8 w-8 rounded-full bg-gray-50 object-cover"
+						:src="photoUrl || '/images/placeholder.webp'"
 						alt=""
 					/>
 					<span class="hidden lg:flex lg:items-center">

--- a/resources/js/Layouts/Authenticated.vue
+++ b/resources/js/Layouts/Authenticated.vue
@@ -9,6 +9,7 @@ import { Link, usePage } from "@inertiajs/vue3";
 
 const page = usePage();
 const user = computed(() => page.props?.auth.user);
+const photoUrl = computed(() => page.props?.auth?.photo_url);
 const permissions = computed(() => page.props?.auth?.permissions);
 const canViewDashboard = computed(() =>
 	permissions.value?.includes("view dashboard"),
@@ -60,6 +61,11 @@ const showingNavigationDropdown = ref(false);
 												type="button"
 												class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
 											>
+												<img
+													class="h-8 w-8 rounded-full object-cover mr-2 bg-gray-50"
+													:src="photoUrl || '/images/placeholder.webp'"
+													alt=""
+												/>
 												{{ user.name }}
 
 												<svg

--- a/resources/js/Layouts/HrAuthenticated.vue
+++ b/resources/js/Layouts/HrAuthenticated.vue
@@ -9,6 +9,7 @@ import { Link, usePage } from "@inertiajs/vue3";
 
 const page = usePage();
 const user = computed(() => page.props?.auth.user);
+const photoUrl = computed(() => page.props?.auth?.photo_url);
 const permissions = computed(() => page.props?.auth?.permissions);
 const canViewDashboard = computed(() =>
 	permissions.value?.includes("view dashboard"),
@@ -77,6 +78,11 @@ const showingNavigationDropdown = ref(false);
 											type="button"
 											class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
 										>
+											<img
+												class="h-8 w-8 rounded-full object-cover mr-2 bg-gray-50"
+												:src="photoUrl || '/images/placeholder.webp'"
+												alt=""
+											/>
 											{{ user.name }}
 
 											<svg

--- a/tests/Feature/MyProfile/SharedPropsTest.php
+++ b/tests/Feature/MyProfile/SharedPropsTest.php
@@ -80,6 +80,7 @@ class SharedPropsTest extends TestCase
             ->assertInertia(fn ($page) => $page
                 ->where('auth.has_photo', null)
                 ->where('auth.qualifications_count', null)
+                ->where('auth.photo_url', null)
             );
     }
 

--- a/tests/Feature/MyProfile/SharedPropsTest.php
+++ b/tests/Feature/MyProfile/SharedPropsTest.php
@@ -48,6 +48,27 @@ class SharedPropsTest extends TestCase
             ->assertInertia(fn ($page) => $page->where('auth.qualifications_count', 3));
     }
 
+    public function test_photo_url_is_storage_path_when_person_image_is_set(): void
+    {
+        $staff = $this->createActiveStaff();
+        $staff->person->update(['image' => 'avatars/example.jpg']);
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.photo_url', '/storage/avatars/example.jpg'));
+    }
+
+    public function test_photo_url_is_null_when_person_has_no_image(): void
+    {
+        $staff = $this->createActiveStaff();
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        $this->actingAs($user)
+            ->get(route('my-profile.show'))
+            ->assertInertia(fn ($page) => $page->where('auth.photo_url', null));
+    }
+
     public function test_props_are_null_for_users_without_person_id(): void
     {
         $user = User::factory()->create(['person_id' => null]);


### PR DESCRIPTION
## Summary

Shows the authenticated user's profile photo in the top-right of the top navigation, next to their name. Falls back to the existing `/images/placeholder.webp` when no photo is set.

## What changed

- **Backend** — `HandleInertiaRequests` now shares an `auth.photo_url` prop, derived from the already-loaded `Person.image` (no new DB query — piggybacks the existing memoized `profileFactsForCurrentUser()` lookup). Resolves to `/storage/{image}` when a photo exists, `null` otherwise — covering the no-photo, no-person, and no-user cases. The `/storage/` convention matches the rest of the codebase.
- **All three authenticated layouts** wired up with a consistent `photoUrl` computed + `photoUrl || '/images/placeholder.webp'` fallback and `object-cover`:
  - `Components/TopMenu.vue` (used by `NewAuthenticated`, 71 pages) — bound the existing hardcoded avatar `<img>`.
  - `Layouts/HrAuthenticated.vue` (12 pages) — added an avatar to the previously text-only dropdown trigger.
  - `Layouts/Authenticated.vue` (1 page) — same addition.

## Tests

Three new assertions in `tests/Feature/MyProfile/SharedPropsTest.php`:
- has photo → `auth.photo_url` is `/storage/avatars/example.jpg`
- no photo → `auth.photo_url` is `null`
- no `person_id` → `auth.photo_url` is `null`

`php artisan test --filter=SharedPropsTest` → 6 passed. Pint clean.

## Deploy note

Requires the `public/storage` symlink (`php artisan storage:link`) for avatars to resolve — this is the standard app-wide storage step, not specific to this feature.

## Docs

Spec and implementation plan committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)