### PR TITLE
Date-format retrofit — frontend (Cycle 2c-2)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-date-format-retrofit-frontend.md
+++ b/docs/superpowers/plans/2026-06-03-date-format-retrofit-frontend.md
@@ -1,0 +1,328 @@
+# Date-Format Retrofit — Frontend (Cycle 2c-2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make frontend display dates follow the configured `date_format` setting by translating the PHP format to date-fns in JS (`phpToDateFns`) and applying it via a `useDateFormat()` composable, retrofitting the ~19 date-fns display sites + 5 `toLocaleDateString` DOB sites.
+
+**Architecture:** A pure `phpToDateFns()` translator (own file, node-checkable) + a `useDateFormat()` composable reading the `app.date_format` shared prop. Each display component swaps its local date formatter for the composable's `formatDate()`. Functional `yyyy-MM-dd` inputs and number `toLocaleString` are left alone.
+
+**Tech Stack:** Vue 3 `<script setup>`, Inertia v1, date-fns ^3.6, Laravel Dusk (browser test).
+
+**Testing note:** No JS test runner exists. The risky pure translator is sanity-checked via `node` (not a committed test). Components are build-verified (`npm run build`). End-to-end behavior is verified by a Dusk browser test. The full PHPUnit suite (unaffected by frontend changes) is confirmed green in the Sail container.
+
+**Branch:** `feature/date-format-frontend` (created; design committed there).
+
+**Default-behavior note:** default `date_format='d M Y'` → date-fns `dd MMM yyyy`, so display dates change from `dd MMMM, yyyy` (e.g. `28 June, 2024`) to `28 Jun 2024` by default — unifying with the merged backend (2c-1).
+
+---
+
+## File Structure
+
+- Create: `resources/js/composables/phpToDateFns.js` — pure translator (no imports; node-checkable).
+- Create: `resources/js/composables/useDateFormat.js` — composable (imports the translator + date-fns + Inertia).
+- Modify: 19 components using date-fns display `format(...)` + 5 using `toLocaleDateString` DOB.
+- Create: `tests/Browser/DateFormatTest.php` — Dusk verification.
+
+---
+
+## Task 1: The translator + composable
+
+**Files:**
+- Create: `resources/js/composables/phpToDateFns.js`
+- Create: `resources/js/composables/useDateFormat.js`
+
+- [ ] **Step 1: Create the pure translator** `resources/js/composables/phpToDateFns.js`:
+
+```js
+const PHP_TO_DATE_FNS = {
+	d: "dd",
+	j: "d",
+	D: "EEE",
+	l: "EEEE",
+	m: "MM",
+	n: "M",
+	M: "MMM",
+	F: "MMMM",
+	y: "yy",
+	Y: "yyyy",
+	H: "HH",
+	G: "H",
+	h: "hh",
+	g: "h",
+	i: "mm",
+	s: "ss",
+	A: "a",
+	a: "a",
+};
+
+/**
+ * Translate a PHP date() format string into a date-fns format string.
+ * Unmapped letters are escaped (single-quoted) so date-fns never throws on
+ * an unknown token; non-letters pass through; `\X` is a PHP literal escape.
+ */
+export function phpToDateFns(phpFormat) {
+	let result = "";
+	for (let i = 0; i < phpFormat.length; i++) {
+		const ch = phpFormat[i];
+		if (ch === "\\") {
+			const next = phpFormat[i + 1] ?? "";
+			if (next) {
+				result += `'${next}'`;
+				i++;
+			}
+			continue;
+		}
+		if (Object.prototype.hasOwnProperty.call(PHP_TO_DATE_FNS, ch)) {
+			result += PHP_TO_DATE_FNS[ch];
+		} else if (/[A-Za-z]/.test(ch)) {
+			result += `'${ch}'`;
+		} else {
+			result += ch;
+		}
+	}
+	return result;
+}
+```
+
+- [ ] **Step 2: Sanity-check the translator with node**
+
+Run:
+```bash
+node --input-type=module -e "import('./resources/js/composables/phpToDateFns.js').then(m => { const t = m.phpToDateFns; const cases = [['d M Y','dd MMM yyyy'],['Y-m-d','yyyy-MM-dd'],['d F Y','dd MMMM yyyy'],['d M, Y','dd MMM, yyyy'],['l, d F Y','EEEE, dd MMMM yyyy'],['d M Y H:i','dd MMM yyyy HH:mm']]; let ok=true; for (const [i,o] of cases){ const g=t(i); if(g!==o){ ok=false; console.log('FAIL', JSON.stringify(i), '->', JSON.stringify(g), 'expected', JSON.stringify(o)); } } console.log(ok ? 'ALL PASS' : 'FAILURES'); });"
+```
+Expected: `ALL PASS`. If any FAIL line prints, fix the translator and re-run.
+
+- [ ] **Step 3: Create the composable** `resources/js/composables/useDateFormat.js`:
+
+```js
+import { usePage } from "@inertiajs/vue3";
+import { format, parseISO, isValid } from "date-fns";
+import { phpToDateFns } from "@/composables/phpToDateFns";
+
+export { phpToDateFns };
+
+/**
+ * Returns a `formatDate(value)` bound to the app's configured date_format.
+ * Accepts an ISO date string or a Date; returns '' for null/invalid input.
+ */
+export function useDateFormat() {
+	const page = usePage();
+
+	const formatDate = (value) => {
+		if (!value) {
+			return "";
+		}
+		const date = value instanceof Date ? value : parseISO(String(value));
+		if (!isValid(date)) {
+			return "";
+		}
+		return format(date, phpToDateFns(page.props.app?.date_format ?? "d M Y"));
+	};
+
+	return { formatDate };
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: compiles cleanly (confirms the `@/composables/...` import path and date-fns/Inertia imports resolve). If it fails, report BLOCKED with the error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js/composables/phpToDateFns.js resources/js/composables/useDateFormat.js
+git commit -m "feat: phpToDateFns translator and useDateFormat composable"
+```
+
+---
+
+## Task 2: Retrofit the display sites
+
+**Files (24):**
+- date-fns display (19): `Pages/Institution/Staff.vue`, `Pages/Institution/Sta.vue`, `Pages/Person/Show.vue`, `Pages/Person/PersonAddresses.vue`, `Pages/Person/PersonContacts.vue`, `Pages/Person/Index.vue`, `Pages/Staff/StaffContacts.vue`, `Pages/Staff/StaffUnits.vue`, `Pages/Staff/StaffJobs.vue`, `Pages/Staff/Staff.vue`, `Pages/Staff/Show.vue`, `Pages/Staff/StaffRanks.vue`, `Pages/Status/Index.vue`, `Pages/Report/Recruitment/StaffTableRow.vue`, `Pages/User/StaffContacts.vue`, `Pages/User/StaffJobs.vue`, `Pages/User/Staff.vue`, `Pages/User/StaffRanks.vue`, `Pages/User/StaffUnits.vue` (all under `resources/js/`)
+- `toLocaleDateString` DOB (5): `Components/Staff/ActiveFilters.vue`, `Pages/Person/Address.vue`, `Pages/Staff/NewShow.vue`, `Pages/Staff/Notes.vue`, `Pages/Notes/Qualifications.vue`
+
+- [ ] **Step 1: Retrofit each date-fns display component**
+
+For EACH of the 19 date-fns files, the pattern is a local helper:
+```js
+import { format } from "date-fns";
+...
+const formatDate = (date) => {
+	return format(date, "dd MMMM, yyyy");   // or "d MMMM, yyyy" / "EEEE dd MMMM, yyyy"
+};
+```
+Edit it to:
+1. Add `import { useDateFormat } from "@/composables/useDateFormat";`.
+2. Remove the local `const formatDate = (date) => { return format(date, "..."); };` and replace it with `const { formatDate } = useDateFormat();`.
+3. If `format` from `date-fns` is now unused in the file, remove the `import { format } from "date-fns";` line (or remove only `format` from a multi-import). If the file also uses a `getDate`/`new Date` wrapper that is still referenced by the template, leave it — the composable's `formatDate` accepts both a `Date` and a string.
+
+Verify per file with `php`-free check: `grep -n "format(" <file>` should show no `format(date, "dd MMMM` display calls remain.
+
+- [ ] **Step 2: Retrofit each `toLocaleDateString` DOB component**
+
+For EACH of the 5 DOB files, the pattern is:
+```js
+const formattedDob = (dob) => {
+	if (!dob) return "";
+	return new Date(dob).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+};
+```
+Edit to add `import { useDateFormat } from "@/composables/useDateFormat";` and `const { formatDate } = useDateFormat();`, then replace the local helper body so it delegates:
+```js
+const formattedDob = (dob) => formatDate(dob);
+```
+(Keep the `formattedDob` name so the template is unchanged. If a file names it differently, e.g. an inline `toLocaleDateString` in a computed, replace that expression with `formatDate(<the date value>)`.)
+`ActiveFilters.vue` uses `toLocaleDateString` inside a function returning a label — replace that `date.toLocaleDateString('en-GB', {...})` with `formatDate(date)`.
+
+- [ ] **Step 3: Confirm no display date-fns / toLocaleDateString remains**
+
+Run:
+```bash
+grep -rn "dd MMMM, yyyy\|d MMMM, yyyy\|EEEE dd MMMM, yyyy" resources/js | grep -E "format\(" || echo "(no date-fns display literals)"
+grep -rn "toLocaleDateString" resources/js || echo "(no toLocaleDateString)"
+```
+Expected: the date-fns display literals are gone; `toLocaleDateString` either gone or only in non-DOB/number contexts you intentionally left (there should be none from the 5 listed). The 37 `yyyy-MM-dd` date-fns sites MUST remain (don't touch them).
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: compiles cleanly. If a file errors (e.g. removed `format` still referenced, or a leftover unused import warning that breaks build), fix that file and rebuild.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add resources/js
+git commit -m "refactor: render frontend display dates via useDateFormat"
+```
+
+---
+
+## Task 3: Dusk browser test
+
+**Files:**
+- Create: `tests/Browser/DateFormatTest.php`
+
+> Dusk setup gotcha (from project memory): the selenium container can't reach the host Vite dev server. Run with built assets — `npm run build` first, then pause the in-container Vite (`VPID=$(docker exec hr-laravel.test-1 pgrep -f 'node.*vite' | head -1); docker exec hr-laravel.test-1 sh -c "kill -STOP $VPID"`; back up & remove `public/hot`), run the Dusk test, then resume Vite (`kill -CONT $VPID`) and restore `public/hot`. A super-admin to `loginAs`: `richard.brobbey@audit.gov.gh`. New permissions must be seeded on the dev DB first if needed (not needed here).
+
+- [ ] **Step 1: Write the Dusk test**
+
+Create `tests/Browser/DateFormatTest.php`. It must: create (or use) a record with a known display date, set `GeneralSettings::date_format` to a value, visit a page that renders that date via a retrofitted component, and assert the rendered text. Use a page from the retrofit list that shows a known date. Concretely, target a staff/person date-of-birth or a status date the test controls. Structure:
+
+```php
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use App\Settings\GeneralSettings;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class DateFormatTest extends DuskTestCase
+{
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::where('email', 'richard.brobbey@audit.gov.gh')->firstOrFail();
+    }
+
+    public function test_frontend_renders_dates_in_configured_format(): void
+    {
+        $original = app(GeneralSettings::class)->date_format;
+
+        try {
+            // pick a page + record with a known, controllable display date and assert
+            // the rendered text for at least two formats:
+            //   'd F Y'  -> e.g. '28 June 2024'
+            //   'Y-m-d'  -> e.g. '2024-06-28'
+            // (Use a factory-created person/status with date_of_birth/start_date set to
+            //  a fixed date, navigate via loginAs($this->admin), and assertSee the
+            //  formatted string after setting the GeneralSettings::date_format each time.)
+            $this->markTestIncomplete('Wire the concrete page + fixture during implementation.');
+        } finally {
+            $settings = app(GeneralSettings::class);
+            $settings->date_format = $original;
+            $settings->save();
+        }
+    }
+}
+```
+
+During implementation, replace the `markTestIncomplete` body with a real fixture + assertions: create a record with a fixed date, for each of `'d F Y'` and `'Y-m-d'` set `GeneralSettings::date_format`, save, `loginAs($this->admin)->visit(<route>)`, and `assertSee('28 June 2024')` / `assertSee('2024-06-28')` (or use a `dusk` selector). Restore the original format in `finally`. Pick the simplest retrofitted page whose date you can control via a factory (a person DOB on a profile/show page, or a status date).
+
+- [ ] **Step 2: Run the Dusk test (built assets; pause Vite)**
+
+```bash
+npm run build
+cp public/hot /tmp/hot.save 2>/dev/null
+VPID=$(docker exec hr-laravel.test-1 pgrep -f 'node.*vite' | head -1)
+docker exec hr-laravel.test-1 sh -c "kill -STOP $VPID"
+rm -f public/hot
+docker exec hr-laravel.test-1 php artisan dusk --filter=DateFormatTest 2>&1 | tail -20
+docker exec hr-laravel.test-1 sh -c "kill -CONT $VPID"
+cp /tmp/hot.save public/hot 2>/dev/null
+```
+Expected: PASS. If it fails, read the failure screenshot under `tests/Browser/screenshots/` (a blank page means an asset/JS error — check the console log). Fix the component or the translator and re-run. This is the real end-to-end check of `phpToDateFns` + `useDateFormat`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Browser/DateFormatTest.php
+git commit -m "test: Dusk coverage for configurable frontend date format"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build`
+Expected: clean.
+
+- [ ] **Step 2: PHP suite unaffected (sanity)**
+
+Run: `docker exec hr-laravel.test-1 php artisan test 2>&1 | tail -6`
+Expected: green (frontend changes don't affect PHPUnit; this confirms nothing else regressed, e.g. the new Dusk test file doesn't break collection — note Dusk tests are a separate suite and won't run here).
+
+- [ ] **Step 3: Confirm scope boundaries held**
+
+Run:
+```bash
+echo "functional yyyy-MM-dd date-fns sites still present (expect ~37):"
+grep -rn "yyyy-MM-dd" resources/js | grep -E "format\(" | wc -l
+echo "no display date-fns literals remain:"
+grep -rn "dd MMMM, yyyy\|d MMMM, yyyy\|EEEE dd MMMM, yyyy" resources/js | grep -E "format\(" || echo "(none)"
+```
+Expected: ~37 `yyyy-MM-dd` preserved; no display literals.
+
+- [ ] **Step 4: Lint changed JS (optional, non-blocking)**
+
+Run: `npx eslint resources/js/composables/useDateFormat.js resources/js/composables/phpToDateFns.js 2>&1 | tail -5 || true`
+(ESLint config targets `public/` in this repo, so this may be a no-op — do not block on it.)
+
+- [ ] **Step 5: Manual smoke (ask the user to run)**
+
+With the app running, set "Date format" on `/settings/app` to `Y-m-d` (then `d F Y`), open a page with a display date (a person profile DOB, transfer history, status list) and confirm it re-renders in the chosen format. Confirm date-input fields (edit forms) are unaffected.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `phpToDateFns()` translator with the token map + escape rule → Task 1 (own file, node-checked). ✓
+- `useDateFormat()` composable reading `app.date_format`, null/invalid → `''` → Task 1. ✓
+- Retrofit 19 date-fns display sites + 5 `toLocaleDateString` DOB sites → Task 2 (explicit file list + per-pattern recipe). ✓
+- Leave functional `yyyy-MM-dd` + number `toLocaleString` → Task 2 Step 3, Task 4 Step 3 (verified preserved). ✓
+- Dusk test exercising 2–3 formats → Task 3. ✓
+- Build verification (no JS unit runner) → every task. ✓
+
+**Placeholder scan:** The Dusk test (Task 3) intentionally ships a `markTestIncomplete` skeleton with explicit instructions to wire a concrete fixture/page during implementation — this is a genuine judgment step (the exact page/route + a controllable date fixture is chosen at implementation time), not a vague placeholder; the assertions (`'d F Y'`→`28 June 2024`, `'Y-m-d'`→`2024-06-28`) and the run mechanics are fully specified. No other placeholders. ✓
+
+**Type/name consistency:** `phpToDateFns` defined in Task 1 (`phpToDateFns.js`), imported by `useDateFormat.js` and re-exported; `useDateFormat()`/`formatDate` used in Task 2 edits and Task 3. Import path `@/composables/useDateFormat` consistent. The default `'d M Y'` fallback matches the backend default and the node-check cases. ✓
+
+**Out of scope:** functional `yyyy-MM-dd`, number `toLocaleString`, date math. This completes Cycle 2c.

--- a/docs/superpowers/specs/2026-06-03-date-format-retrofit-frontend-design.md
+++ b/docs/superpowers/specs/2026-06-03-date-format-retrofit-frontend-design.md
@@ -1,0 +1,95 @@
+# Date-Format Retrofit — Frontend (Cycle 2c-2) Design
+
+**Date:** 2026-06-03
+**Status:** Approved for planning
+**Cycle:** 2c-2 of the app-settings effort (frontend half). Pairs with 2c-1 (backend, merged in #48). Consumes the `app.date_format` shared Inertia prop from Cycle 2a.
+
+## Goal
+
+Make frontend **display** dates follow the configured `date_format` setting by translating the PHP format string to date-fns in JS and applying it through a shared composable. Functional date formatting (date-input `yyyy-MM-dd` values, number `toLocaleString`, date math) is left untouched.
+
+## New Component
+
+**`resources/js/composables/useDateFormat.js`** exports two things:
+
+### `phpToDateFns(phpFormat)` — pure translator
+
+Maps PHP date tokens to date-fns tokens, character by character:
+
+| PHP | date-fns | | PHP | date-fns |
+|---|---|---|---|---|
+| `d` | `dd` | | `Y` | `yyyy` |
+| `j` | `d` | | `y` | `yy` |
+| `D` | `EEE` | | `H` | `HH` |
+| `l` | `EEEE` | | `G` | `H` |
+| `m` | `MM` | | `h` | `hh` |
+| `n` | `M` | | `g` | `h` |
+| `M` | `MMM` | | `i` | `mm` |
+| `F` | `MMMM` | | `s` | `ss` |
+| | | | `A` / `a` | `a` |
+
+Rules:
+- Non-alphabetic characters (spaces, `,`, `-`, `/`, `:`) pass through unchanged.
+- A PHP backslash-escaped char (`\X`) becomes a date-fns escaped literal.
+- Any alphabetic character NOT in the map is wrapped in single quotes (date-fns escapes literals that way) so `format()` never throws on an unknown token.
+- Example: `'d M Y'` → `'dd MMM yyyy'`; `'d F Y'` → `'dd MMMM yyyy'`; `'Y-m-d'` → `'yyyy-MM-dd'`.
+
+### `useDateFormat()` — composable
+
+```js
+import { usePage } from "@inertiajs/vue3";
+import { format, parseISO, isValid } from "date-fns";
+
+export function phpToDateFns(phpFormat) { /* the translator above */ }
+
+export function useDateFormat() {
+    const page = usePage();
+
+    const formatDate = (value) => {
+        if (!value) {
+            return "";
+        }
+        const date = value instanceof Date ? value : parseISO(String(value));
+        if (!isValid(date)) {
+            return "";
+        }
+        return format(date, phpToDateFns(page.props.app?.date_format ?? "d M Y"));
+    };
+
+    return { formatDate };
+}
+```
+
+- Reads the reactive `app.date_format` shared prop; falls back to `'d M Y'`.
+- `formatDate(value)` accepts an ISO string or a `Date`, returns `''` for null/invalid.
+
+## The Retrofit (~24 display sites)
+
+Per-site edits (not a blind sed): each affected component imports the composable (`const { formatDate } = useDateFormat()`) and swaps the display expression.
+
+- **date-fns display family (~19):** `format(new Date(x), 'dd MMMM, yyyy' | 'd MMMM, yyyy' | 'EEEE dd MMMM, yyyy')` → `formatDate(x)`. Where date-fns `format` is then unused in the file, drop it from the import.
+- **`toLocaleDateString` DOB (5):** `new Date(dob).toLocaleDateString('en-GB', {...})` → `formatDate(dob)` (files: `Components/Staff/ActiveFilters.vue`, `Pages/Person/Address.vue`, `Pages/Staff/NewShow.vue`, `Pages/Staff/Notes.vue`, `Pages/Notes/Qualifications.vue`).
+
+### Left alone
+- date-fns `'yyyy-MM-dd'` (37 sites) — date-input values, must stay machine format.
+- Number `toLocaleString` (85) — not dates.
+- `parseISO`/`addDays`/`subYears`/`format` used for date math or input binding, not display.
+
+## Testing
+
+No JS unit test (no vitest in the repo, per the chosen approach). Verification:
+- `npm run build` compiles cleanly.
+- One **Dusk browser test** (`tests/Browser/DateFormatTest.php`) that sets `date_format` to 2–3 values and asserts a frontend-rendered display date matches:
+  - `'Y-m-d'` → a known DOB renders as e.g. `2024-06-28`.
+  - `'d F Y'` → renders as `28 June 2024`.
+  - (default `'d M Y'` → `28 Jun 2024`.)
+  This exercises the translator's main tokens (`d`, `M`/`F`, `Y`, `m`) end-to-end through the UI. Run via the Sail/selenium setup (pause Vite, serve built assets — see the project memory on Dusk).
+
+## Default-Behavior Note
+
+Default `date_format='d M Y'` → date-fns `dd MMM yyyy`. The current display sites use `dd MMMM, yyyy` (full month + comma), so by default the displayed dates change appearance (e.g. `28 June, 2024` → `28 Jun 2024`), unifying with the backend (2c-1).
+
+## Out of Scope
+
+- Functional `yyyy-MM-dd` date inputs, number `toLocaleString`, date math.
+- This completes the date-format retrofit (2c). No further 2c cycles planned.

--- a/resources/js/Components/Staff/ActiveFilters.vue
+++ b/resources/js/Components/Staff/ActiveFilters.vue
@@ -1,6 +1,9 @@
 <script setup>
 import { computed } from 'vue'
 import { XMarkIcon } from '@heroicons/vue/20/solid'
+import { useDateFormat } from '@/composables/useDateFormat'
+
+const { formatDate } = useDateFormat()
 
 const props = defineProps({
     filters: {
@@ -157,16 +160,6 @@ const activeFilters = computed(() => {
 })
 
 const hasActiveFilters = computed(() => activeFilters.value.length > 0)
-
-const formatDate = (dateString) => {
-    if (!dateString) return ''
-    const date = new Date(dateString)
-    return date.toLocaleDateString('en-GB', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-    })
-}
 
 const removeFilter = (filter) => {
     const keysToRemove = filter.removeKeys || [filter.key]

--- a/resources/js/Pages/Institution/Sta.vue
+++ b/resources/js/Pages/Institution/Sta.vue
@@ -2,7 +2,8 @@
 import MainLayout from "@/Layouts/HrAuthenticated.vue";
 import { Head, Link } from "@inertiajs/vue3";
 import Tab from "@/Components/Tab.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import BreadCrumpVue from "@/Components/BreadCrump.vue";
 import StaffPersonalInfo from "@/Components/StaffPersonalInfo.vue";
 import StaffDependents from "@/Components/StaffDependents.vue";
@@ -21,10 +22,8 @@ import {
 
 // import { PaperClipIcon } from '@heroicons/vue/20/solid'
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Institution/Staff.vue
+++ b/resources/js/Pages/Institution/Staff.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head, Link } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import {
 	BriefcaseIcon,
 	BuildingOffice2Icon,
@@ -13,10 +14,8 @@ defineProps({
 	staff: Object,
 });
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "d MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Notes/Qualifications.vue
+++ b/resources/js/Pages/Notes/Qualifications.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import { Link } from "@inertiajs/vue3";
 // import AddQualification  from "./partials/AddQualification.vue";
 import Modal from "@/Components/NewModal.vue";
@@ -14,14 +15,8 @@ defineProps({
 let openQualificationModal = ref(false);
 let toggleQualificationModal = useToggle(openQualificationModal);
 
-const formattedDob = (dob) => {
-	if (!dob) return "";
-	return new Date(dob).toLocaleDateString("en-GB", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dob) => formatDate(dob);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Person/Address.vue
+++ b/resources/js/Pages/Person/Address.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import { Link, usePage } from "@inertiajs/vue3";
 import Modal from "@/Components/NewModal.vue";
 import { ref, computed } from "vue";
@@ -21,13 +22,8 @@ let toggleAddressModal = useToggle(openAddressModal);
 let openContactModal = ref(false);
 let toggleContactModal = useToggle(openContactModal);
 
-const formattedDob = (dob) => {
-	return new Date(dob).toLocaleDateString("en-GB", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dob) => formatDate(dob);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Person/Index.vue
+++ b/resources/js/Pages/Person/Index.vue
@@ -6,8 +6,8 @@ import { ref, watch, computed } from "vue";
 import { debouncedWatch } from "@vueuse/core";
 import { router } from "@inertiajs/vue3";
 import Pagination from "../../Components/Pagination.vue";
-import format from "date-fns/format";
 import differenceInYears from "date-fns/differenceInYears";
+import { useDateFormat } from "@/composables/useDateFormat";
 import BreadCrumpVue from "@/Components/BreadCrump.vue";
 import InfoCard from "@/Components/InfoCard.vue";
 import { MagnifyingGlassIcon } from "@heroicons/vue/24/outline";
@@ -37,11 +37,7 @@ debouncedWatch(
 	{ debounce: 300 },
 );
 
-let formatDate = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "EEEE dd MMMM, yyyy");
-	// return new Intl.DateTimeFormat("en-GB", { dateStyle: "full" }).format(date);
-};
+const { formatDate } = useDateFormat();
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Person/PersonAddresses.vue
+++ b/resources/js/Pages/Person/PersonAddresses.vue
@@ -2,7 +2,8 @@
 import { Link } from "@inertiajs/vue3";
 import DeleteAddressModal from "./DeleteAddressModal.vue";
 import AddAddressModal from "./AddAddressModal.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 import {
 	MagnifyingGlassIcon,
@@ -29,10 +30,8 @@ let deleteAddress = (id) => {
 };
 let editAddress = (id) => {};
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Person/PersonContacts.vue
+++ b/resources/js/Pages/Person/PersonContacts.vue
@@ -2,7 +2,8 @@
 import { Link } from "@inertiajs/vue3";
 import DeleteContactsModal from "./DeleteContactsModal.vue";
 import AddContactsModal from "./AddContactsModal.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 import {
 	MagnifyingGlassIcon,
@@ -30,10 +31,8 @@ let deleteDependents = (id) => {
 };
 let editDependent = (id) => {};
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Person/Show.vue
+++ b/resources/js/Pages/Person/Show.vue
@@ -1,16 +1,15 @@
 <script setup>
 import MainLayout from "@/Layouts/NewAuthenticated.vue";
 import { Head } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import PersonContacts from "./PersonContacts.vue";
 import PersonAddresses from "./PersonAddresses.vue";
 import Avatar from "./partials/Avatar.vue";
 import Summary from "./Summary.vue";
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Report/Recruitment/StaffTableRow.vue
+++ b/resources/js/Pages/Report/Recruitment/StaffTableRow.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from "vue";
-import { format, differenceInYears, addYears } from "date-fns";
+import { differenceInYears, addYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import StaffTableData from "./StaffTableData.vue";
 
 let props = defineProps({
@@ -14,10 +15,7 @@ let hireDate = computed(() => {
 	return formatDate(props.staff.hire_date);
 });
 
-let formatDate = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
 
 let getAge = (dateString, now = new Date()) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Staff/NewShow.vue
+++ b/resources/js/Pages/Staff/NewShow.vue
@@ -26,6 +26,9 @@ import EditContactForm from "./EditContactForm.vue";
 import EditAvatarForm from "./EditAvatarForm.vue";
 import DeleteAvatar from "./DeleteAvatar.vue";
 import { router } from "@inertiajs/vue3";
+import { useDateFormat } from "@/composables/useDateFormat";
+
+const { formatDate } = useDateFormat();
 
 let showPromotionForm = ref(false);
 let showTransferForm = ref(false);
@@ -58,14 +61,7 @@ const toggleDeleteAvatarModal = useToggle(openDeleteAvatarModel);
 
 let togglePromotionForm = useToggle(showPromotionForm);
 let toggleTransferForm = useToggle(showTransferForm);
-const formattedDob = (dob) => {
-	if (!dob) return "";
-	return new Date(dob).toLocaleDateString("en-GB", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-};
+const formattedDob = (dob) => formatDate(dob);
 
 let props = defineProps({
 	user: { type: Object, default: () => null },

--- a/resources/js/Pages/Staff/Notes.vue
+++ b/resources/js/Pages/Staff/Notes.vue
@@ -5,6 +5,9 @@ import NotesDetails from "./NotesDetails.vue";
 import { ref, computed } from "vue";
 import { useToggle } from "@vueuse/core";
 import NewNote from "./NewNote.vue";
+import { useDateFormat } from "@/composables/useDateFormat";
+
+const { formatDate } = useDateFormat();
 
 const page = usePage();
 const permissions = computed(() => page.props?.auth.permissions);
@@ -19,14 +22,7 @@ defineProps({
 let openQualificationModal = ref(false);
 let toggleQualificationModal = useToggle(openQualificationModal);
 
-const formattedDob = (dob) => {
-	if (!dob) return "";
-	return new Date(dob).toLocaleDateString("en-GB", {
-		day: "numeric",
-		month: "short",
-		year: "numeric",
-	});
-};
+const formattedDob = (dob) => formatDate(dob);
 </script>
 <template>
 	<!-- Notes on staff -->

--- a/resources/js/Pages/Staff/Show.vue
+++ b/resources/js/Pages/Staff/Show.vue
@@ -4,7 +4,8 @@ import { Head, Link } from "@inertiajs/vue3";
 import Tab from "@/Components/Tab.vue";
 import StaffRanks from "./StaffRanks.vue";
 import StaffUnits from "./StaffUnits.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import BreadCrumpVue from "@/Components/BreadCrump.vue";
 import StaffPersonalInfo from "@/Components/StaffPersonalInfo.vue";
 import StaffDates from "@/Pages/Staff/StaffDates.vue";
@@ -12,10 +13,8 @@ import StaffDependents from "@/Components/StaffDependents.vue";
 
 // import { PaperClipIcon } from '@heroicons/vue/20/solid'
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Staff/Staff.vue
+++ b/resources/js/Pages/Staff/Staff.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head, Link } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import {
 	BriefcaseIcon,
 	BuildingOffice2Icon,
@@ -13,10 +14,8 @@ defineProps({
 	staff: Object,
 });
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "d MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Staff/StaffContacts.vue
+++ b/resources/js/Pages/Staff/StaffContacts.vue
@@ -2,7 +2,8 @@
 import { Link } from "@inertiajs/vue3";
 import DeleteContactsModal from "./DeleteContactsModal.vue";
 import AddContactsModal from "./AddContactsModal.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 import { MagnifyingGlassIcon, MegaphoneIcon } from "@heroicons/vue/24/outline";
 import { ref } from "vue";
@@ -23,10 +24,8 @@ let deleteDependents = (id) => {
 };
 let editDependent = (id) => {};
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Staff/StaffJobs.vue
+++ b/resources/js/Pages/Staff/StaffJobs.vue
@@ -1,14 +1,13 @@
 <script setup>
 import { Link } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 defineProps({
 	jobs: Object,
 });
 
-const formattedDate = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDate = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/Staff/StaffRanks.vue
+++ b/resources/js/Pages/Staff/StaffRanks.vue
@@ -1,12 +1,10 @@
 <script setup>
-import { format } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 const getDate = (dateString) => {
 	return new Date(dateString);
 };
-const formatDate = (date) => {
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
 defineProps({
 	ranks: Array,
 });

--- a/resources/js/Pages/Staff/StaffUnits.vue
+++ b/resources/js/Pages/Staff/StaffUnits.vue
@@ -1,12 +1,10 @@
 <script setup>
-import { format } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 const getDate = (dateString) => {
 	return new Date(dateString);
 };
-const formatDate = (date) => {
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
 defineProps({
 	units: Array,
 });

--- a/resources/js/Pages/Status/Index.vue
+++ b/resources/js/Pages/Status/Index.vue
@@ -5,7 +5,7 @@ import BreezeInput from "@/Components/Input.vue";
 import { ref, watch } from "vue";
 import { debouncedWatch } from "@vueuse/core";
 import { router } from "@inertiajs/vue3";
-import { format } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import BreadCrumpVue from "@/Components/BreadCrump.vue";
 import { PlusIcon } from "@heroicons/vue/24/outline";
 import Modal from "@/Components/NewModal.vue";
@@ -39,11 +39,7 @@ let openStaff = (staff) => {
 	router.visit(route("staff.show", { staff: staff }));
 };
 
-let formatDate = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-	// return new Intl.DateTimeFormat("en-GB", { dateStyle: "full" }).format(date);
-};
+const { formatDate } = useDateFormat();
 
 let BreadCrumpLinks = [
 	{

--- a/resources/js/Pages/User/Staff.vue
+++ b/resources/js/Pages/User/Staff.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Head, Link } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 import {
 	BriefcaseIcon,
 	BuildingOffice2Icon,
@@ -13,10 +14,8 @@ defineProps({
 	staff: Object,
 });
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "d MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/User/StaffContacts.vue
+++ b/resources/js/Pages/User/StaffContacts.vue
@@ -2,7 +2,8 @@
 import { Link } from "@inertiajs/vue3";
 import DeleteContactsModal from "./DeleteContactsModal.vue";
 import AddContactsModal from "./AddContactsModal.vue";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 import { MagnifyingGlassIcon, MegaphoneIcon } from "@heroicons/vue/24/outline";
 import { ref } from "vue";
@@ -23,10 +24,8 @@ let deleteDependents = (id) => {
 };
 let editDependent = (id) => {};
 
-const formattedDob = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDob = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/User/StaffJobs.vue
+++ b/resources/js/Pages/User/StaffJobs.vue
@@ -1,14 +1,13 @@
 <script setup>
 import { Link } from "@inertiajs/vue3";
-import { format, differenceInYears } from "date-fns";
+import { differenceInYears } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 defineProps({
 	jobs: Object,
 });
 
-const formattedDate = (dateString) => {
-	const date = new Date(dateString);
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
+const formattedDate = (dateString) => formatDate(dateString);
 
 let getAge = (dateString) => {
 	const date = new Date(dateString);

--- a/resources/js/Pages/User/StaffRanks.vue
+++ b/resources/js/Pages/User/StaffRanks.vue
@@ -1,12 +1,10 @@
 <script setup>
-import { format } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 const getDate = (dateString) => {
 	return new Date(dateString);
 };
-const formatDate = (date) => {
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
 defineProps({
 	ranks: Array,
 });

--- a/resources/js/Pages/User/StaffUnits.vue
+++ b/resources/js/Pages/User/StaffUnits.vue
@@ -1,12 +1,10 @@
 <script setup>
-import { format } from "date-fns";
+import { useDateFormat } from "@/composables/useDateFormat";
 
 const getDate = (dateString) => {
 	return new Date(dateString);
 };
-const formatDate = (date) => {
-	return format(date, "dd MMMM, yyyy");
-};
+const { formatDate } = useDateFormat();
 defineProps({
 	units: Array,
 });

--- a/resources/js/composables/phpToDateFns.js
+++ b/resources/js/composables/phpToDateFns.js
@@ -1,0 +1,48 @@
+const PHP_TO_DATE_FNS = {
+	d: "dd",
+	j: "d",
+	D: "EEE",
+	l: "EEEE",
+	m: "MM",
+	n: "M",
+	M: "MMM",
+	F: "MMMM",
+	y: "yy",
+	Y: "yyyy",
+	H: "HH",
+	G: "H",
+	h: "hh",
+	g: "h",
+	i: "mm",
+	s: "ss",
+	A: "a",
+	a: "a",
+};
+
+/**
+ * Translate a PHP date() format string into a date-fns format string.
+ * Unmapped letters are escaped (single-quoted) so date-fns never throws on
+ * an unknown token; non-letters pass through; `\X` is a PHP literal escape.
+ */
+export function phpToDateFns(phpFormat) {
+	let result = "";
+	for (let i = 0; i < phpFormat.length; i++) {
+		const ch = phpFormat[i];
+		if (ch === "\\") {
+			const next = phpFormat[i + 1] ?? "";
+			if (next) {
+				result += `'${next}'`;
+				i++;
+			}
+			continue;
+		}
+		if (Object.prototype.hasOwnProperty.call(PHP_TO_DATE_FNS, ch)) {
+			result += PHP_TO_DATE_FNS[ch];
+		} else if (/[A-Za-z]/.test(ch)) {
+			result += `'${ch}'`;
+		} else {
+			result += ch;
+		}
+	}
+	return result;
+}

--- a/resources/js/composables/useDateFormat.js
+++ b/resources/js/composables/useDateFormat.js
@@ -1,0 +1,26 @@
+import { usePage } from "@inertiajs/vue3";
+import { format, parseISO, isValid } from "date-fns";
+import { phpToDateFns } from "@/composables/phpToDateFns";
+
+export { phpToDateFns };
+
+/**
+ * Returns a `formatDate(value)` bound to the app's configured date_format.
+ * Accepts an ISO date string or a Date; returns '' for null/invalid input.
+ */
+export function useDateFormat() {
+	const page = usePage();
+
+	const formatDate = (value) => {
+		if (!value) {
+			return "";
+		}
+		const date = value instanceof Date ? value : parseISO(String(value));
+		if (!isValid(date)) {
+			return "";
+		}
+		return format(date, phpToDateFns(page.props.app?.date_format ?? "d M Y"));
+	};
+
+	return { formatDate };
+}

--- a/tests/Browser/DateFormatTest.php
+++ b/tests/Browser/DateFormatTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\Person;
+use App\Models\User;
+use App\Settings\GeneralSettings;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class DateFormatTest extends DuskTestCase
+{
+    public function test_frontend_renders_dates_in_configured_format(): void
+    {
+        $admin = User::where('email', 'richard.brobbey@audit.gov.gh')->firstOrFail();
+
+        $settings = app(GeneralSettings::class);
+        $original = $settings->date_format;
+
+        $surname = 'Zdatefmt' . now()->timestamp;
+
+        $person = Person::factory()->create([
+            'surname' => $surname,
+            'date_of_birth' => '2024-06-28',
+        ]);
+
+        $search = '?search=' . $surname;
+
+        try {
+            $settings->date_format = 'd F Y';
+            $settings->save();
+
+            $this->browse(fn (Browser $b) => $b->loginAs($admin)
+                ->visit('/person' . $search)
+                ->waitForText($surname)
+                ->waitForText('28 June 2024')
+                ->assertSee('28 June 2024'));
+
+            $settings->date_format = 'Y-m-d';
+            $settings->save();
+
+            $this->browse(fn (Browser $b) => $b->loginAs($admin)
+                ->visit('/person' . $search)
+                ->waitForText($surname)
+                ->waitForText('2024-06-28')
+                ->assertSee('2024-06-28'));
+        } finally {
+            $settings->date_format = $original;
+            $settings->save();
+
+            $person->forceDelete();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes the date-format effort: frontend **display** dates now follow the configurable **Date format** setting (the `app.date_format` shared prop from Cycle 2a), matching the backend (2c-1).

- New **`composables/phpToDateFns.js`** — pure translator mapping PHP date tokens → date-fns (`'d M Y'` → `'dd MMM yyyy'`), escaping unmapped letters so date-fns never throws. Node-sanity-checked across 6 cases.
- New **`composables/useDateFormat.js`** — `useDateFormat()` returns `formatDate(value)` (reads the configured format, accepts an ISO string or `Date`, returns `''` for null/invalid).
- Retrofitted **24 components** (19 date-fns display sites + 5 `toLocaleDateString` DOB sites) to `formatDate()`.
- **Left alone:** functional `format(x, 'yyyy-MM-dd')` date-input values and number `toLocaleString`.

By default (`d M Y`), display dates change from `dd MMMM, yyyy` (e.g. `28 June, 2024`) to `28 Jun 2024`, unifying with the backend.

## Test Plan
- [x] `phpToDateFns` node sanity-check (6 cases) ✓
- [x] **Dusk** `tests/Browser/DateFormatTest.php` — sets `d F Y` → renders `28 June 2024`, and `Y-m-d` → `2024-06-28`, on the retrofitted Person index; restores the setting + deletes the fixture in `finally`. **1 passed (2 assertions).**
- [x] `npm run build` clean; diff is formatter-only (no incidental reformatting); functional `yyyy-MM-dd` untouched
- [ ] Manual: set Date format on `/settings/app` to `Y-m-d` then `d F Y`; confirm a profile DOB / status / transfer date re-renders; confirm edit-form date inputs are unaffected

## Notes
- **Known dormant caveat:** `formatDate` parses ISO instants and formats in the browser's local TZ. Laravel's `date` cast serializes a date as `…T00:00:00Z`, so in a **negative-offset** timezone a date-only value could render the prior day. This app deploys at **GMT+0 (Ghana)** and the env is UTC, so it renders correctly today; worth tightening (parse date-only as local) if the app ever serves negative-offset timezones.
- Dusk runs via the selenium container against built assets (pause Vite + serve `public/build`); it is not part of the feature-test CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)