### PR TITLE
Settings admin hub dashboard (Cycle 1)

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Institution;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
+use Spatie\Activitylog\Models\Activity;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
@@ -23,8 +24,10 @@ class SettingsController extends Controller
                     'user_agent' => request()->userAgent(),
                 ])
                 ->log('attempted access to settings');
+
             return redirect()->back()->with('error', 'You are not authorized to view settings');
         }
+
         activity()
             ->causedBy(auth()->user())
             ->event('view')
@@ -35,19 +38,31 @@ class SettingsController extends Controller
             ])
             ->log('viewed settings');
 
-        // Fetch the settings data from the database or any other source
+        $recentActivity = Gate::allows('view user activity')
+            ? Activity::with('causer')
+                ->latest()
+                ->limit(5)
+                ->get()
+                ->map(fn (Activity $activity) => [
+                    'id' => $activity->id,
+                    'description' => $activity->description,
+                    'causer_name' => $activity->causer?->name ?? 'System',
+                    'created_at' => $activity->created_at->format('d M Y H:i'),
+                ])
+                ->all()
+            : [];
 
-        $users = User::count();
-        $staff = User::role('staff')->count();
-        $hrUser = User::role('hr-user')->count();
-        $roles = Role::count();
-        $permissions = Permission::count();
         return Inertia::render('Settings/Index', [
-            'users' => $users,
-            'hr-user' => $hrUser,
-            'staff' => $staff,
-            'roles' => $roles,
-            'permissions' => $permissions,
+            'stats' => [
+                'users' => User::count(),
+                'staff' => User::role('staff')->count(),
+                'hrUser' => User::role('hr-user')->count(),
+                'roles' => Role::count(),
+                'permissions' => Permission::count(),
+                'auditLogs' => Activity::count(),
+                'institutions' => Institution::count(),
+            ],
+            'recentActivity' => $recentActivity,
         ]);
     }
 }

--- a/database/seeders/AllPermissionsSeeder.php
+++ b/database/seeders/AllPermissionsSeeder.php
@@ -46,6 +46,7 @@ class AllPermissionsSeeder extends Seeder
             'restore user',
             'destroy user',
             'view user activity',
+            'view admin settings',
             'view user permissions',
             'update user permissions',
             'view user roles',

