### PR TITLE
App settings store (Cycle 2a)

### DIFF
--- a/app/Http/Controllers/AppSettingsController.php
+++ b/app/Http/Controllers/AppSettingsController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateAppSettingsRequest;
+use App\Settings\GeneralSettings;
+use App\Settings\SecuritySettings;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AppSettingsController extends Controller
+{
+    public function edit(GeneralSettings $general, SecuritySettings $security): Response
+    {
+        return Inertia::render('Settings/App', [
+            'general' => [
+                'org_name' => $general->org_name,
+                'support_email' => $general->support_email,
+                'date_format' => $general->date_format,
+                'pagination_size' => $general->pagination_size,
+            ],
+            'security' => [
+                'password_change_interval_days' => $security->password_change_interval_days,
+            ],
+        ]);
+    }
+
+    public function update(UpdateAppSettingsRequest $request, GeneralSettings $general, SecuritySettings $security)
+    {
+        $data = $request->validated();
+
+        $general->org_name = $data['org_name'];
+        $general->support_email = $data['support_email'];
+        $general->date_format = $data['date_format'];
+        $general->pagination_size = $data['pagination_size'];
+        $general->save();
+
+        $security->password_change_interval_days = $data['password_change_interval_days'];
+        $security->save();
+
+        return redirect()->route('app-settings.edit')->with('success', 'Settings updated successfully');
+    }
+}

--- a/app/Http/Controllers/AppSettingsController.php
+++ b/app/Http/Controllers/AppSettingsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\UpdateAppSettingsRequest;
 use App\Settings\GeneralSettings;
 use App\Settings\SecuritySettings;
+use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -25,7 +26,7 @@ class AppSettingsController extends Controller
         ]);
     }
 
-    public function update(UpdateAppSettingsRequest $request, GeneralSettings $general, SecuritySettings $security)
+    public function update(UpdateAppSettingsRequest $request, GeneralSettings $general, SecuritySettings $security): RedirectResponse
     {
         $data = $request->validated();
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -61,6 +61,16 @@ class HandleInertiaRequests extends Middleware
                 'qualifications_count' => fn () => $this->profileFactsForCurrentUser($request)['qualifications_count'] ?? null,
             ],
             // 'permissions' => fn() => $request->user()?->getAllPermissions()->pluck('name'),
