### PR TITLE
Redesign user show page (two-column, green-clean) + permission correctness fix

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -99,9 +99,24 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-        $user->load(['roles', 'permissions', 'person.institution']);
+        $user->load(['roles.permissions', 'permissions', 'person.institution']);
 
         $this->logSuccess('viewed a user', $user);
+
+        $directIds = $user->getDirectPermissions()->pluck('id');
+        $roles = $user->roles;
+
+        $inherited = $user->getAllPermissions()
+            ->reject(fn ($permission) => $directIds->contains($permission->id))
+            ->map(fn ($permission) => [
+                'id' => $permission->id,
+                'name' => $permission->name,
+                'via' => $roles
+                    ->filter(fn ($role) => $role->permissions->contains('id', $permission->id))
+                    ->pluck('name')
+                    ->implode(', '),
+            ])
+            ->values();
 
         return Inertia::render('User/Show', [
             'user' => [
@@ -115,20 +130,17 @@ class UserController extends Controller
                     'name' => $user->person->full_name,
                     'staff_number' => $user->person->institution->first()?->staff?->staff_number,
                 ] : null,
-                'roles' => $user->roles->map(function ($role) {
-                    return [
-                        'id' => $role->id,
-                        'name' => $role->name,
-                        'start_date' => $role->created_at->format('d M Y'),
-                    ];
-                }),
-                'permissions' => $user->getAllPermissions()->map(function ($permission) {
-                    return [
-                        'id' => $permission->id,
-                        'name' => $permission->name,
-                        'start_date' => $permission->created_at->format('d M Y'),
-                    ];
-                }),
+                'roles' => $user->roles->map(fn ($role) => [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'start_date' => $role->created_at->format('d M Y'),
+                ]),
+                'direct_permissions' => $user->getDirectPermissions()->map(fn ($permission) => [
+                    'id' => $permission->id,
+                    'name' => $permission->name,
+                    'start_date' => $permission->created_at->format('d M Y'),
+                ])->values(),
+                'inherited_permissions' => $inherited,
             ],
         ]);
     }