--- a/docs/superpowers/plans/2026-06-02-settings-admin-hub.md
+++ b/docs/superpowers/plans/2026-06-02-settings-admin-hub.md
@@ -1,0 +1,519 @@
+# Settings Admin Hub Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bare `/settings` page with a green-clean admin dashboard: permission-gated stat cards linking into existing management areas, plus a recent-activity list.
+
+**Architecture:** Rewrite `SettingsController@__invoke` to return a `stats` object (counts) and a `recentActivity` array (gated on `view user activity`). Build two new presentational components under `resources/js/Components/Settings/` and rewrite `Settings/Index.vue` to compose them, deriving the visible cards from `stats` filtered by `auth.permissions`.
+
+**Tech Stack:** Laravel 11, Inertia v1, Vue 3 `<script setup>`, Tailwind 3, Spatie Permission, Spatie Activitylog, PHPUnit, Heroicons.
+
+**Testing note:** No JS test runner exists in this repo (ESLint lints only `public/`; no vitest). Backend is covered by a PHPUnit feature test with `assertInertia`; frontend is verified by `npm run build` compiling cleanly. Each frontend task ends with a build step.
+
+**Branch:** `redesign/settings-dashboard` (already created; design doc committed there).
+
+---
+
+## File Structure
+
+**Backend**
+- Modify: `app/Http/Controllers/SettingsController.php` — return `stats` + `recentActivity`.
+- Create: `tests/Feature/SettingsControllerTest.php` — authorized payload + deny redirect.
+
+**Frontend**
+- Create: `resources/js/Components/Settings/SettingCard.vue` — one stat/nav card (Inertia `<Link>`).
+- Create: `resources/js/Components/Settings/RecentActivityCard.vue` — recent activity list.
+- Modify: `resources/js/Pages/Settings/Index.vue` — compose cards + activity from props.
+
+---
+
+## Task 1: Backend — `stats` + `recentActivity` payload
+
+**Files:**
+- Modify: `app/Http/Controllers/SettingsController.php`
+- Test: `tests/Feature/SettingsControllerTest.php`
+
+- [ ] **Step 1: Write the failing test** — create `tests/Feature/SettingsControllerTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SettingsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_settings_dashboard(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo(['view admin settings', 'view user activity']);
+
+        User::factory()->count(3)->create();
+        Role::firstOrCreate(['name' => 'reviewer']);
+
+        $response = $this->actingAs($admin)->get(route('settings.index'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Settings/Index')
+                ->where('stats.users', User::count())
+                ->where('stats.roles', Role::count())
+                ->where('stats.permissions', Permission::count())
+                ->has('stats.staff')
+                ->has('stats.hrUser')
+                ->has('stats.auditLogs')
+                ->has('stats.institutions')
+                ->has('recentActivity')
+        );
+    }
+
+    public function test_recent_activity_is_empty_without_activity_permission(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('view admin settings'); // no 'view user activity'
+
+        $response = $this->actingAs($admin)->get(route('settings.index'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Settings/Index')
+                ->where('recentActivity', [])
+        );
+    }
+
+    public function test_settings_denied_without_permission(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->from('/dashboard')
+            ->get(route('settings.index'));
+
+        $response->assertRedirect('/dashboard');
+        $response->assertSessionHas('error');
+    }
+}
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `php artisan test --filter=SettingsControllerTest`
+Expected: FAIL — current controller sends `users`/`hr-user`/`staff`/`roles`/`permissions` (no `stats`, no `recentActivity`).
+
+- [ ] **Step 3: Rewrite the controller** — replace the ENTIRE contents of `app/Http/Controllers/SettingsController.php` with:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Institution;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Spatie\Activitylog\Models\Activity;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class SettingsController extends Controller
+{
+    public function __invoke()
+    {
+        if (Gate::denies('view admin settings')) {
+            activity()
+                ->causedBy(auth()->user())
+                ->event('view')
+                ->withProperties([
+                    'result' => 'failed',
+                    'user_ip' => request()->ip(),
+                    'user_agent' => request()->userAgent(),
+                ])
+                ->log('attempted access to settings');
+
+            return redirect()->back()->with('error', 'You are not authorized to view settings');
+        }
+
+        activity()
+            ->causedBy(auth()->user())
+            ->event('view')
+            ->withProperties([
+                'result' => 'success',
+                'user_ip' => request()->ip(),
+                'user_agent' => request()->userAgent(),
+            ])
+            ->log('viewed settings');
+
+        $recentActivity = Gate::allows('view user activity')
+            ? Activity::with('causer')
+                ->latest()
+                ->limit(5)
+                ->get()
+                ->map(fn (Activity $activity) => [
+                    'id' => $activity->id,
+                    'description' => $activity->description,
+                    'causer_name' => $activity->causer?->name ?? 'System',
+                    'created_at' => $activity->created_at->format('d M Y H:i'),
+                ])
+                ->all()
+            : [];
+
+        return Inertia::render('Settings/Index', [
+            'stats' => [
+                'users' => User::count(),
+                'staff' => User::role('staff')->count(),
+                'hrUser' => User::role('hr-user')->count(),
+                'roles' => Role::count(),
+                'permissions' => Permission::count(),
+                'auditLogs' => Activity::count(),
+                'institutions' => Institution::count(),
+            ],
+            'recentActivity' => $recentActivity,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it PASSES**
+
+Run: `php artisan test --filter=SettingsControllerTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run Pint and commit**
+
+```bash
+vendor/bin/pint app/Http/Controllers/SettingsController.php tests/Feature/SettingsControllerTest.php
+git add app/Http/Controllers/SettingsController.php tests/Feature/SettingsControllerTest.php
+git commit -m "feat: settings controller returns stats and recent activity"
+```
+
+Do NOT stage any other files (there are unrelated working-tree changes — leave them).
+
+---
+
+## Task 2: `SettingCard.vue` component
+
+**Files:**
+- Create: `resources/js/Components/Settings/SettingCard.vue`
+
+- [ ] **Step 1: Create the component** (directory `resources/js/Components/Settings/` does not exist yet — create it):
+
+```vue
+<script setup>
+import { Link } from "@inertiajs/vue3";
+import { ChevronRightIcon } from "@heroicons/vue/16/solid";
+
+defineProps({
+	title: { type: String, required: true },
+	count: { type: [Number, String], required: true },
+	secondary: { type: String, default: null },
+	href: { type: String, required: true },
+	linkLabel: { type: String, default: "Manage" },
+	icon: { type: [Object, Function], default: null },
+});
+</script>
+
+<template>
+	<Link
+		:href="href"
+		class="group flex flex-col rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5 transition hover:border-green-400 dark:hover:border-gray-500 hover:shadow"
+	>
+		<div class="flex items-center justify-between">
+			<span
+				class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-green-50 dark:bg-gray-700 text-green-600 dark:text-green-300"
+			>
+				<component :is="icon" v-if="icon" class="h-5 w-5" />
+			</span>
+			<ChevronRightIcon
+				class="h-5 w-5 text-gray-300 group-hover:text-green-500 dark:text-gray-500"
+			/>
+		</div>
+		<div class="mt-4">
+			<p class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+				{{ count }}
+			</p>
+			<p class="text-sm font-semibold text-gray-700 dark:text-gray-200">
+				{{ title }}
+			</p>
+			<p
+				v-if="secondary"
+				class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
+			>
+				{{ secondary }}
+			</p>
+		</div>
+		<span
+			class="mt-4 text-sm font-medium text-green-600 dark:text-green-300 group-hover:underline"
+		>
+			{{ linkLabel }} →
+		</span>
+	</Link>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/Settings/SettingCard.vue
+git commit -m "feat: add SettingCard component"
+```
+
+---
+
+## Task 3: `RecentActivityCard.vue` component
+
+**Files:**
+- Create: `resources/js/Components/Settings/RecentActivityCard.vue`
+
+- [ ] **Step 1: Create the component**
+
+```vue
+<script setup>
+defineProps({
+	activities: { type: Array, default: () => [] },
+});
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Recent admin activity
+		</h2>
+		<ul
+			v-if="activities.length > 0"
+			class="mt-3 divide-y divide-gray-100 dark:divide-gray-700"
+		>
+			<li
+				v-for="activity in activities"
+				:key="activity.id"
+				class="flex items-center justify-between gap-3 py-2 text-sm"
+			>
+				<span class="min-w-0 truncate text-gray-700 dark:text-gray-200">
+					<span class="font-medium text-gray-900 dark:text-gray-100">{{
+						activity.causer_name
+					}}</span>
+					{{ activity.description }}
+				</span>
+				<span class="flex-shrink-0 text-xs text-gray-400 dark:text-gray-400">
+					{{ activity.created_at }}
+				</span>
+			</li>
+		</ul>
+		<p v-else class="mt-3 text-sm text-gray-400 dark:text-gray-300">
+			No recent activity.
+		</p>
+	</div>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Components/Settings/RecentActivityCard.vue
+git commit -m "feat: add RecentActivityCard component"
+```
+
+---
+
+## Task 4: Rewrite `Settings/Index.vue`
+
+**Files:**
+- Modify: `resources/js/Pages/Settings/Index.vue`
+
+- [ ] **Step 1: Replace the page** — replace the ENTIRE contents of `resources/js/Pages/Settings/Index.vue` with:
+
+```vue
+<script setup>
+import NewAuthenticated from "@/Layouts/NewAuthenticated.vue";
+import { Head, usePage } from "@inertiajs/vue3";
+import BreadCrump from "@/Components/BreadCrump.vue";
+import SettingCard from "@/Components/Settings/SettingCard.vue";
+import RecentActivityCard from "@/Components/Settings/RecentActivityCard.vue";
+import { computed } from "vue";
+import {
+	UsersIcon,
+	ShieldCheckIcon,
+	KeyIcon,
+	ClipboardDocumentListIcon,
+	BuildingOffice2Icon,
+} from "@heroicons/vue/24/outline";
+
+const props = defineProps({
+	stats: { type: Object, required: true },
+	recentActivity: { type: Array, default: () => [] },
+});
+
+const page = usePage();
+const permissions = computed(() => page.props?.auth.permissions);
+const can = (permission) => permissions.value?.includes(permission);
+
+const breadcrumbLinks = [
+	{ name: "Home", url: "/dashboard" },
+	{ name: "Settings", url: null },
+];
+
+const cards = computed(() =>
+	[
+		{
+			title: "Users",
+			count: props.stats.users,
+			secondary: `${props.stats.staff} staff · ${props.stats.hrUser} HR`,
+			href: route("user.index"),
+			linkLabel: "Manage",
+			icon: UsersIcon,
+			gate: "view all users",
+		},
+		{
+			title: "Roles",
+			count: props.stats.roles,
+			href: route("role.index"),
+			linkLabel: "Manage",
+			icon: ShieldCheckIcon,
+			gate: "view roles",
+		},
+		{
+			title: "Permissions",
+			count: props.stats.permissions,
+			href: route("permission.index"),
+			linkLabel: "Manage",
+			icon: KeyIcon,
+			gate: "view permissions",
+		},
+		{
+			title: "Audit Log",
+			count: props.stats.auditLogs,
+			href: route("audit-log.index"),
+			linkLabel: "View",
+			icon: ClipboardDocumentListIcon,
+			gate: "view user activity",
+		},
+		{
+			title: "Institutions",
+			count: props.stats.institutions,
+			href: route("institution.index"),
+			linkLabel: "Manage",
+			icon: BuildingOffice2Icon,
+			gate: "view admin settings",
+		},
+	].filter((card) => can(card.gate)),
+);
+</script>
+
+<template>
+	<Head title="Settings" />
+	<NewAuthenticated>
+		<main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+			<BreadCrump :links="breadcrumbLinks" />
+
+			<div class="mt-4">
+				<h1
+					class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+				>
+					Settings
+				</h1>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Manage users, roles, permissions, and related administration.
+				</p>
+			</div>
+
+			<div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+				<SettingCard
+					v-for="card in cards"
+					:key="card.title"
+					:title="card.title"
+					:count="card.count"
+					:secondary="card.secondary"
+					:href="card.href"
+					:link-label="card.linkLabel"
+					:icon="card.icon"
+				/>
+			</div>
+
+			<RecentActivityCard
+				v-if="can('view user activity')"
+				:activities="recentActivity"
+				class="mt-6"
+			/>
+		</main>
+	</NewAuthenticated>
+</template>
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds. (A wrong Heroicon import name would fail here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/Pages/Settings/Index.vue
+git commit -m "feat: settings admin hub dashboard page"
+```
+
+---
+
+## Task 5: Final verification
+
+- [ ] **Step 1: Run the settings test**
+
+Run: `php artisan test --filter=SettingsControllerTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 2: Run Pint on changed PHP**
+
+Run: `vendor/bin/pint --dirty`
+Expected: no errors. (Note: `--dirty` may also touch unrelated pre-existing working-tree PHP files; do not stage those.)
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Manual smoke check (ask the user to run)**
+
+With `npm run dev` running, open `/settings` as an admin and confirm:
+- Green-clean stat cards render for Users (with "{staff} staff · {hr} HR"), Roles, Permissions, Audit Log, Institutions.
+- Each card links to its management page.
+- "Recent admin activity" lists the latest entries (or "No recent activity.").
+- A user without a given permission does not see that card; a user without `view user activity` sees no activity panel.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Green-clean dashboard layout → Task 4. ✓
+- Five permission-gated cards (Users/Roles/Permissions/Audit Log/Institutions) with counts + links → Task 4 `cards` config; counts from Task 1 `stats`. ✓
+- Users card secondary "{staff} staff · {hrUser} HR" → Task 4. ✓
+- Recent admin activity (last 5, gated on `view user activity`) → Task 1 (`recentActivity`, server-gated) + Task 3 (`RecentActivityCard`) + Task 4 (`v-if can('view user activity')`). ✓
+- Backend `stats` + `recentActivity` payload replacing mismatched props → Task 1. ✓
+- New `Components/Settings/` components → Tasks 2-3. ✓
+- Testing (authorized payload + deny redirect + empty activity without permission) → Task 1, Task 5. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full content. ✓
+
+**Type/name consistency:** `stats` keys `users/staff/hrUser/roles/permissions/auditLogs/institutions` produced in Task 1 and read in Task 4. `recentActivity` item shape `{id, description, causer_name, created_at}` produced in Task 1 and consumed in Task 3 (`activity.causer_name`, `activity.description`, `activity.created_at`, `:key="activity.id"`). `SettingCard` props (`title/count/secondary/href/linkLabel/icon`) defined in Task 2 and passed in Task 4 (`:link-label` ↔ `linkLabel`). ✓
+
+**Out of scope:** persisted app-settings store is Cycle 2 (separate spec/plan).

--- a/docs/superpowers/specs/2026-06-02-settings-admin-hub-design.md
+++ b/docs/superpowers/specs/2026-06-02-settings-admin-hub-design.md
@@ -1,0 +1,106 @@
+# Settings Admin Hub — Design
+
+**Date:** 2026-06-02
+**Status:** Approved for planning
+**Cycle:** 1 of 2 (this spec). Cycle 2 — persisted app-settings store — is a separate spec/plan (see "Follow-up").
+
+## Goal
+
+Turn the bare `/settings` page into a green-clean **admin dashboard**: a central, permission-aware landing page with stat cards, quick-links into the existing management areas, and a small recent-activity list. Also fixes the current page's prop mismatch (the Vue expects `admins`/`hrUser` props the controller never sends correctly).
+
+## Visual Direction
+
+Match the recently-merged user-show redesign:
+- Card surface: `bg-white dark:bg-gray-800`
+- Border: soft green — `border border-green-200/60 dark:border-gray-700`
+- Shape/elevation: `rounded-2xl shadow-sm`
+- Accents: green icon chips, green "Manage →" links
+- Page constrained to `max-w-7xl` with `px-4 sm:px-6 lg:px-8 py-6`
+
+## Layout
+
+```
+Breadcrumb: Home / Settings
+┌──────────────────────────────────────────────┐
+│  Settings                                      │  ← heading + subtitle
+├──────────────────────────────────────────────┤
+│ ┌──────────┐ ┌──────────┐ ┌──────────┐         │
+│ │ Users 42 │ │ Roles  7 │ │ Perms 88 │         │  ← management cards
+│ │30 staff· │ │          │ │          │         │     (count + optional sub)
+│ │ Manage → │ │ Manage → │ │ Manage → │         │
+│ └──────────┘ └──────────┘ └──────────┘         │
+│ ┌──────────┐ ┌──────────┐                       │
+│ │Audit 1.2k│ │Institut.3│                       │
+│ │ View   → │ │ Manage → │                       │
+│ └──────────┘ └──────────┘                       │
+├──────────────────────────────────────────────┤
+│  Recent admin activity                         │  ← last 5 activity entries
+│   • Jude added a role · 2 Jun 2026 10:14        │
+│   • Ama revoked a permission · 2 Jun 2026 09:50 │
+│   …                                             │
+└──────────────────────────────────────────────┘
+```
+
+Cards grid: `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5`. The recent-activity panel is full-width below the grid.
+
+## Cards (each conditionally rendered by permission)
+
+| Card | Count | Secondary | Link (route) | Gate (auth.permissions) |
+|---|---|---|---|---|
+| Users | total users | "{staff} staff · {hrUser} HR" | `user.index` (`/user`) | `view all users` |
+| Roles | role count | — | `role.index` (`/role`) | `view roles` |
+| Permissions | permission count | — | `permission.index` (`/permission`) | `view permissions` |
+| Audit Log | activity count | — | `audit-log.index` (`/audit-log`) | `view user activity` |
+| Institutions | institution count | — | `institution.index` (`/institution`) | `view admin settings` |
+
+A card the admin lacks permission for simply does not render. Gating is client-side via `page.props.auth.permissions` (matches existing app convention); the page itself remains server-gated on `view admin settings`.
+
+## Recent Admin Activity
+
+A full-width panel below the cards listing the **5 most recent** `Spatie\Activitylog\Models\Activity` records. Each row shows: `description`, `causer_name` (causer relation `->name`, fallback "System"), and formatted `created_at`. The controller eager-loads `causer` to avoid N+1. The panel renders only when the admin has `view user activity`; otherwise it is omitted. An empty list shows a friendly "No recent activity." state.
+
+## Components
+
+- **New `resources/js/Components/Settings/SettingCard.vue`** — presentational card. Props: `title` (String), `count` (Number), `secondary` (String, optional), `href` (String), `linkLabel` (String, default "Manage"), `icon` (Object, optional). Renders as an Inertia `<Link>` to `href`. Single responsibility, single root.
+- **New `resources/js/Components/Settings/RecentActivityCard.vue`** — presentational panel. Prop: `activities` (Array of `{ id, description, causer_name, created_at }`). Renders the list or the empty state. Single root.
+- **Rewrite `resources/js/Pages/Settings/Index.vue`** — builds the card list locally from the `stats` prop + permission gates (each card entry pairs a count from `stats` with its route, gate, icon, and label), renders a `SettingCard` per visible entry, and renders `RecentActivityCard` from `recentActivity`. Drops `lang="ts"` to match the plain `<script setup>` convention used across the app.
+
+## Backend
+
+Rewrite `SettingsController@__invoke`:
+- Keep the `view admin settings` gate and the existing success/failure activity logging.
+- Compute counts: `users` (`User::count()`), `staff` (`User::role('staff')->count()`), `hrUser` (`User::role('hr-user')->count()`), `roles` (`Role::count()`), `permissions` (`Permission::count()`), `auditLogs` (`Activity::count()`), `institutions` (`Institution::count()`).
+- Recent activity: `Activity::with('causer')->latest()->limit(5)->get()` mapped to `{ id, description, causer_name, created_at }`.
+- Return a clean payload:
+  ```php
+  Inertia::render('Settings/Index', [
+      'stats' => [
+          'users' => $users,
+          'staff' => $staff,
+          'hrUser' => $hrUser,
+          'roles' => $roles,
+          'permissions' => $permissions,
+          'auditLogs' => $auditLogs,
+          'institutions' => $institutions,
+      ],
+      'recentActivity' => $recentActivity,
+  ]);
+  ```
+- This replaces the current mismatched `users`/`hr-user`/`staff`/`roles`/`permissions` keys.
+
+## Data Flow
+
+- Single server round-trip on page load (all counts + 5 activity rows).
+- No new routes; the hub links to existing named routes.
+- No writes from this page; it is read-only navigation + stats.
+
+## Testing
+
+- Feature test `tests/Feature/SettingsControllerTest.php`:
+  - An admin with `view admin settings` gets `Settings/Index` with a `stats` payload whose counts match seeded/created data, and a `recentActivity` array.
+  - A user **without** `view admin settings` is redirected back with an error (matches current behavior).
+- Frontend: no JS test runner in this repo — verified via `npm run build`.
+
+## Out of Scope / Follow-up (Cycle 2)
+
+A new persisted **application-settings store** — settings table + model, edit forms, validation, seeded defaults, and tests — is a separate spec/plan to be done after this hub ships. The hub is built so a future "App settings" card can be added with one entry in the `sections` array once that store exists.

--- a/resources/js/Components/Settings/RecentActivityCard.vue
+++ b/resources/js/Components/Settings/RecentActivityCard.vue
@@ -1,0 +1,38 @@
+<script setup>
+defineProps({
+	activities: { type: Array, default: () => [] },
+});
+</script>
+
+<template>
+	<div
+		class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+	>
+		<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+			Recent admin activity
+		</h2>
+		<ul
+			v-if="activities.length > 0"
+			class="mt-3 divide-y divide-gray-100 dark:divide-gray-700"
+		>
+			<li
+				v-for="activity in activities"
+				:key="activity.id"
+				class="flex items-center justify-between gap-3 py-2 text-sm"
+			>
+				<span class="min-w-0 truncate text-gray-700 dark:text-gray-200">
+					<span class="font-medium text-gray-900 dark:text-gray-100">{{
+						activity.causer_name
+					}}</span>
+					{{ activity.description }}
+				</span>
+				<span class="flex-shrink-0 text-xs text-gray-400 dark:text-gray-400">
+					{{ activity.created_at }}
+				</span>
+			</li>
+		</ul>
+		<p v-else class="mt-3 text-sm text-gray-400 dark:text-gray-300">
+			No recent activity.
+		</p>
+	</div>
+</template>

--- a/resources/js/Components/Settings/SettingCard.vue
+++ b/resources/js/Components/Settings/SettingCard.vue
@@ -1,0 +1,50 @@
+<script setup>
+import { Link } from "@inertiajs/vue3";
+import { ChevronRightIcon } from "@heroicons/vue/16/solid";
+
+defineProps({
+	title: { type: String, required: true },
+	count: { type: [Number, String], required: true },
+	secondary: { type: String, default: null },
+	href: { type: String, required: true },
+	linkLabel: { type: String, default: "Manage" },
+	icon: { type: [Object, Function], default: null },
+});
+</script>
+
+<template>
+	<Link
+		:href="href"
+		class="group flex flex-col rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5 transition hover:border-green-400 dark:hover:border-gray-500 hover:shadow"
+	>
+		<div class="flex items-center justify-between">
+			<span
+				class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-green-50 dark:bg-gray-700 text-green-600 dark:text-green-300"
+			>
+				<component :is="icon" v-if="icon" class="h-5 w-5" />
+			</span>
+			<ChevronRightIcon
+				class="h-5 w-5 text-gray-300 group-hover:text-green-500 dark:text-gray-500"
+			/>
+		</div>
+		<div class="mt-4">
+			<p class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+				{{ count }}
+			</p>
+			<p class="text-sm font-semibold text-gray-700 dark:text-gray-200">
+				{{ title }}
+			</p>
+			<p
+				v-if="secondary"
+				class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
+			>
+				{{ secondary }}
+			</p>
+		</div>
+		<span
+			class="mt-4 text-sm font-medium text-green-600 dark:text-green-300 group-hover:underline"
+		>
+			{{ linkLabel }} →
+		</span>
+	</Link>
+</template>

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -1,45 +1,114 @@
-<script setup lang="ts">
+<script setup>
 import NewAuthenticated from "@/Layouts/NewAuthenticated.vue";
 import { Head, usePage } from "@inertiajs/vue3";
-import BreadCrumpVue from "@/Components/BreadCrump.vue";
+import BreadCrump from "@/Components/BreadCrump.vue";
+import SettingCard from "@/Components/Settings/SettingCard.vue";
+import RecentActivityCard from "@/Components/Settings/RecentActivityCard.vue";
 import { computed } from "vue";
-import { UsersIcon } from "@heroicons/vue/20/solid";
-
-const BreadcrumbLinks = [
-	{
-		name: "Home",
-		url: "/dashboard",
-	},
-	{
-		name: "Settings",
-	},
-];
+import {
+	UsersIcon,
+	ShieldCheckIcon,
+	KeyIcon,
+	ClipboardDocumentListIcon,
+	BuildingOffice2Icon,
+} from "@heroicons/vue/24/outline";
 
 const props = defineProps({
-	users: { type: Number, required: true },
-	admins: { type: Number, required: true },
-	staff: { type: Number, required: true },
-	roles: { type: Number, required: true },
-	hrUser: { type: Number, required: true },
-	permissions: { type: Number, required: true },
+	stats: { type: Object, required: true },
+	recentActivity: { type: Array, default: () => [] },
 });
 
 const page = usePage();
 const permissions = computed(() => page.props?.auth.permissions);
+const can = (permission) => permissions.value?.includes(permission);
+
+const breadcrumbLinks = [
+	{ name: "Home", url: "/dashboard" },
+	{ name: "Settings", url: null },
+];
+
+const cards = computed(() =>
+	[
+		{
+			title: "Users",
+			count: props.stats.users,
+			secondary: `${props.stats.staff} staff · ${props.stats.hrUser} HR`,
+			href: route("user.index"),
+			linkLabel: "Manage",
+			icon: UsersIcon,
+			gate: "view all users",
+		},
+		{
+			title: "Roles",
+			count: props.stats.roles,
+			href: route("role.index"),
+			linkLabel: "Manage",
+			icon: ShieldCheckIcon,
+			gate: "view roles",
+		},
+		{
+			title: "Permissions",
+			count: props.stats.permissions,
+			href: route("permission.index"),
+			linkLabel: "Manage",
+			icon: KeyIcon,
+			gate: "view permissions",
+		},
+		{
+			title: "Audit Log",
+			count: props.stats.auditLogs,
+			href: route("audit-log.index"),
+			linkLabel: "View",
+			icon: ClipboardDocumentListIcon,
+			gate: "view user activity",
+		},
+		{
+			title: "Institutions",
+			count: props.stats.institutions,
+			href: route("institution.index"),
+			linkLabel: "Manage",
+			icon: BuildingOffice2Icon,
+			gate: "view admin settings",
+		},
+	].filter((card) => can(card.gate)),
+);
 </script>
 
 <template>
+	<Head title="Settings" />
 	<NewAuthenticated>
-		<Head title="Next Promotion list" />
-		<main class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-			<BreadCrumpVue :links="BreadcrumbLinks" />
-			<div class="flex gap-x-4 text-2xl m-4 text-gray-700 dark:text-gray-50">
-				<div>Users: {{ props.users }}</div>
-				<div>HR User: {{ props.hrUser }}</div>
-				<div>Staff: {{ props.staff }}</div>
-				<div>Roles: {{ props.roles }}</div>
-				<div>permissions: {{ props.permissions }}</div>
+		<main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
+			<BreadCrump :links="breadcrumbLinks" />
+
+			<div class="mt-4">
+				<h1
+					class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+				>
+					Settings
+				</h1>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Manage users, roles, permissions, and related administration.
+				</p>
 			</div>
+
+			<div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+				<SettingCard
+					v-for="card in cards"
+					:key="card.title"
+					:title="card.title"
+					:count="card.count"
+					:secondary="card.secondary"
+					:href="card.href"
+					:link-label="card.linkLabel"
+					:icon="card.icon"
+				/>
+			</div>
+
+			<RecentActivityCard
+				v-if="can('view user activity')"
+				:activities="recentActivity"
+				class="mt-6"
+			/>
 		</main>
 	</NewAuthenticated>
 </template>

--- a/tests/Feature/SettingsControllerTest.php
+++ b/tests/Feature/SettingsControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class SettingsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_settings_dashboard(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo(['view admin settings', 'view user activity']);
+
+        User::factory()->count(3)->create();
+        Role::firstOrCreate(['name' => 'reviewer']);
+
+        $response = $this->actingAs($admin)->get(route('settings.index'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Settings/Index')
+                ->where('stats.users', User::count())
+                ->where('stats.roles', Role::count())
+                ->where('stats.permissions', Permission::count())
+                ->has('stats.staff')
+                ->has('stats.hrUser')
+                ->has('stats.auditLogs')
+                ->has('stats.institutions')
+                ->has('recentActivity')
+        );
+    }
+
+    public function test_recent_activity_is_empty_without_activity_permission(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('view admin settings'); // no 'view user activity'
+
+        $response = $this->actingAs($admin)->get(route('settings.index'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Settings/Index')
+                ->where('recentActivity', [])
+        );
+    }
+
+    public function test_settings_denied_without_permission(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->from('/dashboard')
+            ->get(route('settings.index'));
+
+        $response->assertRedirect('/dashboard');
+        $response->assertSessionHas('error');
+    }
+}


### PR DESCRIPTION
## Summary

Rebuilds the bare `/settings` page into a green-clean **admin hub** — a central, permission-aware dashboard for managing users, roles, permissions, and related administration.

- **Stat cards** linking into existing management pages: Users (with "{staff} staff · {hr} HR"), Roles, Permissions, Audit Log, Institutions. Each card is hidden unless the admin holds its permission.
- **Recent admin activity** panel — the 5 latest audit-log entries, server-gated on `view user activity` (returns `[]` otherwise) and client-gated to match.
- **Backend:** `SettingsController@__invoke` now returns a structured `stats` object + `recentActivity`, replacing the previous mismatched flat props (the old Vue even expected `admins`/`hrUser` props the controller never sent).
- **Permission fix:** seeded the previously-missing `view admin settings` permission. It was only referenced in the controller gate and sat commented-out in a seeder, so the Settings page and its nav link were effectively inaccessible in the UI (the super-admin `Gate::before` doesn't populate the explicit `auth.permissions` list the UI gates on). Now created in `AllPermissionsSeeder` and assigned to super-administrator.
- New presentational components `Components/Settings/SettingCard.vue` and `RecentActivityCard.vue`; green-clean styling consistent with the user-show redesign.

Design + plan: `docs/superpowers/specs/2026-06-02-settings-admin-hub-design.md`, `docs/superpowers/plans/2026-06-02-settings-admin-hub.md`.

This is **Cycle 1**. A persisted **application-settings store** (settings table/model, edit forms, defaults) is a planned follow-up (Cycle 2).

## Test Plan
- [x] `php artisan test --filter=SettingsControllerTest` — 3 passed (authorized payload, empty recentActivity without permission, deny redirect)
- [x] `php -d memory_limit=512M artisan test --filter="Permission|Role|Settings|User|Staff"` — 103 passed (seeder change introduces no count regressions)
- [x] `vendor/bin/pint` — clean
- [x] `npm run build` — clean
- [ ] Manual: open `/settings` as an admin — confirm green-clean cards, per-permission visibility, links, and the recent-activity panel

## Notes / follow-ups
- Optional consistency tweak (reviewer suggestion, intentionally left per approved spec): the Institutions card gates on `view admin settings` (so it always shows to settings viewers) rather than a per-area `view all institutions`.
- Pre-existing repo quirk surfaced: `database/seeders/` is gitignored-but-tracked, so the seeder edit needed `git add -f`. Worth fixing the `.gitignore` rule separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)