+            'app' => function () {
+                $general = app(\App\Settings\GeneralSettings::class);
+
+                return [
+                    'org_name' => $general->org_name,
+                    'support_email' => $general->support_email,
+                    'date_format' => $general->date_format,
+                    'pagination_size' => $general->pagination_size,
+                ];
+            },
             'ziggy' => function () use ($request) {
                 return array_merge((new Ziggy)->toArray(), [
                     'location' => $request->url(),

--- a/app/Http/Requests/UpdateAppSettingsRequest.php
+++ b/app/Http/Requests/UpdateAppSettingsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAppSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'org_name' => ['required', 'string', 'max:255'],
+            'support_email' => ['nullable', 'email', 'max:255'],
+            'date_format' => ['required', 'string', 'max:50'],
+            'pagination_size' => ['required', 'integer', 'min:5', 'max:100'],
+            'password_change_interval_days' => ['required', 'integer', 'min:0', 'max:3650'],
+        ];
+    }
+}

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class GeneralSettings extends Settings
+{
+    public string $org_name;
+
+    public ?string $support_email;
+
+    public string $date_format;
+
+    public int $pagination_size;
+
+    public static function group(): string
+    {
+        return 'general';
+    }
+}

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -6,13 +6,13 @@ use Spatie\LaravelSettings\Settings;
 
 class GeneralSettings extends Settings
 {
-    public string $org_name;
+    public string $org_name = 'HRMIS';
 
-    public ?string $support_email;
+    public ?string $support_email = null;
 
-    public string $date_format;
+    public string $date_format = 'd M Y';
 
-    public int $pagination_size;
+    public int $pagination_size = 10;
 
     public static function group(): string
     {

--- a/app/Settings/SecuritySettings.php
+++ b/app/Settings/SecuritySettings.php
@@ -6,7 +6,7 @@ use Spatie\LaravelSettings\Settings;
 
 class SecuritySettings extends Settings
 {
-    public int $password_change_interval_days;
+    public int $password_change_interval_days = 90;
 
     public static function group(): string
     {

--- a/app/Settings/SecuritySettings.php
+++ b/app/Settings/SecuritySettings.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class SecuritySettings extends Settings
+{
+    public int $password_change_interval_days;
+
+    public static function group(): string
+    {
+        return 'security';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
 		"psr/simple-cache": "^2.0 || ^3.0",
 		"spatie/laravel-activitylog": "^4.5",
 		"spatie/laravel-permission": "^6.7",
+		"spatie/laravel-settings": "^3.9",
 		"tightenco/ziggy": "^1.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cc5cebc565b1059addcc5e35f2968bc",
+    "content-hash": "2f26f6529bf6872a136a770867b996ab",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -3908,6 +3908,117 @@
             "time": "2025-07-22T14:01:30+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoffice/phpspreadsheet",
             "version": "1.30.5",
             "source": {
@@ -4089,6 +4200,53 @@
                 }
             ],
             "time": "2025-08-21T11:53:16+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "psr/cache",
@@ -5128,6 +5286,152 @@
                 }
             ],
             "time": "2025-11-03T20:16:13+00:00"
+        },
+        {
+            "name": "spatie/laravel-settings",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-settings.git",
+                "reference": "6c1351cf57c4ae96cd2313ae395c6d367dfeee01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-settings/zipball/6c1351cf57c4ae96cd2313ae395c6d367dfeee01",
+                "reference": "6c1351cf57c4ae96cd2313ae395c6d367dfeee01",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "phpdocumentor/type-resolver": "^1.5|^2.0",
+                "spatie/temporary-directory": "^1.3|^2.0"
+            },
+            "require-dev": {
+                "ext-redis": "*",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "spatie/laravel-data": "^2.0.0|^4.0.0",
+                "spatie/pest-plugin-snapshots": "^2.0",
+                "spatie/phpunit-snapshot-assertions": "^4.2|^5.0",
+                "spatie/ray": "^1.36"
+            },
+            "suggest": {
+                "spatie/data-transfer-object": "Allows for DTO casting to settings. (deprecated)"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\LaravelSettings\\LaravelSettingsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelSettings\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Store your application settings",
+            "homepage": "https://github.com/spatie/laravel-settings",
+            "keywords": [
+                "laravel-settings",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-settings/issues",
+                "source": "https://github.com/spatie/laravel-settings/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-26T13:18:06+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "662e481d6ec07ef29fd05010433428851a42cd07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/662e481d6ec07ef29fd05010433428851a42cd07",
+                "reference": "662e481d6ec07ef29fd05010433428851a42cd07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-12T07:42:22+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,0 +1,101 @@
+<?php
+
+return [
+
+    /*
+     * Each settings class used in your application must be registered, you can
+     * put them (manually) here.
+     */
+    'settings' => [
+        \App\Settings\GeneralSettings::class,
+        \App\Settings\SecuritySettings::class,
+    ],
+
+    /*
+     * The path where the settings classes will be created.
+     */
+    'setting_class_path' => app_path('Settings'),
+
+    /*
+     * In these directories settings migrations will be stored and ran when migrating. A settings
+     * migration created via the make:settings-migration command will be stored in the first path or
+     * a custom defined path when running the command.
+     */
+    'migrations_paths' => [
+        database_path('settings'),
+    ],
+
+    /*
+     * When no repository was set for a settings class the following repository
+     * will be used for loading and saving settings.
+     */
+    'default_repository' => 'database',
+
+    /*
+     * Settings will be stored and loaded from these repositories.
+     */
+    'repositories' => [
+        'database' => [
+            'type' => Spatie\LaravelSettings\SettingsRepositories\DatabaseSettingsRepository::class,
+            'model' => null,
+            'table' => null,
+            'connection' => null,
+        ],
+        'redis' => [
+            'type' => Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository::class,
+            'connection' => null,
+            'prefix' => null,
+        ],
+    ],
+
+    /*
+     * The encoder and decoder will determine how settings are stored and
+     * retrieved in the database. By default, `json_encode` and `json_decode`
+     * are used.
+     */
+    'encoder' => null,
+    'decoder' => null,
+
+    /*
+     * The contents of settings classes can be cached through your application,
+     * settings will be stored within a provided Laravel store and can have an
+     * additional prefix.
+     */
+    'cache' => [
+        'enabled' => (bool)env('SETTINGS_CACHE_ENABLED', false),
+        'store' => null,
+        'prefix' => null,
+        'ttl' => null,
+
+        /*
+         * When enabled, uses Laravel's memoized cache driver (requires Laravel 12.9+)
+         * to keep resolved values in memory during a single request.
+         */
+        'memo' => env('SETTINGS_CACHE_MEMO', false),
+    ],
+
+    /*
+     * These global casts will be automatically used whenever a property within
+     * your settings class isn't a default PHP type.
+     */
+    'global_casts' => [
+        DateTimeInterface::class => Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast::class,
+        DateTimeZone::class => Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast::class,
+//        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
+        Spatie\LaravelData\Data::class => Spatie\LaravelSettings\SettingsCasts\DataCast::class,
+    ],
+
+    /*
+     * The package will look for settings in these paths and automatically
+     * register them.
+     */
+    'auto_discover_settings' => [
+        app_path('Settings'),
+    ],
+
+    /*
+     * Automatically discovered settings classes can be cached, so they don't
+     * need to be searched each time the application boots up.
+     */
+    'discovered_settings_cache_path' => base_path('bootstrap/cache'),
+];

--- a/config/settings.php
+++ b/config/settings.php
@@ -62,7 +62,7 @@ return [
      * additional prefix.
      */
     'cache' => [
-        'enabled' => (bool)env('SETTINGS_CACHE_ENABLED', false),
+        'enabled' => (bool) env('SETTINGS_CACHE_ENABLED', false),
         'store' => null,
         'prefix' => null,
         'ttl' => null,
@@ -81,7 +81,7 @@ return [
     'global_casts' => [
         DateTimeInterface::class => Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast::class,
         DateTimeZone::class => Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast::class,
-//        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
+        //        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
         Spatie\LaravelData\Data::class => Spatie\LaravelSettings\SettingsCasts\DataCast::class,
     ],
 

--- a/database/migrations/2022_12_14_083707_create_settings_table.php
+++ b/database/migrations/2022_12_14_083707_create_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(config('settings.repositories.database.table') ?? 'settings', function (Blueprint $table): void {
+            $table->id();
+
+            $table->string('group');
+            $table->string('name');
+            $table->boolean('locked')->default(false);
+            $table->json('payload');
+
+            $table->timestamps();
+
+            $table->unique(['group', 'name']);
+        });
+    }
+};

--- a/database/seeders/AllPermissionsSeeder.php
+++ b/database/seeders/AllPermissionsSeeder.php
@@ -47,6 +47,7 @@ class AllPermissionsSeeder extends Seeder
             'destroy user',
             'view user activity',
             'view admin settings',
+            'update app settings',
             'view user permissions',
             'update user permissions',
             'view user roles',

--- a/database/settings/2026_06_02_000000_create_app_settings.php
+++ b/database/settings/2026_06_02_000000_create_app_settings.php
@@ -1,0 +1,15 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.org_name', 'HRMIS');
+        $this->migrator->add('general.support_email', null);
+        $this->migrator->add('general.date_format', 'd M Y');
+        $this->migrator->add('general.pagination_size', 10);
+        $this->migrator->add('security.password_change_interval_days', 90);
+    }
+};

--- a/docs/superpowers/plans/2026-06-02-app-settings-store.md
+++ b/docs/superpowers/plans/2026-06-02-app-settings-store.md
@@ -1,0 +1,785 @@
+# App Settings Store (Cycle 2a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persisted application-settings store (spatie/laravel-settings) with an admin management page, seeded defaults, frontend exposure, and org-name branding — without enforcing the password interval yet.
+
+**Architecture:** Two settings classes (`GeneralSettings`, `SecuritySettings`) backed by spatie/laravel-settings with a defaults migration. An `AppSettingsController` + Form Request power a gated `/settings/app` edit page. General settings are shared to the frontend via `HandleInertiaRequests` and the org name is shown in the layout. A hub card links to the page.
+
+**Tech Stack:** Laravel 11, PHP 8.4, spatie/laravel-settings (new dep, approved), Inertia v1, Vue 3 `<script setup>`, Tailwind 3, Spatie Permission, PHPUnit, Heroicons.
+
+**Testing note:** No JS test runner exists (ESLint lints only `public/`; no vitest). Backend is covered by PHPUnit feature tests; frontend is verified by `npm run build` compiling cleanly. `tests/TestCase.php` sets `$seed = true` and uses `RefreshDatabase`, so `php artisan migrate` (including the spatie settings migration under `database/settings/`) seeds defaults before each test.
+
+**Branch:** `feature/app-settings-store` (created; design committed there).
+
+---
+
+## File Structure
+
+**Backend / store**
+- Add dep: `spatie/laravel-settings` (composer).
+- Create: `config/settings.php` (published, then edited to register classes).
+- Create: `database/migrations/*_create_settings_table.php` (published by the package).
+- Create: `app/Settings/GeneralSettings.php`, `app/Settings/SecuritySettings.php`.
+- Create: `database/settings/2026_06_02_000000_create_app_settings.php` (defaults).
+- Modify: `database/seeders/AllPermissionsSeeder.php` (add `update app settings`).
+
+**Backend / admin**
+- Create: `app/Http/Controllers/AppSettingsController.php`, `app/Http/Requests/UpdateAppSettingsRequest.php`.
+- Modify: `routes/web.php` (two routes).
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php` (shared `app` prop).
+
+**Frontend**
+- Modify: `resources/js/Components/Settings/SettingCard.vue` (optional `count`).
+- Create: `resources/js/Pages/Settings/App.vue` (settings form).
+- Modify: `resources/js/Pages/Settings/Index.vue` (Application card).
+- Modify: `resources/js/Layouts/NewAuthenticated.vue` (org name branding).
+
+**Tests**
+- Create: `tests/Feature/AppSettingsTest.php`.
+
+---
+
+## Task 1: Store foundation — package, settings classes, defaults, permission
+
+**Files:**
+- Add dep `spatie/laravel-settings`; publish `config/settings.php` + settings-table migration.
+- Create: `app/Settings/GeneralSettings.php`, `app/Settings/SecuritySettings.php`
+- Create: `database/settings/2026_06_02_000000_create_app_settings.php`
+- Modify: `config/settings.php`, `database/seeders/AllPermissionsSeeder.php`
+- Test: `tests/Feature/AppSettingsTest.php` (defaults + permission)
+
+> Package install is not TDD-able; do Steps 1-6 (setup), then Step 7 writes a test that locks the seeded defaults and the new permission.
+
+- [ ] **Step 1: Install the package**
+
+Run: `composer require spatie/laravel-settings`
+Expected: installs (v3.x, compatible with Laravel 11 / PHP 8.4).
+
+- [ ] **Step 2: Publish config and the settings-table migration**
+
+Run:
+```bash
+php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="settings-config" --no-interaction
+php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider" --tag="settings-migrations" --no-interaction
+```
+Expected: creates `config/settings.php` and a `database/migrations/*_create_settings_table.php`.
+If a command reports "Nothing to publish", run `php artisan vendor:publish --provider="Spatie\LaravelSettings\LaravelSettingsServiceProvider"` once to list the exact tag names and use those instead. Do not invent tag names — report BLOCKED if they can't be found.
+
+- [ ] **Step 3: Create the settings classes**
+
+Create `app/Settings/GeneralSettings.php`:
+```php
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class GeneralSettings extends Settings
+{
+    public string $org_name;
+
+    public ?string $support_email;
+
+    public string $date_format;
+
+    public int $pagination_size;
+
+    public static function group(): string
+    {
+        return 'general';
+    }
+}
+```
+
+Create `app/Settings/SecuritySettings.php`:
+```php
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class SecuritySettings extends Settings
+{
+    public int $password_change_interval_days;
+
+    public static function group(): string
+    {
+        return 'security';
+    }
+}
+```
+
+- [ ] **Step 4: Register the classes in `config/settings.php`**
+
+In `config/settings.php`, find the `'settings' => [` array and set it to include both classes:
+```php
+    'settings' => [
+        \App\Settings\GeneralSettings::class,
+        \App\Settings\SecuritySettings::class,
+    ],
+```
+Leave the rest of the published config unchanged.
+
+- [ ] **Step 5: Create the defaults migration**
+
+Create `database/settings/2026_06_02_000000_create_app_settings.php`:
+```php
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.org_name', 'HRMIS');
+        $this->migrator->add('general.support_email', null);
+        $this->migrator->add('general.date_format', 'd M Y');
+        $this->migrator->add('general.pagination_size', 10);
+        $this->migrator->add('security.password_change_interval_days', 90);
+    }
+};
+```
+
+- [ ] **Step 6: Add the `update app settings` permission**
+
+In `database/seeders/AllPermissionsSeeder.php`, in the `getAllPermissions()` array, add the line `'update app settings',` immediately after `'view admin settings',` (in the User Management / settings area). Add only that one line. (The seeder's `firstOrCreate` loop + `syncPermissions(Permission::all())` will create it and assign it to super-administrator.)
+
+- [ ] **Step 7: Write the foundation test**
+
+Create `tests/Feature/AppSettingsTest.php`:
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Settings\GeneralSettings;
+use App\Settings\SecuritySettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class AppSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_settings_have_seeded_defaults(): void
+    {
+        $general = app(GeneralSettings::class);
+        $security = app(SecuritySettings::class);
+
+        $this->assertSame('HRMIS', $general->org_name);
+        $this->assertNull($general->support_email);
+        $this->assertSame('d M Y', $general->date_format);
+        $this->assertSame(10, $general->pagination_size);
+        $this->assertSame(90, $security->password_change_interval_days);
+    }
+
+    public function test_update_app_settings_permission_is_seeded(): void
+    {
+        $this->assertTrue(
+            Permission::where('name', 'update app settings')->exists(),
+            "Permission 'update app settings' should be seeded"
+        );
+    }
+}
+```
+
+- [ ] **Step 8: Run migrations and the test**
+
+Run: `php artisan migrate --no-interaction` then `php artisan test --filter=AppSettingsTest`
+Expected: PASS (2 tests). If the settings migration didn't run, confirm `config/settings.php` has `'migrations_paths' => [database_path('settings')]` (the package default) and that the `database/settings/` file is named correctly.
+
+- [ ] **Step 9: Pint and commit**
+
+```bash
+vendor/bin/pint app/Settings tests/Feature/AppSettingsTest.php database/seeders/AllPermissionsSeeder.php
+git add -f config/settings.php database/migrations/*_create_settings_table.php database/settings/2026_06_02_000000_create_app_settings.php database/seeders/AllPermissionsSeeder.php
+git add app/Settings/GeneralSettings.php app/Settings/SecuritySettings.php tests/Feature/AppSettingsTest.php composer.json composer.lock
+git commit -m "feat: add app settings store with general and security groups"
+```
+> Note: `database/` paths are gitignored-but-tracked in this repo, so `git add -f` is required for files under `database/`. Verify the commit includes the migration + settings files with `git show --stat HEAD`. Do not stage unrelated pre-existing changes (e.g. `database/seeders/AdminUserSeeder.php`).
+
+---
+
+## Task 2: Admin controller, request, routes
+
+**Files:**
+- Create: `app/Http/Controllers/AppSettingsController.php`
+- Create: `app/Http/Requests/UpdateAppSettingsRequest.php`
+- Modify: `routes/web.php`
+- Test: `tests/Feature/AppSettingsTest.php` (append controller tests)
+
+- [ ] **Step 1: Add the controller tests**
+
+Append these methods to the existing `tests/Feature/AppSettingsTest.php` class (and add the imports `use App\Models\User;`, `use Inertia\Testing\AssertableInertia as Assert;` at the top):
+```php
+    public function test_admin_can_view_app_settings_page(): void
+    {
+        $admin = \App\Models\User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->get(route('app-settings.edit'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (\Inertia\Testing\AssertableInertia $page) => $page
+                ->component('Settings/App')
+                ->where('general.org_name', 'HRMIS')
+                ->where('general.pagination_size', 10)
+                ->where('security.password_change_interval_days', 90)
+        );
+    }
+
+    public function test_admin_can_update_app_settings(): void
+    {
+        $admin = \App\Models\User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->put(route('app-settings.update'), [
+            'org_name' => 'New Org',
+            'support_email' => 'help@example.com',
+            'date_format' => 'Y-m-d',
+            'pagination_size' => 25,
+            'password_change_interval_days' => 30,
+        ]);
+
+        $response->assertRedirect(route('app-settings.edit'));
+        $response->assertSessionHas('success');
+
+        $this->assertSame('New Org', app(\App\Settings\GeneralSettings::class)->org_name);
+        $this->assertSame('help@example.com', app(\App\Settings\GeneralSettings::class)->support_email);
+        $this->assertSame('Y-m-d', app(\App\Settings\GeneralSettings::class)->date_format);
+        $this->assertSame(25, app(\App\Settings\GeneralSettings::class)->pagination_size);
+        $this->assertSame(30, app(\App\Settings\SecuritySettings::class)->password_change_interval_days);
+    }
+
+    public function test_update_rejects_invalid_input(): void
+    {
+        $admin = \App\Models\User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)
+            ->from(route('app-settings.edit'))
+            ->put(route('app-settings.update'), [
+                'org_name' => '',
+                'support_email' => 'not-an-email',
+                'date_format' => 'd M Y',
+                'pagination_size' => 9999,
+                'password_change_interval_days' => 30,
+            ]);
+
+        $response->assertSessionHasErrors(['org_name', 'support_email', 'pagination_size']);
+    }
+
+    public function test_app_settings_require_permission(): void
+    {
+        $user = \App\Models\User::factory()->create();
+
+        $this->actingAs($user)->get(route('app-settings.edit'))->assertForbidden();
+        $this->actingAs($user)->put(route('app-settings.update'), [])->assertForbidden();
+    }
+```
+
+- [ ] **Step 2: Run the tests, verify they FAIL**
+
+Run: `php artisan test --filter=AppSettingsTest`
+Expected: FAIL — `route('app-settings.edit')` does not exist yet.
+
+- [ ] **Step 3: Create the Form Request**
+
+Create `app/Http/Requests/UpdateAppSettingsRequest.php`:
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAppSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'org_name' => ['required', 'string', 'max:255'],
+            'support_email' => ['nullable', 'email', 'max:255'],
+            'date_format' => ['required', 'string', 'max:50'],
+            'pagination_size' => ['required', 'integer', 'min:5', 'max:100'],
+            'password_change_interval_days' => ['required', 'integer', 'min:0', 'max:3650'],
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Create the controller**
+
+Create `app/Http/Controllers/AppSettingsController.php`:
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateAppSettingsRequest;
+use App\Settings\GeneralSettings;
+use App\Settings\SecuritySettings;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AppSettingsController extends Controller
+{
+    public function edit(GeneralSettings $general, SecuritySettings $security): Response
+    {
+        return Inertia::render('Settings/App', [
+            'general' => [
+                'org_name' => $general->org_name,
+                'support_email' => $general->support_email,
+                'date_format' => $general->date_format,
+                'pagination_size' => $general->pagination_size,
+            ],
+            'security' => [
+                'password_change_interval_days' => $security->password_change_interval_days,
+            ],
+        ]);
+    }
+
+    public function update(UpdateAppSettingsRequest $request, GeneralSettings $general, SecuritySettings $security)
+    {
+        $data = $request->validated();
+
+        $general->org_name = $data['org_name'];
+        $general->support_email = $data['support_email'];
+        $general->date_format = $data['date_format'];
+        $general->pagination_size = $data['pagination_size'];
+        $general->save();
+
+        $security->password_change_interval_days = $data['password_change_interval_days'];
+        $security->save();
+
+        return redirect()->route('app-settings.edit')->with('success', 'Settings updated successfully');
+    }
+}
+```
+
+- [ ] **Step 5: Register the routes**
+
+In `routes/web.php`, add the import near the other controller imports at the top:
+```php
+use App\Http\Controllers\AppSettingsController;
+```
+And add these two lines immediately after the `Route::get('/settings', SettingsController::class)...->name('settings.index');` line:
+```php
+Route::get('/settings/app', [AppSettingsController::class, 'edit'])->middleware(['auth', 'password_changed', 'can:update app settings'])->name('app-settings.edit');
+Route::put('/settings/app', [AppSettingsController::class, 'update'])->middleware(['auth', 'password_changed', 'can:update app settings'])->name('app-settings.update');
+```
+
+- [ ] **Step 6: Run the tests, verify they PASS**
+
+Run: `php artisan test --filter=AppSettingsTest`
+Expected: PASS (6 tests). The `Settings/App` Inertia component does not need to exist on disk for these backend tests — `assertInertia` checks the response payload, not a rendered page.
+
+- [ ] **Step 7: Pint and commit**
+
+```bash
+vendor/bin/pint app/Http/Controllers/AppSettingsController.php app/Http/Requests/UpdateAppSettingsRequest.php tests/Feature/AppSettingsTest.php
+git add app/Http/Controllers/AppSettingsController.php app/Http/Requests/UpdateAppSettingsRequest.php tests/Feature/AppSettingsTest.php routes/web.php
+git commit -m "feat: app settings edit/update controller, request, routes"
+```
+
+---
+
+## Task 3: Expose general settings via shared Inertia props
+
+**Files:**
+- Modify: `app/Http/Middleware/HandleInertiaRequests.php`
+- Test: `tests/Feature/AppSettingsTest.php` (append)
+
+- [ ] **Step 1: Add the shared-props test**
+
+Append to `tests/Feature/AppSettingsTest.php`:
+```php
+    public function test_app_settings_are_shared_to_frontend(): void
+    {
+        $admin = \App\Models\User::factory()->create();
+        $admin->givePermissionTo(['view admin settings', 'update app settings']);
+
+        $response = $this->actingAs($admin)->get(route('app-settings.edit'));
+
+        $response->assertInertia(
+            fn (\Inertia\Testing\AssertableInertia $page) => $page
+                ->where('app.org_name', 'HRMIS')
+                ->where('app.pagination_size', 10)
+        );
+    }
+```
+
+- [ ] **Step 2: Run it, verify it FAILS**
+
+Run: `php artisan test --filter=test_app_settings_are_shared_to_frontend`
+Expected: FAIL — `app` prop not present.
+
+- [ ] **Step 3: Add the shared prop**
+
+In `app/Http/Middleware/HandleInertiaRequests.php`, inside the array returned by `share()` (after the `'auth' => [...]` block, alongside `'ziggy'`/`'flash'`), add:
+```php
+            'app' => function () {
+                $general = app(\App\Settings\GeneralSettings::class);
+
+                return [
+                    'org_name' => $general->org_name,
+                    'support_email' => $general->support_email,
+                    'date_format' => $general->date_format,
+                    'pagination_size' => $general->pagination_size,
+                ];
+            },
+```
+
+- [ ] **Step 4: Run it, verify it PASSES**
+
+Run: `php artisan test --filter=AppSettingsTest`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Pint and commit**
+
+```bash
+vendor/bin/pint app/Http/Middleware/HandleInertiaRequests.php
+git add app/Http/Middleware/HandleInertiaRequests.php tests/Feature/AppSettingsTest.php
+git commit -m "feat: share general app settings to the frontend"
+```
+
+---
+
+## Task 4: Settings form page + optional SettingCard count
+
+**Files:**
+- Modify: `resources/js/Components/Settings/SettingCard.vue`
+- Create: `resources/js/Pages/Settings/App.vue`
+
+- [ ] **Step 1: Make `count` optional in `SettingCard.vue`**
+
+In `resources/js/Components/Settings/SettingCard.vue`, change the `count` prop declaration from:
+```js
+	count: { type: [Number, String], required: true },
+```
+to:
+```js
+	count: { type: [Number, String], default: null },
+```
+And in the template, change the count line from:
+```html
+			<p class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+				{{ count }}
+			</p>
+```
+to:
+```html
+			<p
+				v-if="count !== null"
+				class="text-2xl font-bold text-gray-900 dark:text-gray-50"
+			>
+				{{ count }}
+			</p>
+```
+Leave everything else unchanged.
+
+- [ ] **Step 2: Create the settings form page**
+
+Create `resources/js/Pages/Settings/App.vue`:
+```vue
+<script setup>
+import NewAuthenticated from "@/Layouts/NewAuthenticated.vue";
+import { Head, useForm } from "@inertiajs/vue3";
+import BreadCrump from "@/Components/BreadCrump.vue";
+
+const props = defineProps({
+	general: { type: Object, required: true },
+	security: { type: Object, required: true },
+});
+
+const breadcrumbLinks = [
+	{ name: "Home", url: "/dashboard" },
+	{ name: "Settings", url: "/settings" },
+	{ name: "Application", url: null },
+];
+
+const form = useForm({
+	org_name: props.general.org_name,
+	support_email: props.general.support_email,
+	date_format: props.general.date_format,
+	pagination_size: props.general.pagination_size,
+	password_change_interval_days: props.security.password_change_interval_days,
+});
+
+const submit = () => {
+	form.put(route("app-settings.update"), { preserveScroll: true });
+};
+
+const fieldClass =
+	"mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-green-500 focus:ring-green-500 sm:text-sm";
+const labelClass =
+	"block text-sm font-medium text-gray-700 dark:text-gray-200";
+const errorClass = "mt-1 text-xs text-red-600 dark:text-red-400";
+</script>
+
+<template>
+	<Head title="Application settings" />
+	<NewAuthenticated>
+		<main class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-6">
+			<BreadCrump :links="breadcrumbLinks" />
+
+			<div class="mt-4 mb-6">
+				<h1
+					class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+				>
+					Application settings
+				</h1>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Organisation-wide configuration.
+				</p>
+			</div>
+
+			<form class="space-y-6" @submit.prevent="submit">
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Branding
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label class="$labelClass" :class="labelClass">Organization name</label>
+							<input v-model="form.org_name" type="text" :class="fieldClass" />
+							<p v-if="form.errors.org_name" :class="errorClass">
+								{{ form.errors.org_name }}
+							</p>
+						</div>
+						<div>
+							<label :class="labelClass">Support email</label>
+							<input
+								v-model="form.support_email"
+								type="email"
+								:class="fieldClass"
+							/>
+							<p v-if="form.errors.support_email" :class="errorClass">
+								{{ form.errors.support_email }}
+							</p>
+						</div>
+					</div>
+				</section>
+
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Display
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label :class="labelClass">Date format</label>
+							<input v-model="form.date_format" type="text" :class="fieldClass" />
+							<p class="mt-1 text-xs text-gray-400">PHP date format, e.g. d M Y</p>
+							<p v-if="form.errors.date_format" :class="errorClass">
+								{{ form.errors.date_format }}
+							</p>
+						</div>
+						<div>
+							<label :class="labelClass">Records per page</label>
+							<input
+								v-model.number="form.pagination_size"
+								type="number"
+								min="5"
+								max="100"
+								:class="fieldClass"
+							/>
+							<p v-if="form.errors.pagination_size" :class="errorClass">
+								{{ form.errors.pagination_size }}
+							</p>
+						</div>
+					</div>
+				</section>
+
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Security
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label :class="labelClass">Password change interval (days)</label>
+							<input
+								v-model.number="form.password_change_interval_days"
+								type="number"
+								min="0"
+								max="3650"
+								:class="fieldClass"
+							/>
+							<p class="mt-1 text-xs text-gray-400">0 disables forced rotation.</p>
+							<p
+								v-if="form.errors.password_change_interval_days"
+								:class="errorClass"
+							>
+								{{ form.errors.password_change_interval_days }}
+							</p>
+						</div>
+					</div>
+				</section>
+
+				<div class="flex justify-end">
+					<button
+						type="submit"
+						:disabled="form.processing"
+						class="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 disabled:opacity-50 dark:bg-gray-600 dark:hover:bg-gray-500"
+					>
+						Save
+					</button>
+				</div>
+			</form>
+		</main>
+	</NewAuthenticated>
+</template>
+```
+
+> Note: the `<label class="$labelClass" :class="labelClass">` on the first field must be just `<label :class="labelClass">` — remove the literal `class="$labelClass"` if present; only the bound `:class` is needed.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: succeeds. If it fails, report BLOCKED with the error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Components/Settings/SettingCard.vue resources/js/Pages/Settings/App.vue
+git commit -m "feat: application settings form page"
+```
+
+---
+
+## Task 5: Hub card + org-name branding
+
+**Files:**
+- Modify: `resources/js/Pages/Settings/Index.vue`
+- Modify: `resources/js/Layouts/NewAuthenticated.vue`
+
+- [ ] **Step 1: Add the Application card to the hub**
+
+In `resources/js/Pages/Settings/Index.vue`, add `Cog6ToothIcon` to the Heroicons import:
+```js
+import {
+	UsersIcon,
+	ShieldCheckIcon,
+	KeyIcon,
+	ClipboardDocumentListIcon,
+	BuildingOffice2Icon,
+	Cog6ToothIcon,
+} from "@heroicons/vue/24/outline";
+```
+Then, inside the `cards` computed array (before the final `].filter(...)`), add this entry after the Institutions entry:
+```js
+		{
+			title: "Application",
+			count: null,
+			secondary: "Name, email, display, security",
+			href: route("app-settings.edit"),
+			linkLabel: "Configure",
+			icon: Cog6ToothIcon,
+			gate: "update app settings",
+		},
+```
+
+- [ ] **Step 2: Show the org name in the layout**
+
+In `resources/js/Layouts/NewAuthenticated.vue`, replace the hardcoded desktop sidebar heading:
+```html
+						<h2
+							class="font-semibold text-xl text-gray-800 leading-tight dark:text-gray-50"
+						>
+							Audit Service
+						</h2>
+```
+with:
+```html
+						<h2
+							class="font-semibold text-xl text-gray-800 leading-tight dark:text-gray-50"
+						>
+							{{ $page.props.app?.org_name ?? "HRMIS" }}
+						</h2>
+```
+(`$page` is globally available in Inertia templates — no import needed.)
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Pages/Settings/Index.vue resources/js/Layouts/NewAuthenticated.vue
+git commit -m "feat: settings hub application card and org-name branding"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the settings tests**
+
+Run: `php artisan test --filter="AppSettingsTest|SettingsControllerTest"`
+Expected: PASS.
+
+- [ ] **Step 2: Broader test sweep (the seeder + shared-props changes are app-wide)**
+
+Run: `php -d memory_limit=512M artisan test --filter="Settings|Permission|Role|Dashboard|Inertia|Shared"`
+Expected: PASS. (The full suite OOMs at the default 128MB during bootstrap — a pre-existing env issue; 512M avoids it.)
+
+- [ ] **Step 3: Pint**
+
+Run: `vendor/bin/pint --dirty`
+Expected: no errors. Do not stage unrelated pre-existing PHP files it may touch.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: succeeds.
+
+- [ ] **Step 5: Manual smoke check (ask the user to run)**
+
+With `npm run dev`, as an admin with `update app settings`:
+- Settings hub shows an "Application" card → `/settings/app`.
+- The form shows Branding / Display / Security sections with current values; saving persists and flashes success; invalid input shows field errors.
+- The sidebar shows the configured org name (default "HRMIS").
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- spatie/laravel-settings install + `settings` table → Task 1 Steps 1-2. ✓
+- `GeneralSettings` + `SecuritySettings` classes, registered, with defaults migration → Task 1 Steps 3-5. ✓
+- `update app settings` permission seeded → Task 1 Step 6. ✓
+- Routes `app-settings.edit`/`update` gated on `update app settings` → Task 2 Step 5. ✓
+- `AppSettingsController` edit/update + `UpdateAppSettingsRequest` validation → Task 2. ✓
+- Shared `app` prop (general settings) → Task 3. ✓
+- `Settings/App.vue` grouped form (Branding/Display/Security) via `useForm` → Task 4. ✓
+- Hub "Application" card + optional `SettingCard` count → Task 4 Step 1 + Task 5 Step 1. ✓
+- org-name branding in layout → Task 5 Step 2. ✓
+- Tests (defaults, view, update, validation, authz, shared props) → Tasks 1-3, 6. ✓
+- Password-interval enforcement deferred (stored only, no middleware change) → honored (no task touches `PasswordChanged`). ✓
+
+**Placeholder scan:** No TBD/TODO; all code shown. The one prose caveat (stray `class="$labelClass"`) is an explicit correction instruction, not a placeholder. ✓
+
+**Type/name consistency:** Settings property names (`org_name`, `support_email`, `date_format`, `pagination_size`, `password_change_interval_days`) are identical across the classes (Task 1), migration (Task 1), controller payload (Task 2), Form Request rules (Task 2), `useForm` fields (Task 4), and tests (Tasks 1-3). Route names `app-settings.edit`/`app-settings.update` consistent across Task 2, Task 4, Task 5. Shared prop key `app.org_name` consistent across Task 3 and Task 5. ✓
+
+**Out of scope:** 2b pagination retrofit, 2c date-format retrofit, password-interval enforcement — all deferred.

--- a/docs/superpowers/specs/2026-06-02-app-settings-store-design.md
+++ b/docs/superpowers/specs/2026-06-02-app-settings-store-design.md
@@ -1,0 +1,74 @@
+# App Settings Store — Cycle 2a Design
+
+**Date:** 2026-06-02
+**Status:** Approved for planning
+**Cycle:** 2a of the app-settings effort. Follow-ups: 2b (pagination retrofit), 2c (date-format retrofit), and password-interval enforcement (deferred — see "Out of scope").
+
+## Goal
+
+Add a persisted application-settings store with an admin management page, building on the settings hub from Cycle 1. This cycle delivers the store, the admin UI, seeded defaults, and the cheap/safe wiring (exposing settings to the frontend + showing the org name in branding). It **defines and exposes** `date_format` and `pagination_size` so the later retrofits (2b/2c) are pure consumption. Password-interval enforcement is intentionally deferred — the value is stored and editable, but not yet enforced.
+
+## Storage — spatie/laravel-settings
+
+The user approved adding the `spatie/laravel-settings` Composer dependency (CLAUDE.md requires approval for new deps; given here).
+
+- `composer require spatie/laravel-settings`; publish its config (`config/settings.php`) and the migration that creates the `settings` table.
+- Two settings classes (one per concern):
+  - **`app/Settings/GeneralSettings.php`** — group `general`:
+    - `org_name` (string)
+    - `support_email` (?string)
+    - `date_format` (string)
+    - `pagination_size` (int)
+  - **`app/Settings/SecuritySettings.php`** — group `security`:
+    - `password_change_interval_days` (int)
+- Register both classes in `config/settings.php` under `settings => [...]`.
+- A spatie settings migration `database/settings/2026_06_02_000000_create_app_settings.php` (extends `Spatie\LaravelSettings\Migrations\SettingsMigration`) seeds defaults:
+  - `general.org_name = 'HRMIS'`
+  - `general.support_email = null`
+  - `general.date_format = 'd M Y'`
+  - `general.pagination_size = 10`
+  - `security.password_change_interval_days = 90`
+- These migrations run via `php artisan migrate`, so `RefreshDatabase` seeds them in tests.
+
+## Admin Page
+
+- **Permission:** new `update app settings`, added to `AllPermissionsSeeder` (assigned to super-administrator via its existing `syncPermissions`). Gates both the page and the save.
+- **Routes** (mirroring the existing `settings.index` middleware style):
+  - `GET /settings/app` → `AppSettingsController@edit`, name `app-settings.edit`
+  - `PUT /settings/app` → `AppSettingsController@update`, name `app-settings.update`
+  - both behind `auth`, `password_changed`, `can:update app settings`.
+- **`AppSettingsController`** injects both settings classes:
+  - `edit(GeneralSettings $general, SecuritySettings $security)` → `Inertia::render('Settings/App', [...current values...])`.
+  - `update(UpdateAppSettingsRequest $request, GeneralSettings $general, SecuritySettings $security)` → assign validated values to each object, `$general->save()` / `$security->save()`, redirect back with success.
+- **`UpdateAppSettingsRequest`** validation:
+  - `org_name` — required, string, max:255
+  - `support_email` — nullable, email, max:255
+  - `date_format` — required, string, max:50
+  - `pagination_size` — required, integer, min:5, max:100
+  - `password_change_interval_days` — required, integer, min:0, max:3650 (0 = disabled, for the future enforcement step)
+- **`resources/js/Pages/Settings/App.vue`** — green-clean form using Inertia `useForm`, organized into visual sections **Branding** (org_name, support_email), **Display** (date_format, pagination_size), **Security** (password_change_interval_days). Per-field validation errors and a Save button. Breadcrumb: Home / Settings / Application.
+
+## Hub Integration
+
+- Add an **"Application settings"** card to `Settings/Index.vue`, gated on `update app settings`, linking to `route('app-settings.edit')`. It is not a count card, so make `SettingCard`'s `count` prop optional (null → number hidden); the card shows title + a "Configure →" link with a secondary line ("Name, email, display, security").
+
+## Wiring Into Behavior (this cycle)
+
+- **Shared props:** add an `app` key in `HandleInertiaRequests::share()` exposing the **general** settings only — `org_name`, `support_email`, `date_format`, `pagination_size` (resolved from `GeneralSettings`; spatie caches settings so this is cheap). Frontend can read `$page.props.app.*`. (Security settings are not exposed to the frontend.)
+- **Branding:** display `org_name` text beside the logo in `resources/js/Layouts/NewAuthenticated.vue`, sourced from `$page.props.app.org_name`. (Today only an SVG logo shows; this adds the name.)
+
+## Testing
+
+- `tests/Feature/AppSettingsTest.php`:
+  - An admin with `update app settings` gets `Settings/App` with the current general + security values.
+  - A valid `PUT` persists new values (re-resolve `GeneralSettings`/`SecuritySettings` and assert) and redirects with success.
+  - Validation rejects a bad `support_email` and an out-of-range `pagination_size`.
+  - A user **without** `update app settings` is forbidden (403) on both `edit` and `update`.
+- Shared-props coverage: a test (or assertion) that an authenticated page exposes `app.org_name` reflecting the stored value.
+- No middleware/enforcement test this cycle (enforcement deferred).
+
+## Out of Scope (follow-ups)
+
+- **Password-interval enforcement** — wiring `password_change_interval_days` into the `PasswordChanged` middleware (and adding a `password_change_at` datetime cast to `User`). Deferred; the value is stored and editable now.
+- **2b — pagination retrofit:** replace the 44 hardcoded `paginate(N)` sites across 26 controllers with `pagination_size`. Its own spec/plan.
+- **2c — date-format retrofit:** replace the ~180 hardcoded date-format sites (backend `->format()` + frontend) with `date_format`. Its own spec/plan.

--- a/resources/js/Components/Settings/SettingCard.vue
+++ b/resources/js/Components/Settings/SettingCard.vue
@@ -4,7 +4,7 @@ import { ChevronRightIcon } from "@heroicons/vue/16/solid";
 
 defineProps({
 	title: { type: String, required: true },
-	count: { type: [Number, String], required: true },
+	count: { type: [Number, String], default: null },
 	secondary: { type: String, default: null },
 	href: { type: String, required: true },
 	linkLabel: { type: String, default: "Manage" },
@@ -28,7 +28,10 @@ defineProps({
 			/>
 		</div>
 		<div class="mt-4">
-			<p class="text-2xl font-bold text-gray-900 dark:text-gray-50">
+			<p
+				v-if="count !== null"
+				class="text-2xl font-bold text-gray-900 dark:text-gray-50"
+			>
 				{{ count }}
 			</p>
 			<p class="text-sm font-semibold text-gray-700 dark:text-gray-200">

--- a/resources/js/Layouts/NewAuthenticated.vue
+++ b/resources/js/Layouts/NewAuthenticated.vue
@@ -270,7 +270,7 @@ const closeAlert = (index) => {
 						<h2
 							class="font-semibold text-xl text-gray-800 leading-tight dark:text-gray-50"
 						>
-							Audit Service
+							{{ $page.props.app?.org_name ?? "HRMIS" }}
 						</h2>
 					</div>
 				</Link>

--- a/resources/js/Pages/Settings/App.vue
+++ b/resources/js/Pages/Settings/App.vue
@@ -1,0 +1,161 @@
+<script setup>
+import NewAuthenticated from "@/Layouts/NewAuthenticated.vue";
+import { Head, useForm } from "@inertiajs/vue3";
+import BreadCrump from "@/Components/BreadCrump.vue";
+
+const props = defineProps({
+	general: { type: Object, required: true },
+	security: { type: Object, required: true },
+});
+
+const breadcrumbLinks = [
+	{ name: "Home", url: "/dashboard" },
+	{ name: "Settings", url: "/settings" },
+	{ name: "Application", url: null },
+];
+
+const form = useForm({
+	org_name: props.general.org_name,
+	support_email: props.general.support_email,
+	date_format: props.general.date_format,
+	pagination_size: props.general.pagination_size,
+	password_change_interval_days: props.security.password_change_interval_days,
+});
+
+function submit() {
+	form.put(route("app-settings.update"), { preserveScroll: true });
+}
+</script>
+
+<template>
+	<Head title="Application Settings" />
+	<NewAuthenticated>
+		<main class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-6">
+			<BreadCrump :links="breadcrumbLinks" />
+
+			<div class="mt-4">
+				<h1
+					class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
+				>
+					Application Settings
+				</h1>
+				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+					Manage general and security configuration for the application.
+				</p>
+			</div>
+
+			<form @submit.prevent="submit" class="mt-6 space-y-6">
+				<div class="space-y-4">
+					<div>
+						<label
+							for="org_name"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+						>
+							Organisation name
+						</label>
+						<input
+							id="org_name"
+							v-model="form.org_name"
+							type="text"
+							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+						/>
+						<p v-if="form.errors.org_name" class="mt-1 text-sm text-red-600">
+							{{ form.errors.org_name }}
+						</p>
+					</div>
+
+					<div>
+						<label
+							for="support_email"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+						>
+							Support email
+						</label>
+						<input
+							id="support_email"
+							v-model="form.support_email"
+							type="email"
+							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+						/>
+						<p
+							v-if="form.errors.support_email"
+							class="mt-1 text-sm text-red-600"
+						>
+							{{ form.errors.support_email }}
+						</p>
+					</div>
+
+					<div>
+						<label
+							for="date_format"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+						>
+							Date format
+						</label>
+						<input
+							id="date_format"
+							v-model="form.date_format"
+							type="text"
+							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+						/>
+						<p v-if="form.errors.date_format" class="mt-1 text-sm text-red-600">
+							{{ form.errors.date_format }}
+						</p>
+					</div>
+
+					<div>
+						<label
+							for="pagination_size"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+						>
+							Pagination size
+						</label>
+						<input
+							id="pagination_size"
+							v-model.number="form.pagination_size"
+							type="number"
+							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+						/>
+						<p
+							v-if="form.errors.pagination_size"
+							class="mt-1 text-sm text-red-600"
+						>
+							{{ form.errors.pagination_size }}
+						</p>
+					</div>
+
+					<div>
+						<label
+							for="password_change_interval_days"
+							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+						>
+							Password change interval (days)
+						</label>
+						<input
+							id="password_change_interval_days"
+							v-model.number="form.password_change_interval_days"
+							type="number"
+							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+						/>
+						<p
+							v-if="form.errors.password_change_interval_days"
+							class="mt-1 text-sm text-red-600"
+						>
+							{{ form.errors.password_change_interval_days }}
+						</p>
+					</div>
+				</div>
+
+				<div class="flex justify-end">
+					<button
+						type="submit"
+						:disabled="form.processing"
+						class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+					>
+						Save changes
+					</button>
+				</div>
+			</form>
+		</main>
+	</NewAuthenticated>
+</template>

--- a/resources/js/Pages/Settings/App.vue
+++ b/resources/js/Pages/Settings/App.vue
@@ -59,7 +59,12 @@ const errorClass = "mt-1 text-xs text-red-600 dark:text-red-400";
 					<div class="mt-4 space-y-4">
 						<div>
 							<label :class="labelClass">Organization name</label>
-							<input v-model="form.org_name" type="text" :class="fieldClass" />
+							<input
+								v-model="form.org_name"
+								type="text"
+								dusk="org_name"
+								:class="fieldClass"
+							/>
 							<p v-if="form.errors.org_name" :class="errorClass">
 								{{ form.errors.org_name }}
 							</p>
@@ -100,6 +105,7 @@ const errorClass = "mt-1 text-xs text-red-600 dark:text-red-400";
 								type="number"
 								min="5"
 								max="100"
+								dusk="pagination_size"
 								:class="fieldClass"
 							/>
 							<p v-if="form.errors.pagination_size" :class="errorClass">
@@ -139,6 +145,7 @@ const errorClass = "mt-1 text-xs text-red-600 dark:text-red-400";
 				<div class="flex justify-end">
 					<button
 						type="submit"
+						dusk="save"
 						:disabled="form.processing"
 						class="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 disabled:opacity-50 dark:bg-gray-600 dark:hover:bg-gray-500"
 					>

--- a/resources/js/Pages/Settings/App.vue
+++ b/resources/js/Pages/Settings/App.vue
@@ -22,137 +22,127 @@ const form = useForm({
 	password_change_interval_days: props.security.password_change_interval_days,
 });
 
-function submit() {
+const submit = () => {
 	form.put(route("app-settings.update"), { preserveScroll: true });
-}
+};
+
+const fieldClass =
+	"mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-green-500 focus:ring-green-500 sm:text-sm";
+const labelClass = "block text-sm font-medium text-gray-700 dark:text-gray-200";
+const errorClass = "mt-1 text-xs text-red-600 dark:text-red-400";
 </script>
 
 <template>
-	<Head title="Application Settings" />
+	<Head title="Application settings" />
 	<NewAuthenticated>
 		<main class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 py-6">
 			<BreadCrump :links="breadcrumbLinks" />
 
-			<div class="mt-4">
+			<div class="mt-4 mb-6">
 				<h1
 					class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-50"
 				>
-					Application Settings
+					Application settings
 				</h1>
 				<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-					Manage general and security configuration for the application.
+					Organisation-wide configuration.
 				</p>
 			</div>
 
-			<form @submit.prevent="submit" class="mt-6 space-y-6">
-				<div class="space-y-4">
-					<div>
-						<label
-							for="org_name"
-							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-						>
-							Organisation name
-						</label>
-						<input
-							id="org_name"
-							v-model="form.org_name"
-							type="text"
-							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
-						/>
-						<p v-if="form.errors.org_name" class="mt-1 text-sm text-red-600">
-							{{ form.errors.org_name }}
-						</p>
+			<form class="space-y-6" @submit.prevent="submit">
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Branding
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label :class="labelClass">Organization name</label>
+							<input v-model="form.org_name" type="text" :class="fieldClass" />
+							<p v-if="form.errors.org_name" :class="errorClass">
+								{{ form.errors.org_name }}
+							</p>
+						</div>
+						<div>
+							<label :class="labelClass">Support email</label>
+							<input
+								v-model="form.support_email"
+								type="email"
+								:class="fieldClass"
+							/>
+							<p v-if="form.errors.support_email" :class="errorClass">
+								{{ form.errors.support_email }}
+							</p>
+						</div>
 					</div>
+				</section>
 
-					<div>
-						<label
-							for="support_email"
-							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-						>
-							Support email
-						</label>
-						<input
-							id="support_email"
-							v-model="form.support_email"
-							type="email"
-							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
-						/>
-						<p
-							v-if="form.errors.support_email"
-							class="mt-1 text-sm text-red-600"
-						>
-							{{ form.errors.support_email }}
-						</p>
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Display
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label :class="labelClass">Date format</label>
+							<input v-model="form.date_format" type="text" :class="fieldClass" />
+							<p class="mt-1 text-xs text-gray-400">PHP date format, e.g. d M Y</p>
+							<p v-if="form.errors.date_format" :class="errorClass">
+								{{ form.errors.date_format }}
+							</p>
+						</div>
+						<div>
+							<label :class="labelClass">Records per page</label>
+							<input
+								v-model.number="form.pagination_size"
+								type="number"
+								min="5"
+								max="100"
+								:class="fieldClass"
+							/>
+							<p v-if="form.errors.pagination_size" :class="errorClass">
+								{{ form.errors.pagination_size }}
+							</p>
+						</div>
 					</div>
+				</section>
 
-					<div>
-						<label
-							for="date_format"
-							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-						>
-							Date format
-						</label>
-						<input
-							id="date_format"
-							v-model="form.date_format"
-							type="text"
-							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
-						/>
-						<p v-if="form.errors.date_format" class="mt-1 text-sm text-red-600">
-							{{ form.errors.date_format }}
-						</p>
+				<section
+					class="rounded-2xl border border-green-200/60 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm p-5"
+				>
+					<h2 class="text-sm font-semibold text-green-900 dark:text-gray-100">
+						Security
+					</h2>
+					<div class="mt-4 space-y-4">
+						<div>
+							<label :class="labelClass">Password change interval (days)</label>
+							<input
+								v-model.number="form.password_change_interval_days"
+								type="number"
+								min="0"
+								max="3650"
+								:class="fieldClass"
+							/>
+							<p class="mt-1 text-xs text-gray-400">0 disables forced rotation.</p>
+							<p
+								v-if="form.errors.password_change_interval_days"
+								:class="errorClass"
+							>
+								{{ form.errors.password_change_interval_days }}
+							</p>
+						</div>
 					</div>
-
-					<div>
-						<label
-							for="pagination_size"
-							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-						>
-							Pagination size
-						</label>
-						<input
-							id="pagination_size"
-							v-model.number="form.pagination_size"
-							type="number"
-							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
-						/>
-						<p
-							v-if="form.errors.pagination_size"
-							class="mt-1 text-sm text-red-600"
-						>
-							{{ form.errors.pagination_size }}
-						</p>
-					</div>
-
-					<div>
-						<label
-							for="password_change_interval_days"
-							class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-						>
-							Password change interval (days)
-						</label>
-						<input
-							id="password_change_interval_days"
-							v-model.number="form.password_change_interval_days"
-							type="number"
-							class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
-						/>
-						<p
-							v-if="form.errors.password_change_interval_days"
-							class="mt-1 text-sm text-red-600"
-						>
-							{{ form.errors.password_change_interval_days }}
-						</p>
-					</div>
-				</div>
+				</section>
 
 				<div class="flex justify-end">
 					<button
 						type="submit"
 						:disabled="form.processing"
-						class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+						class="rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 disabled:opacity-50 dark:bg-gray-600 dark:hover:bg-gray-500"
 					>
-						Save changes
+						Save
 					</button>
 				</div>
 			</form>

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -11,6 +11,7 @@ import {
 	KeyIcon,
 	ClipboardDocumentListIcon,
 	BuildingOffice2Icon,
+	Cog6ToothIcon,
 } from "@heroicons/vue/24/outline";
 
 const props = defineProps({
@@ -69,6 +70,15 @@ const cards = computed(() =>
 			linkLabel: "Manage",
 			icon: BuildingOffice2Icon,
 			gate: "view admin settings",
+		},
+		{
+			title: "Application",
+			count: null,
+			secondary: "Name, email, display, security",
+			href: route("app-settings.edit"),
+			linkLabel: "Configure",
+			icon: Cog6ToothIcon,
+			gate: "update app settings",
 		},
 	].filter((card) => can(card.gate)),
 );

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Enums\EmployeeStatusEnum;
 use App\Enums\NoteTypeEnum;
 use App\Enums\StaffTypeEnum;
 use App\Http\Controllers\AgeController;
+use App\Http\Controllers\AppSettingsController;
 use App\Http\Controllers\AuditLogController;
 use App\Http\Controllers\Auth\ChangePasswordController;
 use App\Http\Controllers\CategoryRanksController;
@@ -592,6 +593,8 @@ Route::controller(PositionController::class)->middleware(['auth', 'password_chan
 Route::get('staff-list', StaffListController::class)->middleware(['auth'])->name('staff-list');
 // Route::get('/test', [AgeController::class, 'staffAgeDistribution']);
 Route::get('/settings', SettingsController::class)->middleware(['auth', 'password_changed'])->name('settings.index');
+Route::get('/settings/app', [AppSettingsController::class, 'edit'])->middleware(['auth', 'password_changed', 'can:update app settings'])->name('app-settings.edit');
+Route::put('/settings/app', [AppSettingsController::class, 'update'])->middleware(['auth', 'password_changed', 'can:update app settings'])->name('app-settings.update');
 Route::get('/help', [HelpController::class, 'index'])->middleware(['auth', 'password_changed'])->name('help.index');
 
 Route::post('/role', [RoleController::class, 'store'])->middleware(['auth', 'password_changed', 'can:create role'])->name('role.store');

--- a/tests/Browser/AppSettingsTest.php
+++ b/tests/Browser/AppSettingsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use App\Settings\GeneralSettings;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class AppSettingsTest extends DuskTestCase
+{
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::where('email', 'richard.brobbey@audit.gov.gh')->firstOrFail();
+    }
+
+    public function test_app_settings_frontend_flow(): void
+    {
+        $original = app(GeneralSettings::class)->org_name;
+
+        try {
+            $this->browse(function (Browser $browser) {
+                // 1. Settings hub shows the Application card
+                $browser->loginAs($this->admin)
+                    ->visit('/settings')
+                    ->waitForText('Settings')
+                    ->assertSee('Application')
+                    ->screenshot('app-settings-1-hub');
+
+                // 2. App settings form renders with sections + the current org name
+                $browser->visit('/settings/app')
+                    ->waitForText('Application settings')
+                    ->assertSee('Branding')
+                    ->assertSee('Display')
+                    ->assertSee('Security')
+                    ->assertInputValue('@org_name', 'HRMIS')
+                    ->screenshot('app-settings-2-form');
+
+                // 3. Edit + save persists, and the sidebar branding updates
+                $browser->clear('@org_name')
+                    ->type('@org_name', 'HRMIS QA')
+                    ->clear('@pagination_size')
+                    ->type('@pagination_size', '25')
+                    ->click('@save')
+                    ->waitForText('HRMIS QA')
+                    ->assertInputValue('@org_name', 'HRMIS QA')
+                    ->screenshot('app-settings-3-saved');
+
+                // 4. Validation error surfaces on invalid input.
+                // Use keyboard select-all + delete so Vue's v-model picks up
+                // the change (Dusk clear() does not fire the input event).
+                $browser->click('@org_name')
+                    ->keys('@org_name', ['{control}', 'a'], '{delete}')
+                    ->click('@save')
+                    ->waitForText('required')
+                    ->screenshot('app-settings-4-validation');
+            });
+        } finally {
+            // Restore the original org name so the dev DB is left unchanged.
+            $settings = app(GeneralSettings::class);
+            $settings->org_name = $original;
+            $settings->save();
+        }
+    }
+}

--- a/tests/Feature/AppSettingsTest.php
+++ b/tests/Feature/AppSettingsTest.php
@@ -116,4 +116,18 @@ class AppSettingsTest extends TestCase
         $this->actingAs($user)->get(route('app-settings.edit'))->assertForbidden();
         $this->actingAs($user)->put(route('app-settings.update'), [])->assertForbidden();
     }
+
+    public function test_app_settings_are_shared_to_frontend(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->get(route('app-settings.edit'));
+
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->where('app.org_name', 'HRMIS')
+                ->where('app.pagination_size', 10)
+        );
+    }
 }

--- a/tests/Feature/AppSettingsTest.php
+++ b/tests/Feature/AppSettingsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Settings\GeneralSettings;
+use App\Settings\SecuritySettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class AppSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_settings_have_seeded_defaults(): void
+    {
+        $general = app(GeneralSettings::class);
+        $security = app(SecuritySettings::class);
+
+        $this->assertSame('HRMIS', $general->org_name);
+        $this->assertNull($general->support_email);
+        $this->assertSame('d M Y', $general->date_format);
+        $this->assertSame(10, $general->pagination_size);
+        $this->assertSame(90, $security->password_change_interval_days);
+    }
+
+    public function test_update_app_settings_permission_is_seeded(): void
+    {
+        $this->assertTrue(
+            Permission::where('name', 'update app settings')->exists(),
+            "Permission 'update app settings' should be seeded"
+        );
+    }
+}

--- a/tests/Feature/AppSettingsTest.php
+++ b/tests/Feature/AppSettingsTest.php
@@ -67,11 +67,14 @@ class AppSettingsTest extends TestCase
         $response->assertRedirect(route('app-settings.edit'));
         $response->assertSessionHas('success');
 
-        $this->assertSame('New Org', app(\App\Settings\GeneralSettings::class)->org_name);
-        $this->assertSame('help@example.com', app(\App\Settings\GeneralSettings::class)->support_email);
-        $this->assertSame('Y-m-d', app(\App\Settings\GeneralSettings::class)->date_format);
-        $this->assertSame(25, app(\App\Settings\GeneralSettings::class)->pagination_size);
-        $this->assertSame(30, app(\App\Settings\SecuritySettings::class)->password_change_interval_days);
+        $general = app(GeneralSettings::class);
+        $security = app(SecuritySettings::class);
+
+        $this->assertSame('New Org', $general->org_name);
+        $this->assertSame('help@example.com', $general->support_email);
+        $this->assertSame('Y-m-d', $general->date_format);
+        $this->assertSame(25, $general->pagination_size);
+        $this->assertSame(30, $security->password_change_interval_days);
     }
 
     public function test_update_accepts_null_support_email(): void
@@ -129,5 +132,22 @@ class AppSettingsTest extends TestCase
                 ->where('app.org_name', 'HRMIS')
                 ->where('app.pagination_size', 10)
         );
+    }
+
+    public function test_guest_pages_do_not_crash_when_settings_rows_are_missing(): void
+    {
+        // Simulate a database where the settings data migration has not run
+        // (its rows are absent). The shared-props middleware resolves
+        // GeneralSettings on every Inertia response, including the guest
+        // login page, so the settings classes must fall back to their PHP
+        // defaults rather than throwing MissingSettings.
+        \Illuminate\Support\Facades\DB::table('settings')->delete();
+        app()->forgetInstance(GeneralSettings::class);
+        app()->forgetInstance(SecuritySettings::class);
+
+        $response = $this->get(route('login'));
+
+        $response->assertOk();
+        $this->assertSame('HRMIS', app(GeneralSettings::class)->org_name);
     }
 }

--- a/tests/Feature/AppSettingsTest.php
+++ b/tests/Feature/AppSettingsTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
 use App\Settings\GeneralSettings;
 use App\Settings\SecuritySettings;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
 use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
 
@@ -30,5 +32,71 @@ class AppSettingsTest extends TestCase
             Permission::where('name', 'update app settings')->exists(),
             "Permission 'update app settings' should be seeded"
         );
+    }
+
+    public function test_admin_can_view_app_settings_page(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->get(route('app-settings.edit'));
+
+        $response->assertOk();
+        $response->assertInertia(
+            fn (Assert $page) => $page
+                ->component('Settings/App')
+                ->where('general.org_name', 'HRMIS')
+                ->where('general.pagination_size', 10)
+                ->where('security.password_change_interval_days', 90)
+        );
+    }
+
+    public function test_admin_can_update_app_settings(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->put(route('app-settings.update'), [
+            'org_name' => 'New Org',
+            'support_email' => 'help@example.com',
+            'date_format' => 'Y-m-d',
+            'pagination_size' => 25,
+            'password_change_interval_days' => 30,
+        ]);
+
+        $response->assertRedirect(route('app-settings.edit'));
+        $response->assertSessionHas('success');
+
+        $this->assertSame('New Org', app(\App\Settings\GeneralSettings::class)->org_name);
+        $this->assertSame('help@example.com', app(\App\Settings\GeneralSettings::class)->support_email);
+        $this->assertSame('Y-m-d', app(\App\Settings\GeneralSettings::class)->date_format);
+        $this->assertSame(25, app(\App\Settings\GeneralSettings::class)->pagination_size);
+        $this->assertSame(30, app(\App\Settings\SecuritySettings::class)->password_change_interval_days);
+    }
+
+    public function test_update_rejects_invalid_input(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)
+            ->from(route('app-settings.edit'))
+            ->put(route('app-settings.update'), [
+                'org_name' => '',
+                'support_email' => 'not-an-email',
+                'date_format' => 'd M Y',
+                'pagination_size' => 9999,
+                'password_change_interval_days' => 30,
+            ]);
+
+        $response->assertSessionHasErrors(['org_name', 'support_email', 'pagination_size']);
+    }
+
+    public function test_app_settings_require_permission(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->get(route('app-settings.edit'))->assertForbidden();
+        $this->actingAs($user)->put(route('app-settings.update'), [])->assertForbidden();
     }
 }

--- a/tests/Feature/AppSettingsTest.php
+++ b/tests/Feature/AppSettingsTest.php
@@ -74,6 +74,23 @@ class AppSettingsTest extends TestCase
         $this->assertSame(30, app(\App\Settings\SecuritySettings::class)->password_change_interval_days);
     }
 
+    public function test_update_accepts_null_support_email(): void
+    {
+        $admin = User::factory()->create();
+        $admin->givePermissionTo('update app settings');
+
+        $response = $this->actingAs($admin)->put(route('app-settings.update'), [
+            'org_name' => 'New Org',
+            'support_email' => null,
+            'date_format' => 'Y-m-d',
+            'pagination_size' => 25,
+            'password_change_interval_days' => 30,
+        ]);
+
+        $response->assertRedirect(route('app-settings.edit'));
+        $this->assertNull(app(\App\Settings\GeneralSettings::class)->support_email);
+    }
+
     public function test_update_rejects_invalid_input(): void
     {
         $admin = User::factory()->create();


### PR DESCRIPTION
## Summary

Adds a persisted application-settings store (via the new `spatie/laravel-settings` dependency) with a gated admin page, building on the settings hub from Cycle 1.

- **Store:** `GeneralSettings` (org_name, support_email, date_format, pagination_size) and `SecuritySettings` (password_change_interval_days), with a settings-data migration seeding defaults. Classes carry PHP defaults so missing rows fall back gracefully.
- **Admin page:** `/settings/app` (`AppSettingsController` edit/update + `UpdateAppSettingsRequest`), a green-clean grouped form (Branding / Display / Security) via Inertia `useForm`. Gated on a new `update app settings` permission (seeded + assigned to super-admin).
- **Hub + branding:** an "Application" card on the settings hub; the org name now shows in the sidebar (replacing the hardcoded "Audit Service").
- **Shared props:** general settings exposed via `$page.props.app.*` for app-wide use.

### Deferred (by design)
- **Password-interval enforcement** — the value is stored/editable but not yet wired into the `PasswordChanged` middleware.
- **2b** pagination retrofit and **2c** date-format retrofit (replacing the ~44 hardcoded `paginate(N)` and ~180 date-format sites with these settings) are their own follow-up cycles. `pagination_size`/`date_format` are stored + exposed now so those become pure consumption.

### Code review
Ran an automated review of the branch. The one real bug it surfaced is fixed here: the eager `app` shared prop resolved `GeneralSettings` on every Inertia response (incl. guest `/login`), so a missing settings-data migration would have 500'd the whole app — fixed by adding PHP defaults to the settings classes, with a regression test (login page must not crash when settings rows are absent; verified it fails without the fix).

## Test Plan
- [x] `php artisan test --filter="AppSettingsTest|SettingsControllerTest"` — 11 passed
- [x] `php -d memory_limit=512M artisan test --filter="Settings|Permission|Role|Dashboard|Associate|UserShow"` — 133 passed (no regressions from the new dep/shared prop)
- [x] `vendor/bin/pint` — clean; `npm run build` — clean
- [ ] Deploy note: run `php artisan migrate` so the settings-data migration seeds (defaults now prevent a hard crash if skipped)
- [ ] Manual: open `/settings/app` as an admin — grouped form saves & validates; the "Application" hub card and sidebar org name render

🤖 Generated with [Claude Code](https://claude.com/claude-code)