--- a/docs/superpowers/plans/2026-06-01-user-show-redesign.md
+++ b/docs/superpowers/plans/2026-06-01-user-show-redesign.md
@@ -1,0 +1,953 @@
+# User Show Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Modernize `User/Show` and its related components into a clean two-column, green-branded layout, and fix the direct-vs-inherited permission correctness bug.
+
+**Architecture:** Split the permission payload in `UserController@show` into `direct_permissions` (revokable) and `inherited_permissions` (read-only, annotated with the role they come from). Build new presentational cards under `resources/js/Components/User/`, restyle the existing stateful partials under `resources/js/Pages/User/partials/` into chip cards, and reassemble `Show.vue` as a two-column layout (left rail = account + staff record, right main = roles + permissions).
+
+**Tech Stack:** Laravel 11, Inertia v1, Vue 3 `<script setup>`, Tailwind 3, FormKit, Spatie Laravel Permission, PHPUnit.
+
+**Testing note:** This repo has **no JavaScript test runner** (ESLint only lints `public/`; there is no vitest). Backend changes are covered by PHPUnit feature tests with `assertInertia`. Frontend components are verified by `npm run build` compiling cleanly. Every frontend task ends with a build step; the data correctness is locked down by the Task 1 backend test.
+
+**Branch:** `redesign/user-show` (already created; the design doc is committed there).
+
+---
+
+## File Structure
+
+**Backend**
+- Modify: `app/Http/Controllers/UserController.php` — `show()` returns split permission lists.
+- Create: `tests/Feature/UserShowTest.php` — asserts the Inertia payload.
+
+**New presentational components** — `resources/js/Components/User/`
+- Create: `UserIdentityCard.vue` — full-width identity strip.
+- Create: `UserAccountCard.vue` — rail: email, verified, id.
+- Create: `UserStaffRecordCard.vue` — rail: staff link + associate/change/unlink (emits only).
+
+**Reworked stateful partials** — `resources/js/Pages/User/partials/`
+- Modify: `UserRoles.vue` — chip card + modal orchestration.
+- Modify: `RolesList.vue` — table → role chips.
+- Modify: `UserPermissions.vue` — direct + inherited sections; pass direct list to modal.
+- Modify: `PermissionsList.vue` — table → permission chips (direct, removable).
+- Modify: `AddUserPermission.vue` / `AddUserRole.vue` / `UserRoleForm.vue` / `AssociateStaff.vue` / `Delete.vue` — green-clean restyle.
+
+**Page**
+- Modify: `resources/js/Pages/User/Show.vue` — two-column assembly.
+
+---
+
+## Task 1: Backend — split direct vs inherited permissions in `show()`
+
+**Files:**
+- Modify: `app/Http/Controllers/UserController.php:100-134`
+- Test: `tests/Feature/UserShowTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/UserShowTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class UserShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** A viewer that can view users and their roles/permissions. */
+    protected function viewer(): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['view user', 'view user roles', 'view user permissions']);
+
+        return $user;
+    }
+
+    public function test_show_splits_direct_and_inherited_permissions(): void
+    {
+        $direct = Permission::firstOrCreate(['name' => 'directly.assigned']);
+        $viaRole = Permission::firstOrCreate(['name' => 'role.granted']);
+
+        $role = Role::firstOrCreate(['name' => 'editor']);
+        $role->givePermissionTo($viaRole);
+
+        $target = User::factory()->create();
+        $target->assignRole($role);
+        $target->givePermissionTo($direct);
+
+        $response = $this->actingAs($this->viewer())
+            ->get(route('user.show', ['user' => $target->id]));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('User/Show')
+                ->where('user.email', $target->email)
+                ->where('user.direct_permissions.0.name', 'directly.assigned')
+                ->where('user.inherited_permissions.0.name', 'role.granted')
+                ->where('user.inherited_permissions.0.via', 'editor')
+        );
+    }
+
+    public function test_directly_held_permission_is_not_listed_as_inherited(): void
+    {
+        $shared = Permission::firstOrCreate(['name' => 'shared.permission']);
+
+        $role = Role::firstOrCreate(['name' => 'editor']);
+        $role->givePermissionTo($shared);
+
+        $target = User::factory()->create();
+        $target->assignRole($role);
+        $target->givePermissionTo($shared); // also held directly
+
+        $response = $this->actingAs($this->viewer())
+            ->get(route('user.show', ['user' => $target->id]));
+
+        $response->assertInertia(function (Assert $page) {
+            $direct = collect($page->toArray()['props']['user']['direct_permissions'])->pluck('name');
+            $inherited = collect($page->toArray()['props']['user']['inherited_permissions'])->pluck('name');
+
+            $this->assertTrue($direct->contains('shared.permission'));
+            $this->assertFalse($inherited->contains('shared.permission'));
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `php artisan test --filter=UserShowTest`
+Expected: FAIL — `user.direct_permissions` does not exist (page currently sends `permissions`).
+
+- [ ] **Step 3: Rewrite `show()` to split permissions**
+
+In `app/Http/Controllers/UserController.php`, replace the body of `show()` (lines 100-134) with:
+
+```php
+    public function show(User $user)
+    {
+        $user->load(['roles.permissions', 'permissions', 'person.institution']);
+
+        $this->logSuccess('viewed a user', $user);
+
+        $directIds = $user->getDirectPermissions()->pluck('id');
+        $roles = $user->roles;
+
+        $inherited = $user->getAllPermissions()
+            ->reject(fn ($permission) => $directIds->contains($permission->id))
+            ->map(fn ($permission) => [
+                'id' => $permission->id,
+                'name' => $permission->name,
+                'via' => $roles
+                    ->filter(fn ($role) => $role->permissions->contains('id', $permission->id))
+                    ->pluck('name')
+                    ->implode(', '),
+            ])
+            ->values();
+
+        return Inertia::render('User/Show', [
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'verified' => $user->email_verified_at ? 'Yes' : 'No',
+                'person_id' => $user->person_id,
+                'staff' => $user->person ? [
+                    'id' => $user->person->id,
+                    'name' => $user->person->full_name,
+                    'staff_number' => $user->person->institution->first()?->staff?->staff_number,
+                ] : null,
+                'roles' => $user->roles->map(fn ($role) => [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'start_date' => $role->created_at->format('d M Y'),
+                ]),
+                'direct_permissions' => $user->getDirectPermissions()->map(fn ($permission) => [
+                    'id' => $permission->id,
+                    'name' => $permission->name,
+                    'start_date' => $permission->created_at->format('d M Y'),
+                ])->values(),
+                'inherited_permissions' => $inherited,
+            ],
+        ]);
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `php artisan test --filter=UserShowTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run Pint and commit**
+
+```bash
+vendor/bin/pint app/Http/Controllers/UserController.php tests/Feature/UserShowTest.php
+git add app/Http/Controllers/UserController.php tests/Feature/UserShowTest.php
+git commit -m "feat: split direct and inherited permissions on user show"
+```
+
+---
+
+## Task 2: `UserIdentityCard.vue` — identity strip
+
+**Files:**
+- Create: `resources/js/Components/User/UserIdentityCard.vue`
+
+- [ ] **Step 1: Create the component**
+
+`User` has no image/initials field, so initials are computed from `name`.
+
+```vue
+<script setup>
+import { computed } from "vue";
+import { CheckBadgeIcon } from "@heroicons/vue/20/solid";
+
+const props = defineProps({
+	user: { type: Object, required: true },
+});
+
+const initials = computed(() =>
+	(props.user.name ?? "")
+		.split(" ")
+		.filter(Boolean)
+		.map((part) => part[0])
+		.slice(0, 2)
+		.join("")
+		.toUpperCase(),
+);
+
+const primaryRole = computed(() => props.user.roles?.[0]?.name ?? null);
+const isVerified = computed(() => props.user.verified === "Yes");
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5 sm:p-6 flex flex-col sm:flex-row items-center sm:items-stretch gap-4 sm:gap-5"
+	>
+		<div class="flex-shrink-0">
+			<div
+				class="w-[72px] h-[72px] rounded-full bg-gradient-to-br from-green-500 to-green-700 dark:from-gray-500 dark:to-gray-700 flex items-center justify-center text-white font-bold text-2xl"
+			>
+				{{ initials }}
+			</div>
+		</div>
+		<div class="flex-1 min-w-0 text-center sm:text-left">
+			<h1
+				class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+			>
+				{{ user.name }}
+			</h1>
+			<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+				<span v-if="primaryRole">{{ primaryRole }}</span>
+				<span v-if="primaryRole && user.staff?.staff_number"> · </span>
+				<span v-if="user.staff?.staff_number"
+					>Staff #{{ user.staff.staff_number }}</span
+				>
+			</p>
+		</div>
+		<div
+			class="flex flex-col items-center sm:items-end justify-center gap-1 text-sm"
+		>
+			<span class="text-gray-600 dark:text-gray-300">{{ user.email }}</span>
+			<span
+				v-if="isVerified"
+				class="inline-flex items-center gap-1 rounded-full bg-green-50 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-green-700 dark:text-green-300 ring-1 ring-inset ring-green-600/20"
+			>
+				<CheckBadgeIcon class="h-4 w-4" /> Verified
+			</span>
+			<span
+				v-else
+				class="inline-flex items-center rounded-full bg-yellow-50 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:text-yellow-300 ring-1 ring-inset ring-yellow-600/20"
+			>
+				Unverified
+			</span>
+		</div>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds (component is not yet imported anywhere; this confirms it parses).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/User/UserIdentityCard.vue
+git commit -m "feat: add UserIdentityCard component"
+```
+
+---
+
+## Task 3: `UserAccountCard.vue` — rail account details
+
+**Files:**
+- Create: `resources/js/Components/User/UserAccountCard.vue`
+
+- [ ] **Step 1: Create the component**
+
+```vue
+<script setup>
+defineProps({
+	user: { type: Object, required: true },
+});
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Account
+		</h2>
+		<dl class="mt-3 space-y-3 text-sm">
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">Email</dt>
+				<dd class="text-gray-900 dark:text-gray-100 truncate">
+					{{ user.email }}
+				</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">Verified</dt>
+				<dd class="text-gray-900 dark:text-gray-100">{{ user.verified }}</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">User ID</dt>
+				<dd class="text-gray-900 dark:text-gray-100">#{{ user.id }}</dd>
+			</div>
+		</dl>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/User/UserAccountCard.vue
+git commit -m "feat: add UserAccountCard component"
+```
+
+---
+
+## Task 4: `UserStaffRecordCard.vue` — rail staff link
+
+**Files:**
+- Create: `resources/js/Components/User/UserStaffRecordCard.vue`
+
+- [ ] **Step 1: Create the component**
+
+Presentational only — emits events; the page owns the modal/confirm.
+
+```vue
+<script setup>
+const props = defineProps({
+	user: { type: Object, required: true },
+	canManage: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["associate", "unlink"]);
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Staff record
+		</h2>
+		<p class="mt-2 text-sm text-gray-700 dark:text-gray-200">
+			{{
+				user.staff
+					? `${user.staff.name} — ${user.staff.staff_number ?? "—"}`
+					: "Not linked"
+			}}
+		</p>
+		<div v-if="canManage" class="mt-4 flex gap-3">
+			<button
+				type="button"
+				class="rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+				@click="emit('associate')"
+			>
+				{{ user.person_id ? "Change" : "Associate" }}
+			</button>
+			<button
+				v-if="user.person_id"
+				type="button"
+				class="rounded-md px-2.5 py-1 text-xs font-medium text-red-600 ring-1 ring-inset ring-red-600/20 dark:text-red-400 dark:ring-red-400/30 hover:bg-red-50 dark:hover:bg-gray-700"
+				@click="emit('unlink')"
+			>
+				Unlink
+			</button>
+		</div>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/User/UserStaffRecordCard.vue
+git commit -m "feat: add UserStaffRecordCard component"
+```
+
+---
+
+## Task 5: Restyle `RolesList.vue` and `UserRoles.vue` into a chip card
+
+**Files:**
+- Modify: `resources/js/Pages/User/partials/RolesList.vue`
+- Modify: `resources/js/Pages/User/partials/UserRoles.vue`
+
+- [ ] **Step 1: Convert `RolesList.vue` to role chips**
+
+Replace the entire file with:
+
+```vue
+<script setup>
+import { usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
+import { XMarkIcon } from "@heroicons/vue/16/solid";
+
+defineProps({
+	roles: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["deleteRole"]);
+
+const page = usePage();
+const permissions = computed(() => page.props?.auth.permissions);
+const canRevoke = computed(() =>
+	permissions.value?.includes("assign roles to user"),
+);
+</script>
+
+<template>
+	<div class="px-5 pb-5">
+		<ul v-if="roles?.length > 0" class="flex flex-wrap gap-2">
+			<li
+				v-for="role in roles"
+				:key="role.id"
+				class="inline-flex items-center gap-1.5 rounded-full bg-green-50 dark:bg-gray-700 pl-3 pr-1.5 py-1 text-sm font-medium text-green-800 dark:text-green-200 ring-1 ring-inset ring-green-600/20"
+			>
+				<span class="h-1.5 w-1.5 rounded-full bg-green-500" />
+				{{ role.name }}
+				<button
+					v-if="canRevoke"
+					type="button"
+					class="rounded-full p-0.5 text-green-500 hover:bg-green-100 hover:text-green-700 dark:hover:bg-gray-600"
+					:aria-label="`Revoke ${role.name}`"
+					@click="emit('deleteRole', role)"
+				>
+					<XMarkIcon class="h-4 w-4" />
+				</button>
+			</li>
+		</ul>
+		<p
+			v-else
+			class="py-6 text-center text-sm font-medium text-gray-400 dark:text-gray-300"
+		>
+			No roles assigned to this user.
+		</p>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Restyle `UserRoles.vue` card shell**
+
+In `resources/js/Pages/User/partials/UserRoles.vue`, replace the outer card markup inside `<main>` (the `<div class="rounded-lg bg-green-200 ...">` block through its closing `</div>`, currently lines 62-88) with:
+
+```html
+		<div
+			class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+		>
+			<div class="flex items-center justify-between px-5 pt-5 pb-3">
+				<h3 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+					Roles
+				</h3>
+				<button
+					v-if="canAdd"
+					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+					@click="toggleAddRoleModal()"
+				>
+					Add Role
+				</button>
+			</div>
+			<RolesList
+				:roles="props.roles"
+				@delete-role="(model) => confirmDeleteRole(model)"
+			/>
+		</div>
+```
+
+Leave the `<script setup>` and the modal/`<Delete>` markup below untouched.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Pages/User/partials/RolesList.vue resources/js/Pages/User/partials/UserRoles.vue
+git commit -m "feat: restyle roles card with chip list"
+```
+
+---
+
+## Task 6: Direct + inherited permissions in `UserPermissions.vue` / `PermissionsList.vue`
+
+**Files:**
+- Modify: `resources/js/Pages/User/partials/PermissionsList.vue`
+- Modify: `resources/js/Pages/User/partials/UserPermissions.vue`
+- Modify: `resources/js/Pages/User/partials/AddUserPermission.vue`
+
+- [ ] **Step 1: Convert `PermissionsList.vue` to removable permission chips**
+
+Replace the entire file with:
+
+```vue
+<script setup>
+import { usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
+import { XMarkIcon } from "@heroicons/vue/16/solid";
+
+defineProps({
+	permissions: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["deletePermission"]);
+
+const page = usePage();
+const authPermissions = computed(() => page.props?.auth.permissions);
+const canRevoke = computed(() =>
+	authPermissions.value?.includes("assign permissions to user"),
+);
+</script>
+
+<template>
+	<ul v-if="permissions?.length > 0" class="flex flex-wrap gap-2">
+		<li
+			v-for="permission in permissions"
+			:key="permission.id"
+			class="inline-flex items-center gap-1.5 rounded-full bg-green-50 dark:bg-gray-700 pl-3 pr-1.5 py-1 text-sm font-medium text-green-800 dark:text-green-200 ring-1 ring-inset ring-green-600/20"
+		>
+			{{ permission.name }}
+			<button
+				v-if="canRevoke"
+				type="button"
+				class="rounded-full p-0.5 text-green-500 hover:bg-green-100 hover:text-green-700 dark:hover:bg-gray-600"
+				:aria-label="`Revoke ${permission.name}`"
+				@click="emit('deletePermission', permission)"
+			>
+				<XMarkIcon class="h-4 w-4" />
+			</button>
+		</li>
+	</ul>
+	<p
+		v-else
+		class="py-4 text-sm font-medium text-gray-400 dark:text-gray-300"
+	>
+		No direct permissions.
+	</p>
+</template>
+```
+
+- [ ] **Step 2: Rework `UserPermissions.vue`**
+
+Replace the entire file with:
+
+```vue
+<script setup>
+import { router } from "@inertiajs/vue3";
+import { ref, computed } from "vue";
+import { useToggle } from "@vueuse/core";
+import Modal from "@/Components/NewModal.vue";
+import AddUserPermission from "./AddUserPermission.vue";
+import Delete from "./Delete.vue";
+import PermissionsList from "./PermissionsList.vue";
+
+defineEmits(["closeForm"]);
+
+const props = defineProps({
+	user: { type: Number, required: true },
+	directPermissions: { type: Array, default: () => [] },
+	inheritedPermissions: { type: Array, default: () => [] },
+	canAdd: { type: Boolean, default: false },
+});
+
+const directNames = computed(() =>
+	props.directPermissions.map((permission) => permission.name),
+);
+
+const openAddPermissionModal = ref(false);
+const toggleAddPermissionModal = useToggle(openAddPermissionModal);
+
+const openDeletePermissionModal = ref(false);
+const toggleDeletePermissionModal = useToggle(openDeletePermissionModal);
+const deleteModel = ref(null);
+
+const confirmDeletePermission = (model) => {
+	deleteModel.value = model;
+	toggleDeletePermissionModal();
+};
+
+const deletePermission = (user, permission) => {
+	router.patch(route("user.revoke.permissions", { user }), {
+		permission,
+		preserveScroll: true,
+	});
+	toggleDeletePermissionModal();
+};
+</script>
+
+<template>
+	<main>
+		<h2 class="sr-only">User Permissions</h2>
+		<div
+			class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
+		>
+			<div class="flex items-center justify-between px-5 pt-5 pb-3">
+				<h3 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+					Permissions
+				</h3>
+				<button
+					v-if="canAdd"
+					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+					@click="toggleAddPermissionModal()"
+				>
+					Add Permission
+				</button>
+			</div>
+
+			<div class="px-5 pb-5 space-y-5">
+				<div>
+					<p
+						class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						Direct
+					</p>
+					<PermissionsList
+						:permissions="directPermissions"
+						@delete-permission="(model) => confirmDeletePermission(model)"
+					/>
+				</div>
+
+				<div v-if="inheritedPermissions.length > 0">
+					<p
+						class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+					>
+						Inherited from roles
+					</p>
+					<ul class="flex flex-wrap gap-2">
+						<li
+							v-for="permission in inheritedPermissions"
+							:key="permission.id"
+							class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 dark:bg-gray-700 px-3 py-1 text-sm text-gray-600 dark:text-gray-300 ring-1 ring-inset ring-gray-400/20"
+						>
+							{{ permission.name }}
+							<span class="text-xs text-gray-400 dark:text-gray-400"
+								>via {{ permission.via }}</span
+							>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+
+		<Modal :show="openAddPermissionModal" @close="toggleAddPermissionModal()">
+			<AddUserPermission
+				:user="user"
+				:user-permissions="directNames"
+				@form-submitted="toggleAddPermissionModal()"
+			/>
+		</Modal>
+
+		<Delete
+			:open="openDeletePermissionModal"
+			:model="deleteModel"
+			@delete-confirmed="deletePermission(user, deleteModel.name)"
+			@close="toggleDeletePermissionModal()"
+		/>
+	</main>
+</template>
+```
+
+- [ ] **Step 3: Point the Add-Permission modal heading at the green-clean style**
+
+In `resources/js/Pages/User/partials/AddUserPermission.vue`, replace the `<main>` wrapper opening tag and `<h1>` (lines 59-60) with:
+
+```html
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Permissions
+		</h1>
+```
+
+(The pre-fill source is already correct — `UserPermissions.vue` now passes only direct permission names via `user-permissions`.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/Pages/User/partials/PermissionsList.vue resources/js/Pages/User/partials/UserPermissions.vue resources/js/Pages/User/partials/AddUserPermission.vue
+git commit -m "feat: split direct and inherited permissions in user permissions card"
+```
+
+---
+
+## Task 7: Green-clean restyle of the remaining modals
+
+**Files:**
+- Modify: `resources/js/Pages/User/partials/UserRoleForm.vue`
+- Modify: `resources/js/Pages/User/partials/AddUserRole.vue`
+- Modify: `resources/js/Pages/User/partials/AssociateStaff.vue`
+- Modify: `resources/js/Pages/User/partials/Delete.vue`
+
+- [ ] **Step 1: Restyle the Add-Role modal wrapper**
+
+In `resources/js/Pages/User/partials/AddUserRole.vue`, replace the `<main>` opening tag and `<h1>` (lines 39-40) with:
+
+```html
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Roles
+		</h1>
+```
+
+- [ ] **Step 2: Restyle the Associate-Staff modal**
+
+In `resources/js/Pages/User/partials/AssociateStaff.vue`, replace the `<main>` opening tag and `<h1>` (lines 48-49) with:
+
+```html
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Associate Staff Record
+		</h1>
+```
+
+- [ ] **Step 3: Inspect and restyle `Delete.vue` confirm dialog**
+
+Read `resources/js/Pages/User/partials/Delete.vue` first. Update its primary confirm button to the green-clean danger style (red confirm, neutral cancel) and ensure the panel uses `rounded-2xl`. Apply this class to the confirm button:
+
+```
+class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:w-auto"
+```
+
+and the cancel button:
+
+```
+class="mt-3 inline-flex w-full justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 sm:mt-0 sm:w-auto"
+```
+
+(Only adjust classes already present on those buttons; do not change the emit/prop wiring.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/Pages/User/partials/AddUserRole.vue resources/js/Pages/User/partials/AssociateStaff.vue resources/js/Pages/User/partials/Delete.vue
+git commit -m "feat: green-clean restyle of user management modals"
+```
+
+---
+
+## Task 8: Reassemble `Show.vue` as a two-column layout
+
+**Files:**
+- Modify: `resources/js/Pages/User/Show.vue`
+
+- [ ] **Step 1: Replace the page**
+
+Replace the entire file with:
+
+```vue
+<script setup>
+import MainLayout from "@/Layouts/NewAuthenticated.vue";
+import { Head, usePage, router } from "@inertiajs/vue3";
+import { ref, computed } from "vue";
+import { useToggle } from "@vueuse/core";
+import BreadCrump from "@/Components/BreadCrump.vue";
+import NoPermission from "@/Components/NoPermission.vue";
+import NewModal from "@/Components/NewModal.vue";
+import UserIdentityCard from "@/Components/User/UserIdentityCard.vue";
+import UserAccountCard from "@/Components/User/UserAccountCard.vue";
+import UserStaffRecordCard from "@/Components/User/UserStaffRecordCard.vue";
+import UserRoles from "./partials/UserRoles.vue";
+import UserPermissions from "./partials/UserPermissions.vue";
+import AssociateStaff from "./partials/AssociateStaff.vue";
+
+const props = defineProps({
+	user: { type: Object, default: () => null },
+});
+
+const page = usePage();
+const permissions = computed(() => page.props?.auth.permissions);
+
+const breadcrumbLinks = [
+	{ name: "Dashboard", url: "/dashboard" },
+	{ name: "Users", url: "/user" },
+	{ name: props.user.name, url: null },
+];
+
+const openAssociateModal = ref(false);
+const toggleAssociateModal = useToggle(openAssociateModal);
+
+const unlinkStaff = () => {
+	if (
+		!window.confirm(
+			"Unlink this user from their staff record? This also removes the staff role.",
+		)
+	) {
+		return;
+	}
+	router.delete(route("user.dissociate-staff", { user: props.user.id }), {
+		preserveScroll: true,
+	});
+};
+</script>
+
+<template>
+	<Head :title="user.name" />
+	<MainLayout>
+		<main
+			v-if="permissions?.includes('view user')"
+			class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6"
+		>
+			<BreadCrump :links="breadcrumbLinks" />
+
+			<UserIdentityCard :user="user" class="mt-4" />
+
+			<div class="mt-5 grid grid-cols-1 lg:grid-cols-3 gap-5">
+				<!-- Left rail -->
+				<div class="lg:col-span-1 flex flex-col gap-5">
+					<UserAccountCard :user="user" />
+					<UserStaffRecordCard
+						:user="user"
+						:can-manage="permissions?.includes('associate user staff')"
+						@associate="toggleAssociateModal()"
+						@unlink="unlinkStaff"
+					/>
+				</div>
+
+				<!-- Right main -->
+				<div class="lg:col-span-2 flex flex-col gap-5">
+					<UserRoles
+						:roles="user.roles"
+						:user="user.id"
+						:can-add="permissions?.includes('assign roles to user')"
+						:has-staff-record="!!user.person_id"
+					/>
+					<UserPermissions
+						:user="user.id"
+						:direct-permissions="user.direct_permissions"
+						:inherited-permissions="user.inherited_permissions"
+						:can-add="permissions?.includes('assign permissions to user')"
+					/>
+				</div>
+			</div>
+
+			<NewModal :show="openAssociateModal" @close="toggleAssociateModal()">
+				<AssociateStaff
+					:user="user.id"
+					@form-submitted="toggleAssociateModal()"
+				/>
+			</NewModal>
+		</main>
+		<NoPermission v-else />
+	</MainLayout>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Pages/User/Show.vue
+git commit -m "feat: two-column user show layout"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Run the user feature tests**
+
+Run: `php artisan test --filter="UserShowTest|AssociateUserStaffTest"`
+Expected: PASS.
+
+- [ ] **Step 2: Run Pint on changed PHP**
+
+Run: `vendor/bin/pint --dirty`
+Expected: no errors.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Manual smoke check (ask the user to run)**
+
+Suggest the user open a user detail page (`/user/{id}`) with `npm run dev` running and confirm:
+- Two-column layout renders with identity strip, account + staff cards on the left, roles + permissions on the right.
+- Roles and direct permissions show as removable chips; inherited permissions show read-only with "via {role}".
+- Adding a role keeps existing roles (the earlier sync fix); revoking a direct permission works; inherited permissions offer no revoke control.
+
+- [ ] **Step 5: Final commit if any cleanup was needed**
+
+```bash
+git add -A
+git commit -m "chore: user show redesign cleanup"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Visual direction (green-clean cards) → Tasks 2-8 use the agreed classes. ✓
+- Two-column layout → Task 8. ✓
+- New `Components/User/` cards (Identity, Account, StaffRecord) → Tasks 2-4. ✓
+- Roles/permissions chip cards → Tasks 5-6. ✓
+- Direct vs inherited backend split → Task 1. ✓
+- Add-Permission modal pre-fills from direct only → Task 6 Step 2 (`directNames` passed as `user-permissions`). ✓
+- Restyled modals → Tasks 5-7. ✓
+- Testing (assertInertia split + existing tests) → Tasks 1, 9. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full content. ✓
+
+**Type/name consistency:** Backend emits `direct_permissions`, `inherited_permissions` (Task 1); `Show.vue` binds `:direct-permissions`/`:inherited-permissions` and `UserPermissions.vue` declares `directPermissions`/`inheritedPermissions` (Tasks 6, 8). `inherited_permissions[].via` is produced in Task 1 and read in Task 6. `confirmDeleteRole`/`deletePermission` names match their existing usages. ✓
+
+**Note on `RolesList`/`PermissionsList`:** The design left "convert vs fold" open; this plan converts them in place (Tasks 5-6), preserving the parent→child boundary.

--- a/docs/superpowers/specs/2026-06-01-user-show-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-01-user-show-redesign-design.md
@@ -1,0 +1,107 @@
+# User Show Page Redesign — Design
+
+**Date:** 2026-06-01
+**Status:** Approved for planning
+
+## Goal
+
+Modernize the user detail page (`User/Show`) and its related components into a cleaner two-column layout, keeping the green brand. Along the way, fix a real correctness bug in how user permissions are displayed and edited (direct vs. role-inherited).
+
+## Visual Direction
+
+Keep the green brand but tidy it. Cards adopt a refined version of the MyProfile design language with green accents:
+
+- Card surface: `bg-white dark:bg-gray-800`
+- Border: soft green — `border border-green-200/60 dark:border-gray-700`
+- Shape/elevation: `rounded-2xl shadow-sm`
+- Accents: green headers, badges, and primary buttons (`bg-green-600 hover:bg-green-500`, dark: gray equivalents already used in the codebase)
+
+The current full-bleed green gradient header (the large clip-path blur block) is removed in favor of a compact green-tinted identity strip.
+
+## Layout
+
+```
+Breadcrumb
+┌──────────── Identity strip (full width) ────────────┐
+│ [avatar] Name · role · Staff#   email  ✓ Verified   │
+└─────────────────────────────────────────────────────┘
+LEFT RAIL (≈1/3)            RIGHT MAIN (≈2/3)
+┌──────────────┐           ┌────────────────────────────┐
+│ Account      │           │ Roles            [+ Add]    │
+│  email/verif │           │  ● admin ×  ● auditor ×     │
+│  user id     │           ├────────────────────────────┤
+├──────────────┤           │ Permissions      [+ Add]    │
+│ Staff record │           │  Direct:  ● users.create ×  │
+│  link/assoc  │           │  Inherited (read-only):     │
+│  change/unlink│          │   ● reports.view (via admin)│
+└──────────────┘           └────────────────────────────┘
+```
+
+- Desktop: two columns — left rail ≈ 1/3, right main ≈ 2/3.
+- Mobile: single column, rail stacks first.
+- Whole page constrained to `max-w-7xl` with the standard `px-4 sm:px-6 lg:px-8 py-6` padding used by MyProfile.
+
+## Components
+
+### New presentational components — `resources/js/Components/User/`
+
+(Mirrors the `Components/MyProfile/` convention. These are presentational: props in, events out, no router/axios calls.)
+
+- **`UserIdentityCard.vue`** — full-width strip. Avatar (image or initials fallback), name, summary line (primary role · staff number), email, and a verified badge.
+- **`UserAccountCard.vue`** — left rail. Email, verified status, user id.
+- **`UserStaffRecordCard.vue`** — left rail. Shows staff link state ("Not linked" or `name — staff_number`). Emits `associate`, `change`, and `unlink`; the page owns the modal and the unlink confirm.
+
+### Reworked existing partials — `resources/js/Pages/User/partials/`
+
+These remain the stateful orchestrators (they own the modals and the Inertia router calls), restyled into the new chip-card look.
+
+- **`UserRoles.vue`** — roles rendered as chips with an `×` remove control and an "Add" button that opens the (restyled) role modal. (Role pre-check bug already fixed in `UserRoleForm.vue`.)
+- **`UserPermissions.vue`** — two sections:
+  - **Direct** — removable chips (`×`).
+  - **Inherited from roles** — read-only chips, each labeled with its source role ("via {role}").
+- **`RolesList.vue` / `PermissionsList.vue`** — converted from `<table>` layouts to chip renderers, or folded into their parent panels if that reads cleaner during implementation.
+
+### Restyled modals
+
+Green-clean restyle of the modal internals (behavior unchanged except where noted in Backend):
+
+- `AddUserRole.vue` / `UserRoleForm.vue`
+- `AddUserPermission.vue`
+- `AssociateStaff.vue`
+- `partials/Delete.vue` (the revoke confirm dialog)
+
+## Backend Change (correctness)
+
+Today `UserController@show` returns `getAllPermissions()` — direct **plus** role-inherited permissions — as one flat list. This produces two real bugs:
+
+1. **Revoke of an inherited permission silently no-ops.** `revokePermission` calls `revokePermissionTo`, which only removes *direct* grants. A permission inherited from a role stays after "revoke" because the role still grants it.
+2. **Opening + saving the Add-Permission modal materializes inherited permissions as direct ones.** The modal pre-checks all permissions (`getAllPermissions`), and `addPermission` calls `syncPermissions($request->permissions)`. Saving therefore converts every role-inherited permission into a direct grant — a destructive side effect from merely opening the modal.
+
+### Fix
+
+- **`UserController@show`** returns two lists instead of one `permissions`:
+  - `direct_permissions` — from `$user->getDirectPermissions()`, mapped to `{ id, name }`. These are revokable.
+  - `inherited_permissions` — permissions granted via roles but not held directly, each annotated with its originating role name(s): `{ id, name, via }`.
+  - `roles`, `email`, `verified` continue to be sent (email/verified are already loaded but currently unused by the page).
+- **`AddUserPermission` modal** pre-fills from **direct** permissions only, so saving no longer materializes inherited permissions.
+
+No new routes. Add/remove for roles and permissions keep their existing routes:
+`user.add.roles`, `user.revoke.roles`, `user.add.permissions`, `user.revoke.permissions`.
+
+## Data Flow
+
+- No new server round-trips on page load: `email`/`verified` are already loaded; permissions are simply re-split in the controller.
+- `UserPermissions.vue` receives `direct_permissions` and `inherited_permissions` as separate props and passes the **direct** list as the modal's pre-fill source.
+- Staff associate/change/unlink continue to flow through `AssociateStaff.vue` and `user.dissociate-staff`.
+
+## Testing
+
+- Feature test on `UserController@show` asserting the Inertia payload splits `direct_permissions` and `inherited_permissions` correctly for a user who has both a direct permission and a role that grants other permissions (PHPUnit + `assertInertia`).
+- Test that revoking a **direct** permission removes it, and that an inherited-only permission is not presented as revokable.
+- Confirm existing add/revoke role & permission feature tests still pass.
+
+## Out of Scope
+
+- No changes to the roles/permissions data model or the Spatie configuration.
+- No changes to the user Index/list page.
+- No inline (modal-less) editing — add still uses the restyled modal with chip lists.

--- a/resources/js/Components/User/UserAccountCard.vue
+++ b/resources/js/Components/User/UserAccountCard.vue
@@ -1,0 +1,31 @@
+<script setup>
+defineProps({
+	user: { type: Object, required: true },
+});
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Account
+		</h2>
+		<dl class="mt-3 space-y-3 text-sm">
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">Email</dt>
+				<dd class="text-gray-900 dark:text-gray-100 truncate">
+					{{ user.email }}
+				</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">Verified</dt>
+				<dd class="text-gray-900 dark:text-gray-100">{{ user.verified }}</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-gray-500 dark:text-gray-400">User ID</dt>
+				<dd class="text-gray-900 dark:text-gray-100">#{{ user.id }}</dd>
+			</div>
+		</dl>
+	</div>
+</template>

--- a/resources/js/Components/User/UserIdentityCard.vue
+++ b/resources/js/Components/User/UserIdentityCard.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { computed } from "vue";
+import { CheckBadgeIcon } from "@heroicons/vue/20/solid";
+
+const props = defineProps({
+	user: { type: Object, required: true },
+});
+
+const initials = computed(() =>
+	(props.user.name ?? "")
+		.split(" ")
+		.filter(Boolean)
+		.map((part) => part[0])
+		.slice(0, 2)
+		.join("")
+		.toUpperCase(),
+);
+
+const primaryRole = computed(() => props.user.roles?.[0]?.name ?? null);
+const isVerified = computed(() => props.user.verified === "Yes");
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5 sm:p-6 flex flex-col sm:flex-row items-center sm:items-stretch gap-4 sm:gap-5"
+	>
+		<div class="flex-shrink-0">
+			<div
+				class="w-[72px] h-[72px] rounded-full bg-gradient-to-br from-green-500 to-green-700 dark:from-gray-500 dark:to-gray-700 flex items-center justify-center text-white font-bold text-2xl"
+			>
+				{{ initials }}
+			</div>
+		</div>
+		<div class="flex-1 min-w-0 text-center sm:text-left">
+			<h1
+				class="text-xl sm:text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+			>
+				{{ user.name }}
+			</h1>
+			<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+				<span v-if="primaryRole">{{ primaryRole }}</span>
+				<span v-if="primaryRole && user.staff?.staff_number"> · </span>
+				<span v-if="user.staff?.staff_number"
+					>Staff #{{ user.staff.staff_number }}</span
+				>
+			</p>
+		</div>
+		<div
+			class="flex flex-col items-center sm:items-end justify-center gap-1 text-sm"
+		>
+			<span class="text-gray-600 dark:text-gray-300">{{ user.email }}</span>
+			<span
+				v-if="isVerified"
+				class="inline-flex items-center gap-1 rounded-full bg-green-50 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-green-700 dark:text-green-300 ring-1 ring-inset ring-green-600/20"
+			>
+				<CheckBadgeIcon class="h-4 w-4" /> Verified
+			</span>
+			<span
+				v-else
+				class="inline-flex items-center rounded-full bg-yellow-50 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:text-yellow-300 ring-1 ring-inset ring-yellow-600/20"
+			>
+				Unverified
+			</span>
+		</div>
+	</div>
+</template>

--- a/resources/js/Components/User/UserStaffRecordCard.vue
+++ b/resources/js/Components/User/UserStaffRecordCard.vue
@@ -1,0 +1,42 @@
+<script setup>
+const props = defineProps({
+	user: { type: Object, required: true },
+	canManage: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["associate", "unlink"]);
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Staff record
+		</h2>
+		<p class="mt-2 text-sm text-gray-700 dark:text-gray-200">
+			{{
+				user.staff
+					? `${user.staff.name} — ${user.staff.staff_number ?? "—"}`
+					: "Not linked"
+			}}
+		</p>
+		<div v-if="canManage" class="mt-4 flex gap-3">
+			<button
+				type="button"
+				class="rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+				@click="emit('associate')"
+			>
+				{{ user.person_id ? "Change" : "Associate" }}
+			</button>
+			<button
+				v-if="user.person_id"
+				type="button"
+				class="rounded-md px-2.5 py-1 text-xs font-medium text-red-600 ring-1 ring-inset ring-red-600/20 dark:text-red-400 dark:ring-red-400/30 hover:bg-red-50 dark:hover:bg-gray-700"
+				@click="emit('unlink')"
+			>
+				Unlink
+			</button>
+		</div>
+	</div>
+</template>

--- a/resources/js/Pages/User/Show.vue
+++ b/resources/js/Pages/User/Show.vue
@@ -1,58 +1,40 @@
 <script setup>
 import MainLayout from "@/Layouts/NewAuthenticated.vue";
 import { Head, usePage, router } from "@inertiajs/vue3";
-import Summary from "@/Pages/Person/Summary.vue";
+import { ref, computed } from "vue";
+import { useToggle } from "@vueuse/core";
+import BreadCrump from "@/Components/BreadCrump.vue";
+import NoPermission from "@/Components/NoPermission.vue";
+import NewModal from "@/Components/NewModal.vue";
+import UserIdentityCard from "@/Components/User/UserIdentityCard.vue";
+import UserAccountCard from "@/Components/User/UserAccountCard.vue";
+import UserStaffRecordCard from "@/Components/User/UserStaffRecordCard.vue";
 import UserRoles from "./partials/UserRoles.vue";
 import UserPermissions from "./partials/UserPermissions.vue";
-import { PlusIcon } from "@heroicons/vue/24/outline";
-import BreadCrump from "@/Components/BreadCrump.vue";
-
-import { useToggle } from "@vueuse/core";
-import { ref, computed } from "vue";
-
-import NewModal from "@/Components/NewModal.vue";
-import EditStaffForm from "./EditStaffForm.vue";
-import EditContactForm from "./EditContactForm.vue";
-import NoItem from "@/Components/NoItem.vue";
-import NoPermission from "@/Components/NoPermission.vue";
-import { url } from "@formkit/icons";
 import AssociateStaff from "./partials/AssociateStaff.vue";
 
-let showPromotionForm = ref(false);
-let showTransferForm = ref(false);
-let openEditModal = ref(false);
-
-let toggle = useToggle(openEditModal);
-
-let togglePermissionsForm = useToggle(showPromotionForm);
-let toggleTransferForm = useToggle(showTransferForm);
-
-let props = defineProps({
+const props = defineProps({
 	user: { type: Object, default: () => null },
 });
 
-let breadcrumbLinks = [
+const page = usePage();
+const permissions = computed(() => page.props?.auth.permissions);
+
+const breadcrumbLinks = [
 	{ name: "Dashboard", url: "/dashboard" },
 	{ name: "Users", url: "/user" },
 	{ name: props.user.name, url: null },
 ];
-const page = usePage();
-const permissions = computed(() => {
-	return page.props?.auth.permissions;
-});
-const openEditContact = ref(false);
-const toggleEditContactModal = useToggle(openEditContact);
-// const confirmDelete = useToggle(openEditModal);
-
-const editContactModal = () => {
-	openEditContact.value = !openEditContact.value;
-};
 
 const openAssociateModal = ref(false);
 const toggleAssociateModal = useToggle(openAssociateModal);
 
 const unlinkStaff = () => {
-	if (!window.confirm("Unlink this user from their staff record? This also removes the staff role.")) {
+	if (
+		!window.confirm(
+			"Unlink this user from their staff record? This also removes the staff role.",
+		)
+	) {
 		return;
 	}
 	router.delete(route("user.dissociate-staff", { user: props.user.id }), {
@@ -60,183 +42,52 @@ const unlinkStaff = () => {
 	});
 };
 </script>
+
 <template>
 	<Head :title="user.name" />
-
 	<MainLayout>
-		<main v-if="permissions?.includes('view user')">
+		<main
+			v-if="permissions?.includes('view user')"
+			class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6"
+		>
 			<BreadCrump :links="breadcrumbLinks" />
-			<header
-				class="relative isolate pt-4 border dark:border-gray-600 rounded-lg"
-			>
-				<div class="absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
-					<div
-						class="absolute left-16 top-full -mt-16 transform-gpu opacity-50 blur-3xl xl:left-1/2 xl:-ml-80"
-					>
-						<div
-							class="aspect-[1154/678] w-[72.125rem] bg-gradient-to-br from-green-100 dark:from-gray-100 to-yellow-200 dark:to-gray-800 dark:border-gray-700 rounded-3xl"
-							style="
-								clip-path: polygon(
-									100% 38.5%,
-									82.6% 100%,
-									60.2% 37.7%,
-									52.4% 32.1%,
-									47.5% 41.8%,
-									45.2% 65.6%,
-									27.5% 23.4%,
-									0.1% 35.3%,
-									17.9% 0%,
-									27.7% 23.4%,
-									76.2% 2.5%,
-									74.2% 56%,
-									100% 38.5%
-								);
-							"
-						/>
-					</div>
-					<div class="absolute inset-x-0 bottom-0 h-px bg-gray-900/5" />
+
+			<UserIdentityCard :user="user" class="mt-4" />
+
+			<div class="mt-5 grid grid-cols-1 lg:grid-cols-3 gap-5">
+				<!-- Left rail -->
+				<div class="lg:col-span-1 flex flex-col gap-5">
+					<UserAccountCard :user="user" />
+					<UserStaffRecordCard
+						:user="user"
+						:can-manage="permissions?.includes('associate user staff')"
+						@associate="toggleAssociateModal()"
+						@unlink="unlinkStaff"
+					/>
 				</div>
 
-				<div class="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-					<div
-						class="mx-auto flex flex-wrap max-w-2xl items-center md:justify-between lg:justify-start gap-x-8 lg:mx-0 lg:max-w-none"
-					>
-						<div
-							class="flex flex-wrap items-center justify-between md:justify-start gap-x-6 w-full md:w-1/2"
-						>
-							<!-- <Avatar
-								:initials="person.initials"
-								:image="person.image"
-								size="lg"
-							/> -->
-							<!-- <img
-								v-if="person.image"
-								:src="person.image"
-								:alt="person.name"
-								class="w-24 h-24 object-cover object-center rounded-full"
-							/>
-							<div
-								v-else
-								class="flex justify-center items-center h-24 w-24 flex-none rounded-lg ring-1 ring-green-400/60 dark:ring-gray-400 text-5xl text-green-400/50 dark:text-gray-300 font-bold tracking-wide"
-							>
-								{{ person.initials }}
-							</div> -->
-							<div class="">
-								<!-- <div class="text-sm leading-6 text-gray-500 dark:text-gray-300">
-									File Number
-									<span class="text-gray-700 dark:text-gray-100">{{
-										staff.file_number
-									}}</span>
-								</div> -->
-								<!-- <div class="text-sm leading-6 text-gray-500 dark:text-gray-300">
-									Staff Number
-									<span class="text-gray-700 dark:text-gray-100">{{
-										staff.staff_number
-									}}</span>
-								</div> -->
-								<div
-									class="mt-1 text-xl font-semibold leading-6 text-gray-900 dark:text-white"
-								>
-									{{ user.name }}
-								</div>
-							</div>
-						</div>
-						<div
-							class="flex items-center gap-x-4 sm:gap-x-6 justify-between w-full md:w-fit"
-						>
-							<button
-								v-if="permissions?.includes('assign roles to user')"
-								type="button"
-								class="hidden text-sm font-semibold leading-6 text-green-900 dark:text-white sm:block"
-								@click="togglePermissionsForm()"
-							>
-								Add Roles
-							</button>
-							<button
-								v-if="permissions?.includes('assign permissions to user')"
-								type="button"
-								class="hidden text-sm font-semibold leading-6 text-green-900 dark:text-white sm:block"
-								@click="toggleTransferForm()"
-							>
-								Add Permissions
-							</button>
-
-							<!-- <a
-								href="#"
-								class="ml-auto flex items-center gap-x-1 rounded-md bg-green-600 dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-600"
-								@click.prevent="toggle()"
-							>
-								<PlusIcon class="-ml-1.5 h-5 w-5" aria-hidden="true" />
-								Edit
-							</a> -->
-						</div>
-					</div>
-				</div>
-			</header>
-
-			<div class="mx-auto max-w-7xl py-4">
-				<div class="mx-auto max-w-2xl items-start lg:mx-0 px-4 gap-4">
-					<div class="flex flex-col md:flex-row gap-4 w-full">
-						<UserPermissions
-							:user="user.id"
-							:permissions="user.permissions"
-							:can-add="permissions?.includes('assign permissions to user')"
-							class="w-full md:w-3/5"
-							@close-form="togglePermissionsForm()"
-						/>
-						<!-- <NoPermission v-else /> -->
-						<UserRoles
-							:roles="user.roles"
-							:user="user.id"
-							class="flex-1"
-							:can-add="permissions?.includes('assign roles to user')"
-							:has-staff-record="!!user.person_id"
-							@close-form="toggleRolesForm()"
-						/>
-						<div
-							v-if="permissions?.includes('associate user staff')"
-							class="rounded-lg bg-green-200 dark:bg-gray-800 p-6 ring-1 ring-gray-900/5 dark:ring-gray-600/80 w-full md:w-2/5"
-						>
-							<h2 class="text-md font-semibold text-gray-900 dark:text-gray-100">
-								Staff record
-							</h2>
-							<p class="mt-2 text-sm text-gray-700 dark:text-gray-200">
-								{{ user.staff ? `${user.staff.name} — ${user.staff.staff_number ?? "—"}` : "Not linked" }}
-							</p>
-							<div class="mt-4 flex gap-3">
-								<button
-									type="button"
-									class="rounded-md bg-green-50 dark:bg-gray-400 px-2 py-1 text-xs font-medium text-green-600 dark:text-gray-50 ring-1 ring-inset ring-green-600/20"
-									@click="toggleAssociateModal()"
-								>
-									{{ user.person_id ? "Change" : "Associate" }}
-								</button>
-								<button
-									v-if="user.person_id"
-									type="button"
-									class="rounded-md px-2 py-1 text-xs font-medium text-red-600 ring-1 ring-inset ring-red-600/20 dark:ring-red-400/30"
-									@click="unlinkStaff"
-								>
-									Unlink
-								</button>
-							</div>
-						</div>
-					</div>
+				<!-- Right main -->
+				<div class="lg:col-span-2 flex flex-col gap-5">
+					<UserRoles
+						:roles="user.roles"
+						:user="user.id"
+						:can-add="permissions?.includes('assign roles to user')"
+						:has-staff-record="!!user.person_id"
+					/>
+					<UserPermissions
+						:user="user.id"
+						:direct-permissions="user.direct_permissions"
+						:inherited-permissions="user.inherited_permissions"
+						:can-add="permissions?.includes('assign permissions to user')"
+					/>
 				</div>
 			</div>
-			<NewModal :show="openEditModal" @close="toggle()">
-				<EditStaffForm :staff-id="staff.staff_id" @form-submitted="toggle()" />
-			</NewModal>
 
-			<NewModal :show="openEditContact" @close="toggleEditContactModal()">
-				<!-- {{ contact }} -->
-				<EditContactForm
-					:contact="staff.staff_id"
-					@form-submitted="(model) => editContactModal(model)"
-				/>
-			</NewModal>
 			<NewModal :show="openAssociateModal" @close="toggleAssociateModal()">
-				<AssociateStaff :user="user.id" @form-submitted="toggleAssociateModal()" />
+				<AssociateStaff
+					:user="user.id"
+					@form-submitted="toggleAssociateModal()"
+				/>
 			</NewModal>
 		</main>
 		<NoPermission v-else />

--- a/resources/js/Pages/User/partials/AddUserPermission.vue
+++ b/resources/js/Pages/User/partials/AddUserPermission.vue
@@ -56,8 +56,10 @@ const submitHandler = (data, node) => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
-		<h1 class="text-2xl pb-4 dark:text-gray-100">Permissions</h1>
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Permissions
+		</h1>
 		<div class="max-h-96">
 			<FormKit type="form" submit-label="Save" @submit="submitHandler">
 				<FormKit id="user" type="hidden" name="user" :value="user" />

--- a/resources/js/Pages/User/partials/AddUserRole.vue
+++ b/resources/js/Pages/User/partials/AddUserRole.vue
@@ -10,15 +10,11 @@ const props = defineProps({
 	hasStaffRecord: { type: Boolean, default: false },
 });
 
-const roles = ref([]);
 const userRoles = ref([]);
 
 onMounted(async () => {
-	const response = await axios.get(route("roles.list"));
-	roles.value = response.data;
-
-	const response2 = await axios.get(route("user.roles", { user: props.user }));
-	userRoles.value = response2.data;
+	const response = await axios.get(route("user.roles", { user: props.user }));
+	userRoles.value = response.data;
 });
 
 const submitHandler = (data, node) => {
@@ -36,8 +32,10 @@ const submitHandler = (data, node) => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
-		<h1 class="text-2xl pb-4 dark:text-gray-100">Roles</h1>
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Roles
+		</h1>
 		<FormKit type="form" submit-label="Save" @submit="submitHandler">
 			<UserRoleForm :user-roles="userRoles.roles" :has-staff-record="props.hasStaffRecord" />
 		</FormKit>

--- a/resources/js/Pages/User/partials/AssociateStaff.vue
+++ b/resources/js/Pages/User/partials/AssociateStaff.vue
@@ -45,8 +45,10 @@ const submit = () => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-gray-100 dark:bg-gray-700">
-		<h1 class="text-2xl pb-4 dark:text-gray-100">Associate Staff Record</h1>
+	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
+			Associate Staff Record
+		</h1>
 		<SearchSelect
 			v-model="selected"
 			:options="options"

--- a/resources/js/Pages/User/partials/Delete.vue
+++ b/resources/js/Pages/User/partials/Delete.vue
@@ -81,7 +81,7 @@ defineProps({
 							>
 								<button
 									type="button"
-									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:ml-3 sm:w-auto"
+									class="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 sm:w-auto"
 									@click="emit('deleteConfirmed')"
 								>
 									Delete
@@ -89,7 +89,7 @@ defineProps({
 								<button
 									ref="cancelButtonRef"
 									type="button"
-									class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 sm:mt-0 sm:w-auto"
+									class="mt-3 inline-flex w-full justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 sm:mt-0 sm:w-auto"
 									@click="emit('close')"
 								>
 									Cancel

--- a/resources/js/Pages/User/partials/PermissionsList.vue
+++ b/resources/js/Pages/User/partials/PermissionsList.vue
@@ -1,90 +1,44 @@
 <script setup>
-import SubMenu from "@/Components/SubMenu.vue";
-// import { usePage } from "@inertiajs/vue3";
-// import { computed } from "vue";
-defineProps({
-	permissions: { type: Array, default: () => null },
-});
+import { usePage } from "@inertiajs/vue3";
+import { computed } from "vue";
+import { XMarkIcon } from "@heroicons/vue/16/solid";
 
-// const page = usePage();
-// const permissions = computed(() => page.props?.auth.permissions);
+defineProps({
+	permissions: { type: Array, default: () => [] },
+});
 
 const emit = defineEmits(["deletePermission"]);
 
-const clicked = (action, model) => {
-	if (action === "Revoke") {
-		emit("deletePermission", model);
-	}
-};
+const page = usePage();
+const authPermissions = computed(() => page.props?.auth.permissions);
+const canRevoke = computed(() =>
+	authPermissions.value?.includes("assign permissions to user"),
+);
 </script>
+
 <template>
-	<body
-		class="my-4 flow-root sm:mx-0 w-full px-4 bg-green-50 dark:bg-gray-500 rounded-b-lg"
-	>
-		<table v-if="permissions?.length > 0" class="min-w-full">
-			<colgroup></colgroup>
-			<thead
-				class="border-b border-gray-300 text-gray-900 dark:text-gray-100 dark:border-gray-200/50"
-			>
-				<tr>
-					<th
-						scope="col"
-						class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-green-900 dark:text-gray-100 sm:pl-0"
-					>
-						Permissions name
-					</th>
-					<th
-						scope="col"
-						class="hidden px-3 py-3.5 text-sm font-semibold text-green-900 dark:text-gray-100 sm:table-cell"
-					>
-						Date granted
-					</th>
-
-					<th
-						scope="col"
-						class="hidden px-3 text-sm font-semibold text-gray-900 dark:text-gray-100 sm:table-cell"
-					></th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr
-					v-for="permission in permissions"
-					:key="permission"
-					class="border-b border-gray-200 dark:border-gray-400/30"
-				>
-					<td class="max-w-0 py-2 pl-2 pr-3 text-sm sm:pl-0 w-3/5">
-						<div class="font-medium text-green-900 dark:text-gray-100">
-							{{ permission.name }}
-						</div>
-						<!-- <div class="mt-1 truncate text-gray-500 text-xs dark:text-gray-100">
-							{{ permission.start_date }}
-						</div> -->
-					</td>
-					<td
-						class="hidden p-1 text-xs text-green-800 dark:text-gray-100 sm:table-cell text-center"
-					>
-						{{ permission.start_date }}
-					</td>
-
-					<td class="w-8 flex justify-end">
-						<SubMenu
-							v-if="
-								permissions?.includes('update permission') ||
-								permissions?.includes('delete permission')
-							"
-							:can-revoke="permissions?.includes('update permission')"
-							:items="['Revoke']"
-							@item-clicked="(value) => clicked(value, permission)"
-						/>
-					</td>
-				</tr>
-			</tbody>
-		</table>
-		<div
-			v-else
-			class="px-4 py-6 text-sm font-bold text-gray-400 dark:text-gray-100 tracking-wider text-center"
+	<ul v-if="permissions?.length > 0" class="flex flex-wrap gap-2">
+		<li
+			v-for="permission in permissions"
+			:key="permission.id"
+			class="inline-flex items-center gap-1.5 rounded-full bg-green-50 dark:bg-gray-700 pl-3 pr-1.5 py-1 text-sm font-medium text-green-800 dark:text-green-200 ring-1 ring-inset ring-green-600/20"
 		>
-			No permissions found.
-		</div>
-	</body>
+			{{ permission.name }}
+			<button
+				v-if="canRevoke"
+				type="button"
+				class="rounded-full p-0.5 text-green-500 hover:bg-green-100 hover:text-green-700 dark:hover:bg-gray-600"
+				:aria-label="`Revoke ${permission.name}`"
+				@click="emit('deletePermission', permission)"
+			>
+				<XMarkIcon class="h-4 w-4" />
+			</button>
+		</li>
+	</ul>
+	<p
+		v-else
+		class="py-4 text-sm font-medium text-gray-400 dark:text-gray-300"
+	>
+		No direct permissions.
+	</p>
 </template>

--- a/resources/js/Pages/User/partials/RolesList.vue
+++ b/resources/js/Pages/User/partials/RolesList.vue
@@ -1,86 +1,47 @@
 <script setup>
-import SubMenu from "@/Components/SubMenu.vue";
 import { usePage } from "@inertiajs/vue3";
 import { computed } from "vue";
+import { XMarkIcon } from "@heroicons/vue/16/solid";
+
 defineProps({
-	roles: { type: Array, default: () => null },
+	roles: { type: Array, default: () => [] },
 });
 
 const emit = defineEmits(["deleteRole"]);
 
 const page = usePage();
 const permissions = computed(() => page.props?.auth.permissions);
-
-const clicked = (action, model) => {
-	if (action === "Revoke") {
-		emit("deleteRole", model);
-	}
-};
+const canRevoke = computed(() =>
+	permissions.value?.includes("assign roles to user"),
+);
 </script>
+
 <template>
-	<body class="mt-4 flow-root sm:mx-0 w-full px-4 bg-green-50 dark:bg-gray-500">
-		<table v-if="roles?.length > 0" class="min-w-full">
-			<colgroup></colgroup>
-			<thead
-				class="border-b border-gray-300 text-gray-900 dark:text-gray-100 dark:border-gray-200/50"
+	<div class="px-5 pb-5">
+		<ul v-if="roles?.length > 0" class="flex flex-wrap gap-2">
+			<li
+				v-for="role in roles"
+				:key="role.id"
+				class="inline-flex items-center gap-1.5 rounded-full bg-green-50 dark:bg-gray-700 pl-3 pr-1.5 py-1 text-sm font-medium text-green-800 dark:text-green-200 ring-1 ring-inset ring-green-600/20"
 			>
-				<tr>
-					<th
-						scope="col"
-						class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 sm:pl-0"
-					>
-						Roles
-					</th>
-					<th
-						scope="col"
-						class="hidden px-3 py-3.5 text-sm font-semibold text-gray-900 dark:text-gray-100 sm:table-cell"
-					>
-						Start
-					</th>
-
-					<th
-						scope="col"
-						class="hidden px-3 text-sm font-semibold text-gray-900 dark:text-gray-100 sm:table-cell"
-					></th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr
-					v-for="role in roles"
-					:key="role.id"
-					class="border-b border-gray-200 dark:border-gray-400/30"
+				<span class="h-1.5 w-1.5 rounded-full bg-green-500" />
+				{{ role.name }}
+				<button
+					v-if="canRevoke"
+					type="button"
+					class="rounded-full p-0.5 text-green-500 hover:bg-green-100 hover:text-green-700 dark:hover:bg-gray-600"
+					:aria-label="`Revoke ${role.name}`"
+					@click="emit('deleteRole', role)"
 				>
-					<td class="max-w-0 py-2 pl-2 pr-3 text-sm sm:pl-0 w-2/5">
-						<div class="font-medium text-gray-900 dark:text-gray-100">
-							{{ role.name }}
-						</div>
-						<div class="mt-1 truncate text-gray-500 text-xs dark:text-gray-100">
-							{{ role.remarks }}
-						</div>
-					</td>
-					<td
-						class="hidden p-1 text-xs text-gray-500 dark:text-gray-100 sm:table-cell"
-					>
-						{{ role.start_date }}
-					</td>
-
-					<td class="w-8 flex justify-end">
-						<SubMenu
-							v-if="permissions?.includes('assign roles to user')"
-							:items="['Revoke']"
-							:can-revoke="permissions?.includes('update permission')"
-							:can-edit="permissions?.includes('assign roles to user')"
-							@item-clicked="(value) => clicked(value, role)"
-						/>
-					</td>
-				</tr>
-			</tbody>
-		</table>
-		<div
+					<XMarkIcon class="h-4 w-4" />
+				</button>
+			</li>
+		</ul>
+		<p
 			v-else
-			class="px-4 py-6 text-sm font-bold text-gray-400 dark:text-gray-100 tracking-wider text-center"
+			class="py-6 text-center text-sm font-medium text-gray-400 dark:text-gray-300"
 		>
-			No roles found for this user.
-		</div>
-	</body>
+			No roles assigned to this user.
+		</p>
+	</div>
 </template>

--- a/resources/js/Pages/User/partials/UserPermissions.vue
+++ b/resources/js/Pages/User/partials/UserPermissions.vue
@@ -1,116 +1,105 @@
 <script setup>
 import { router } from "@inertiajs/vue3";
-import { ref, watch, computed } from "vue";
+import { ref, computed } from "vue";
 import { useToggle } from "@vueuse/core";
 import Modal from "@/Components/NewModal.vue";
 import AddUserPermission from "./AddUserPermission.vue";
-import Edit from "./Edit.vue";
 import Delete from "./Delete.vue";
 import PermissionsList from "./PermissionsList.vue";
 
-const emit = defineEmits(["closeForm"]);
+defineEmits(["closeForm"]);
 
-let props = defineProps({
-	user: {
-		type: Number,
-		required: true,
-	},
-	permissions: {
-		type: Array,
-		default: () => null,
-	},
-	canAdd: {
-		type: Boolean,
-		default: false,
-	},
+const props = defineProps({
+	user: { type: Number, required: true },
+	directPermissions: { type: Array, default: () => [] },
+	inheritedPermissions: { type: Array, default: () => [] },
+	canAdd: { type: Boolean, default: false },
 });
 
-const userPermissions = computed(() => {
-	return props.permissions.map((permission) => {
-		return permission.name;
-	});
-});
+const directNames = computed(() =>
+	props.directPermissions.map((permission) => permission.name),
+);
 
 const openAddPermissionModal = ref(false);
-let toggleAddPermissionModal = useToggle(openAddPermissionModal);
-// emit("closeForm");
-
-const openEditPromoteModal = ref(false);
-const toggleEditPermissionModal = useToggle(openEditPromoteModal);
-const editModel = ref(null);
+const toggleAddPermissionModal = useToggle(openAddPermissionModal);
 
 const openDeletePermissionModal = ref(false);
 const toggleDeletePermissionModal = useToggle(openDeletePermissionModal);
-
 const deleteModel = ref(null);
+
 const confirmDeletePermission = (model) => {
 	deleteModel.value = model;
 	toggleDeletePermissionModal();
-	// deletePermission(model.staff_id, model.rank_id);
 };
 
 const deletePermission = (user, permission) => {
-	router.patch(route("user.revoke.permissions", { user: user }), {
+	router.patch(route("user.revoke.permissions", { user }), {
 		permission,
 		preserveScroll: true,
 	});
 	toggleDeletePermissionModal();
 };
-
-// watch(
-// 	() => props.showPermissionForm,
-// 	(value) => {
-// 		if (value) {
-// 			openAddPermissionModal.value = true;
-// 		}
-// 	},
-// );
 </script>
+
 <template>
-	<!-- Permission History -->
 	<main>
 		<h2 class="sr-only">User Permissions</h2>
 		<div
-			class="rounded-lg bg-green-200 dark:bg-gray-800 shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-600/80 max-h-80"
+			class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
 		>
-			<dl class="flex flex-wrap">
-				<div class="flex-auto pl-6 pt-6">
-					<dt
-						class="text-md tracking-wide font-semibold leading-6 text-green-900 dark:text-gray-100"
+			<div class="flex items-center justify-between px-5 pt-5 pb-3">
+				<h3 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+					Permissions
+				</h3>
+				<button
+					v-if="canAdd"
+					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+					@click="toggleAddPermissionModal()"
+				>
+					Add Permission
+				</button>
+			</div>
+
+			<div class="px-5 pb-5 space-y-5">
+				<div>
+					<p
+						class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
 					>
-						User Permissions
-					</dt>
+						Direct
+					</p>
+					<PermissionsList
+						:permissions="directPermissions"
+						@delete-permission="(model) => confirmDeletePermission(model)"
+					/>
 				</div>
-				<div class="flex-none self-end px-6 pt-4">
-					<button
-						v-if="canAdd"
-						class="rounded-md bg-green-50 dark:bg-gray-400 px-2 py-1 text-xs font-medium text-green-600 dark:text-gray-50 ring-1 ring-inset ring-green-600/20 dark:ring-gray-500"
-						@click="toggleAddPermissionModal()"
+
+				<div v-if="inheritedPermissions.length > 0">
+					<p
+						class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
 					>
-						{{ "Add Permission" }}
-					</button>
+						Inherited from roles
+					</p>
+					<ul class="flex flex-wrap gap-2">
+						<li
+							v-for="permission in inheritedPermissions"
+							:key="permission.id"
+							class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 dark:bg-gray-700 px-3 py-1 text-sm text-gray-600 dark:text-gray-300 ring-1 ring-inset ring-gray-400/20"
+						>
+							{{ permission.name }}
+							<span class="text-xs text-gray-400 dark:text-gray-400"
+								>via {{ permission.via }}</span
+							>
+						</li>
+					</ul>
 				</div>
-				<PermissionsList
-					:permissions="permissions"
-					class="w-full max-h-64 overflow-y-scroll"
-					@delete-permission="(model) => confirmDeletePermission(model)"
-				/>
-			</dl>
+			</div>
 		</div>
 
 		<Modal :show="openAddPermissionModal" @close="toggleAddPermissionModal()">
 			<AddUserPermission
 				:user="user"
-				:user-permissions="userPermissions"
+				:user-permissions="directNames"
 				@form-submitted="toggleAddPermissionModal()"
-			/>
-		</Modal>
-		<Modal :show="openEditPromoteModal" @close="toggleEditPermissionModal()">
-			<Edit
-				:model="editModel"
-				:staff="staff"
-				:institution="institution"
-				@form-submitted="toggleEditPermissionModal()"
 			/>
 		</Modal>
 

--- a/resources/js/Pages/User/partials/UserPermissions.vue
+++ b/resources/js/Pages/User/partials/UserPermissions.vue
@@ -33,10 +33,11 @@ const confirmDeletePermission = (model) => {
 };
 
 const deletePermission = (user, permission) => {
-	router.patch(route("user.revoke.permissions", { user }), {
-		permission,
-		preserveScroll: true,
-	});
+	router.patch(
+		route("user.revoke.permissions", { user }),
+		{ permission },
+		{ preserveScroll: true },
+	);
 	toggleDeletePermissionModal();
 };
 </script>

--- a/resources/js/Pages/User/partials/UserRoleForm.vue
+++ b/resources/js/Pages/User/partials/UserRoleForm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { CheckIcon } from "@heroicons/vue/20/solid";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const props = defineProps({
 	userRoles: {
@@ -14,6 +14,13 @@ const props = defineProps({
 });
 let roles = ref([]);
 const localUserRoles = ref([...props.userRoles]);
+
+watch(
+	() => props.userRoles,
+	(newRoles) => {
+		localUserRoles.value = [...(newRoles ?? [])];
+	},
+);
 
 const roleOptions = computed(() =>
 	roles.value.map((role) =>

--- a/resources/js/Pages/User/partials/UserRoles.vue
+++ b/resources/js/Pages/User/partials/UserRoles.vue
@@ -43,10 +43,11 @@ const confirmDeleteRole = (model) => {
 };
 
 const deleteRole = (user, role) => {
-	router.patch(route("user.revoke.roles", { user: user }), {
-		role,
-		preserveScroll: true,
-	});
+	router.patch(
+		route("user.revoke.roles", { user: user }),
+		{ role },
+		{ preserveScroll: true },
+	);
 	toggleDeleteRoleModal();
 };
 </script>

--- a/resources/js/Pages/User/partials/UserRoles.vue
+++ b/resources/js/Pages/User/partials/UserRoles.vue
@@ -60,31 +60,24 @@ const deleteRole = (user, role) => {
 	<main>
 		<h2 class="sr-only">User Roles</h2>
 		<div
-			class="rounded-lg bg-green-200 dark:bg-gray-800 shadow-sm ring-1 ring-gray-900/5 dark:ring-gray-600/80 max-h-80"
+			class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm"
 		>
-			<dl class="flex flex-wrap">
-				<div class="flex-auto pl-6 pt-6">
-					<dt
-						class="text-md tracking-wide font-semibold leading-6 text-gray-900 dark:text-gray-100"
-					>
-						User Roles
-					</dt>
-				</div>
-				<div class="flex-none self-end px-6 pt-4">
-					<button
-						v-if="canAdd"
-						class="rounded-md bg-green-50 dark:bg-gray-400 px-2 py-1 text-xs font-medium text-green-600 dark:text-gray-50 ring-1 ring-inset ring-green-600/20 dark:ring-gray-500"
-						@click="toggleAddRoleModal()"
-					>
-						{{ "Add Role" }}
-					</button>
-				</div>
-				<RolesList
-					class="w-full max-h-64 overflow-y-scroll"
-					:roles="props.roles"
-					@delete-role="(model) => confirmDeleteRole(model)"
-				/>
-			</dl>
+			<div class="flex items-center justify-between px-5 pt-5 pb-3">
+				<h3 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+					Roles
+				</h3>
+				<button
+					v-if="canAdd"
+					class="inline-flex items-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-500 dark:bg-gray-600 dark:hover:bg-gray-500"
+					@click="toggleAddRoleModal()"
+				>
+					Add Role
+				</button>
+			</div>
+			<RolesList
+				:roles="props.roles"
+				@delete-role="(model) => confirmDeleteRole(model)"
+			/>
 		</div>
 
 		<Modal :show="openAddRoleModal" @close="toggleAddRoleModal()">

--- a/resources/js/Pages/User/partials/UserRoles.vue
+++ b/resources/js/Pages/User/partials/UserRoles.vue
@@ -4,7 +4,6 @@ import { ref, watch } from "vue";
 import { useToggle } from "@vueuse/core";
 import Modal from "@/Components/NewModal.vue";
 import AddUserRole from "./AddUserRole.vue";
-import Edit from "./Edit.vue";
 import Delete from "./Delete.vue";
 import RolesList from "./RolesList.vue";
 
@@ -32,10 +31,6 @@ let props = defineProps({
 const openAddRoleModal = ref(false);
 let toggleAddRoleModal = useToggle(openAddRoleModal);
 // emit("closeForm");
-
-const openEditPromoteModal = ref(false);
-const toggleEditRoleModal = useToggle(openEditPromoteModal);
-const editModel = ref(null);
 
 const openDeleteRoleModal = ref(false);
 const toggleDeleteRoleModal = useToggle(openDeleteRoleModal);
@@ -82,14 +77,6 @@ const deleteRole = (user, role) => {
 
 		<Modal :show="openAddRoleModal" @close="toggleAddRoleModal()">
 			<AddUserRole :user="user" :has-staff-record="props.hasStaffRecord" @form-submitted="toggleAddRoleModal()" />
-		</Modal>
-		<Modal :show="openEditPromoteModal" @close="toggleEditRoleModal()">
-			<Edit
-				:model="editModel"
-				:staff="staff"
-				:institution="institution"
-				@form-submitted="toggleEditRoleModal()"
-			/>
 		</Modal>
 
 		<Delete

--- a/tests/Feature/UserShowTest.php
+++ b/tests/Feature/UserShowTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class UserShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** A viewer that can view users and their roles/permissions. */
+    protected function viewer(): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['view user', 'view user roles', 'view user permissions']);
+
+        return $user;
+    }
+
+    public function test_show_splits_direct_and_inherited_permissions(): void
+    {
+        $direct = Permission::firstOrCreate(['name' => 'directly.assigned']);
+        $viaRole = Permission::firstOrCreate(['name' => 'role.granted']);
+
+        $role = Role::firstOrCreate(['name' => 'editor']);
+        $role->givePermissionTo($viaRole);
+
+        $target = User::factory()->create();
+        $target->assignRole($role);
+        $target->givePermissionTo($direct);
+
+        $response = $this->actingAs($this->viewer())
+            ->get(route('user.show', ['user' => $target->id]));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('User/Show')
+                ->where('user.email', $target->email)
+                ->where('user.direct_permissions.0.name', 'directly.assigned')
+                ->where('user.inherited_permissions.0.name', 'role.granted')
+                ->where('user.inherited_permissions.0.via', 'editor')
+        );
+    }
+
+    public function test_directly_held_permission_is_not_listed_as_inherited(): void
+    {
+        $shared = Permission::firstOrCreate(['name' => 'shared.permission']);
+
+        $role = Role::firstOrCreate(['name' => 'editor']);
+        $role->givePermissionTo($shared);
+
+        $target = User::factory()->create();
+        $target->assignRole($role);
+        $target->givePermissionTo($shared); // also held directly
+
+        $response = $this->actingAs($this->viewer())
+            ->get(route('user.show', ['user' => $target->id]));
+
+        $response->assertInertia(function (Assert $page) {
+            $direct = collect($page->toArray()['props']['user']['direct_permissions'])->pluck('name');
+            $inherited = collect($page->toArray()['props']['user']['inherited_permissions'])->pluck('name');
+
+            $this->assertTrue($direct->contains('shared.permission'));
+            $this->assertFalse($inherited->contains('shared.permission'));
+        });
+    }
+}

--- a/tests/Feature/UserShowTest.php
+++ b/tests/Feature/UserShowTest.php
@@ -70,4 +70,29 @@ class UserShowTest extends TestCase
             $this->assertFalse($inherited->contains('shared.permission'));
         });
     }
+
+    public function test_inherited_permission_via_lists_all_granting_roles(): void
+    {
+        $permission = Permission::firstOrCreate(['name' => 'multi.role.granted']);
+
+        $roleA = Role::firstOrCreate(['name' => 'editor']);
+        $roleB = Role::firstOrCreate(['name' => 'publisher']);
+        $roleA->givePermissionTo($permission);
+        $roleB->givePermissionTo($permission);
+
+        $target = User::factory()->create();
+        $target->assignRole([$roleA->name, $roleB->name]);
+
+        $response = $this->actingAs($this->viewer())
+            ->get(route('user.show', ['user' => $target->id]));
+
+        $response->assertInertia(function (Assert $page) {
+            $inherited = collect($page->toArray()['props']['user']['inherited_permissions'])
+                ->firstWhere('name', 'multi.role.granted');
+
+            $this->assertNotNull($inherited);
+            $this->assertStringContainsString('editor', $inherited['via']);
+            $this->assertStringContainsString('publisher', $inherited['via']);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Modernizes the user detail page (`User/Show`) and its related components into a green-branded **two-column** layout, and fixes a real correctness bug in how user permissions are displayed and edited.

**Layout & components**
- New identity strip + two-column layout: left rail (Account, Staff record), right main (Roles, Permissions).
- New presentational cards under `resources/js/Components/User/`: `UserIdentityCard`, `UserAccountCard`, `UserStaffRecordCard`.
- Roles and direct permissions render as removable chips; modals restyled to the green-clean card language.
- Removed a dead/broken `Edit` modal from `UserRoles.vue` (referenced undefined `staff`/`institution`, never triggered).

**Permission correctness fix**
- `UserController@show` now returns `direct_permissions` (revokable) and `inherited_permissions` (read-only, annotated with the `via` role) instead of one flat `getAllPermissions()` list.
- Inherited permissions are shown read-only — no revoke control (revoking them was a silent no-op before).
- The Add-Permission modal now pre-fills from **direct** permissions only, so opening + saving no longer materializes role-inherited permissions as direct grants via `syncPermissions`.

**Other fixes**
- Preserve existing roles in the Add-Role form by syncing the checkbox model when the async `userRoles` prop resolves (previously lost prior roles on save).
- Pass `preserveScroll` as an Inertia option (not request data) on role/permission revoke.

Design + plan: `docs/superpowers/specs/2026-06-01-user-show-redesign-design.md`, `docs/superpowers/plans/2026-06-01-user-show-redesign.md`.

## Test Plan
- [x] `php artisan test --filter="UserShowTest|AssociateUserStaffTest"` — 24 passed (117 assertions)
- [x] New `UserShowTest` asserts the direct/inherited split, de-dup, and multi-role `via`
- [x] `vendor/bin/pint` — clean
- [x] `npm run build` — clean
- [ ] Manual: open `/user/{id}` — confirm two-column layout, chips render, adding a role keeps existing roles, revoking a direct permission works, inherited permissions show "via {role}" with no revoke control

🤖 Generated with [Claude Code](https://claude.com/claude-code)