### PR TITLE
Associate-staff picker performance + responsive settings pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ ray.php
 tests/Browser/screenshots/
 tests/Browser/console/
 tests/Browser/source/
+
+# Local tooling artifacts
+cookies.txt
+.playwright-mcp/

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -10,6 +10,8 @@ use App\Models\User;
 use App\Traits\LogsAuthorization;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
@@ -261,6 +263,8 @@ class UserController extends Controller
         $user->person_id = $request->validated()['person_id'];
         $user->save();
 
+        Cache::forget('user_staff_options_default');
+
         $this->logSuccess('associated a user with a staff record', $user);
 
         return redirect()->back()->with('success', 'User associated with staff record successfully');
@@ -281,6 +285,8 @@ class UserController extends Controller
             $user->removeRole('staff');
         }
 
+        Cache::forget('user_staff_options_default');
+
         $this->logSuccess('removed a user staff association', $user);
 
         return redirect()->back()->with('success', 'Staff association removed successfully');
@@ -292,27 +298,45 @@ class UserController extends Controller
      * Only people who are staff (have an institution_person row) and are not
      * already linked to another user account are returned.
      */
-    public function staffOptions(): JsonResponse
+    public function staffOptions(Request $request): JsonResponse
     {
-        $linkedPersonIds = User::query()->whereNotNull('person_id')->pluck('person_id');
+        $search = trim((string) $request->query('search', ''));
 
-        $options = Person::query()
-            ->whereHas('institution')
-            ->whereNotIn('id', $linkedPersonIds)
-            ->with('institution')
-            ->orderBy('surname')
-            ->get()
-            ->map(function (Person $person): array {
-                $staffNumber = $person->institution->first()?->staff?->staff_number;
+        $build = function () use ($search): array {
+            $linkedPersonIds = User::query()->whereNotNull('person_id')->pluck('person_id');
 
-                return [
-                    'value' => $person->id,
-                    'label' => $staffNumber
-                        ? "{$person->full_name} — {$staffNumber}"
-                        : $person->full_name,
-                ];
-            })
-            ->values();
+            return Person::query()
+                ->whereHas('institution')
+                ->whereNotIn('id', $linkedPersonIds)
+                ->when($search !== '', function ($query) use ($search): void {
+                    $query->where(function ($q) use ($search): void {
+                        $q->where('surname', 'like', "%{$search}%")
+                            ->orWhere('first_name', 'like', "%{$search}%")
+                            ->orWhere('other_names', 'like', "%{$search}%")
+                            ->orWhereHas('institution', fn ($iq) => $iq->where('institution_person.staff_number', 'like', "%{$search}%"));
+                    });
+                })
+                ->with('institution')
+                ->orderBy('surname')
+                ->limit(25)
+                ->get()
+                ->map(function (Person $person): array {
+                    $staffNumber = $person->institution->first()?->staff?->staff_number;
+
+                    return [
+                        'value' => $person->id,
+                        'label' => $staffNumber
+                            ? "{$person->full_name} — {$staffNumber}"
+                            : $person->full_name,
+                    ];
+                })
+                ->values()
+                ->all();
+        };
+
+        $options = $search === ''
+            ? Cache::remember('user_staff_options_default', 3600, $build)
+            : $build();
 
         return response()->json($options);
     }

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -14,33 +14,15 @@ class AdminUserSeeder extends Seeder
      */
     public function run()
     {
-        User::firstOrCreate(
+        $user = User::firstOrCreate(
             ['email' => 'admin@audit.gov.gh'],
             [
                 'name' => 'System Administrator',
                 'password' => bcrypt('gbqdF4b6zxF7G87ihvA'),
             ]
         );
-        User::firstOrCreate(
-            ['email' => 'richard.brobbey@audit.gov.gh'],
-            [
-                'name' => 'Richard Opoku Brobbey',
-                'password' => bcrypt('password123'),
-            ]
-        );
-        User::firstOrCreate(
-            ['email' => 'yvette.barnor@audit.gov.gh'],
-            [
-                'name' => 'Yvette Akuorkor Barnor',
-                'password' => bcrypt('password123'),
-            ]
-        );
-        User::firstOrCreate(
-            ['email' => 'naadensua.prentice@audit.gov.gh'],
-            [
-                'name' => 'Naa Densua Prentice',
-                'password' => bcrypt('password123'),
-            ]
-        );
+        if ($user) {
+            $user->assignRole('super-administrator');
+        }
     }
 }

--- a/resources/js/Components/Forms/SearchSelect.vue
+++ b/resources/js/Components/Forms/SearchSelect.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import {
     Listbox,
     ListboxButton,
@@ -33,19 +33,45 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    remote: {
+        type: Boolean,
+        default: false,
+    },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
+    maxHeight: {
+        type: String,
+        default: 'max-h-60',
+    },
+    renderLimit: {
+        type: Number,
+        default: 50,
+    },
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'search'])
 
 const searchQuery = ref('')
+
+let searchDebounce
+watch(searchQuery, (value) => {
+    if (!props.remote) {
+        return
+    }
+    clearTimeout(searchDebounce)
+    searchDebounce = setTimeout(() => emit('search', value), 250)
+})
 
 const selectedOption = computed(() => {
     return props.options.find((option) => option.value === props.modelValue)
 })
 
 const filteredOptions = computed(() => {
-    if (!props.searchable || !searchQuery.value) {
-        return props.options
+    // In remote mode the server already filtered; render options as-is.
+    if (props.remote || !props.searchable || !searchQuery.value) {
+        return props.options.slice(0, props.renderLimit)
     }
 
     const query = searchQuery.value.toLowerCase()
@@ -54,7 +80,7 @@ const filteredOptions = computed(() => {
                option.short_name?.toLowerCase().includes(query) ||
                option.category?.toLowerCase().includes(query) ||
                option.department?.toLowerCase().includes(query)
-    })
+    }).slice(0, props.renderLimit)
 })
 
 const updateValue = (option) => {
@@ -106,7 +132,10 @@ const clearSearch = () => {
                     leave-to-class="opacity-0"
                 >
                     <ListboxOptions
-                        class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+                        :class="[
+                            maxHeight,
+                            'absolute z-10 mt-1 w-full overflow-auto rounded-md bg-white dark:bg-gray-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm',
+                        ]"
                     >
                         <!-- Search Input (if searchable) -->
                         <div
@@ -128,6 +157,14 @@ const clearSearch = () => {
                                 />
                             </div>
                         </div>
+
+                        <!-- Loading indicator (remote mode) -->
+                        <li
+                            v-if="remote && loading"
+                            class="relative cursor-default select-none py-2 pl-3 pr-9 text-gray-500 dark:text-gray-400"
+                        >
+                            Searching…
+                        </li>
 
                         <ListboxOption
                             v-slot="{ active, selected }"

--- a/resources/js/Pages/AuditLog/Index.vue
+++ b/resources/js/Pages/AuditLog/Index.vue
@@ -95,14 +95,14 @@ const BreadCrumpLinks = [{ name: "Audit Log", url: "" }];
                     title="Audit Log"
                     :total="activities.total"
                     :search="filters.search"
-                    class="w-4/6"
+                    class="w-full lg:w-4/6"
                     :show-action="false"
                     @search-entered="(value) => searchActivity(value)"
                 />
 
                 <!-- Filters -->
                 <div
-                    class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg"
+                    class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-6 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg"
                 >
                     <div>
                         <label

--- a/resources/js/Pages/AuditLog/Show.vue
+++ b/resources/js/Pages/AuditLog/Show.vue
@@ -149,7 +149,7 @@ const BreadCrumpLinks = [
                     </div>
 
                     <!-- Timestamps -->
-                    <div class="grid grid-cols-2 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
                         <div>
                             <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400">
                                 Created At

--- a/resources/js/Pages/Permission/Index.vue
+++ b/resources/js/Pages/Permission/Index.vue
@@ -52,7 +52,7 @@ let BreadCrumpLinks = [
 					title="Permissions"
 					:total="permissions.total"
 					:search="filters.search"
-					class="w-4/6"
+					class="w-full lg:w-4/6"
 					action-text="Create Permission"
 					@action-clicked="toggle()"
 					@search-entered="(value) => searchPermission(value)"

--- a/resources/js/Pages/Permission/partials/PermissionList.vue
+++ b/resources/js/Pages/Permission/partials/PermissionList.vue
@@ -23,7 +23,7 @@ const tableCols = ["Permissions", "Roles", "Users"];
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="permissions.length > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/Permission/partials/PermissionRoles.vue
+++ b/resources/js/Pages/Permission/partials/PermissionRoles.vue
@@ -28,7 +28,7 @@ const openRole = (roleId) => {
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="roles.total > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/Permission/partials/PermissionUsers.vue
+++ b/resources/js/Pages/Permission/partials/PermissionUsers.vue
@@ -28,7 +28,7 @@ const openUser = (userId) => {
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="users.total > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/Role/Index.vue
+++ b/resources/js/Pages/Role/Index.vue
@@ -55,7 +55,7 @@ let BreadCrumpLinks = [
 					title="Roles"
 					:total="roles.total"
 					:search="filters.search"
-					class="w-4/6"
+					class="w-full lg:w-4/6"
 					action-text="Crate Role"
 					@action-clicked="toggle()"
 					@search-entered="(value) => searchRole(value)"

--- a/resources/js/Pages/Role/partials/RoleList.vue
+++ b/resources/js/Pages/Role/partials/RoleList.vue
@@ -23,7 +23,7 @@ const tableCols = ["Roles", "Permissions", "Users"];
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="roles.length > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/Role/partials/RolePermissions.vue
+++ b/resources/js/Pages/Role/partials/RolePermissions.vue
@@ -134,7 +134,7 @@ const tableCols = computed(() => {
 			</div>
 			<div
 				v-if="permissions?.total > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/Role/partials/RoleUsers.vue
+++ b/resources/js/Pages/Role/partials/RoleUsers.vue
@@ -52,7 +52,7 @@ const openUser = (userId) => {
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="users.total > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/resources/js/Pages/User/Index.vue
+++ b/resources/js/Pages/User/Index.vue
@@ -96,7 +96,7 @@ const openAssociate = (id) => {
 					title="Users"
 					:total="users.total"
 					:search="filters.search"
-					class="w-4/6"
+					class="w-full lg:w-4/6"
 					action-text="Create User"
 					@action-clicked="toggle()"
 					@search-entered="(value) => searchUser(value)"

--- a/resources/js/Pages/User/partials/AssociateStaff.vue
+++ b/resources/js/Pages/User/partials/AssociateStaff.vue
@@ -14,15 +14,23 @@ const options = ref([]);
 const selected = ref(null);
 const error = ref("");
 const loading = ref(false);
+const loadingOptions = ref(false);
 
-onMounted(async () => {
+const fetchOptions = async (search = "") => {
+	loadingOptions.value = true;
 	try {
-		const response = await axios.get(route("users.staff-options"));
+		const response = await axios.get(route("users.staff-options"), {
+			params: { search },
+		});
 		options.value = response.data;
 	} catch (e) {
 		error.value = "Could not load staff records.";
+	} finally {
+		loadingOptions.value = false;
 	}
-});
+};
+
+onMounted(() => fetchOptions());
 
 const submit = () => {
 	error.value = "";
@@ -45,7 +53,7 @@ const submit = () => {
 </script>
 
 <template>
-	<main class="px-8 py-8 bg-white dark:bg-gray-800">
+	<main class="px-8 py-8 bg-white dark:bg-gray-800 min-h-96">
 		<h1 class="text-xl font-semibold pb-4 text-green-900 dark:text-gray-100">
 			Associate Staff Record
 		</h1>
@@ -53,9 +61,13 @@ const submit = () => {
 			v-model="selected"
 			:options="options"
 			:searchable="true"
+			remote
+			:loading="loadingOptions"
+			max-height="max-h-96"
 			label="Staff record"
 			placeholder="Search staff by name or staff number"
 			:error="error"
+			@search="fetchOptions"
 		/>
 		<div class="flex justify-end pt-6">
 			<button

--- a/resources/js/Pages/User/partials/UserList.vue
+++ b/resources/js/Pages/User/partials/UserList.vue
@@ -60,7 +60,7 @@ const tableCols = [
 		<div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
 			<div
 				v-if="users.length > 0"
-				class="overflow-hidden border-b border-gray-200 rounded-md shadow-md"
+				class="overflow-x-auto border-b border-gray-200 rounded-md shadow-md"
 			>
 				<MainTable>
 					<TableHead>

--- a/tests/Feature/AssociateUserStaffTest.php
+++ b/tests/Feature/AssociateUserStaffTest.php
@@ -74,6 +74,76 @@ class AssociateUserStaffTest extends TestCase
         $this->assertStringContainsString($linkable->fresh()->institution->first()->staff->staff_number, $option['label']);
     }
 
+    public function test_staff_options_limits_results(): void
+    {
+        for ($i = 0; $i < 30; $i++) {
+            $this->staffPerson();
+        }
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson(route('users.staff-options'));
+
+        $response->assertOk();
+        $this->assertLessThanOrEqual(25, count($response->json()));
+    }
+
+    public function test_staff_options_filters_by_name(): void
+    {
+        $match = $this->staffPerson();
+        $match->update(['surname' => 'Zephyrson']);
+
+        $other = $this->staffPerson();
+        $other->update(['surname' => 'Aldridge']);
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson(route('users.staff-options', ['search' => 'Zephyr']));
+
+        $response->assertOk();
+        $values = collect($response->json())->pluck('value');
+
+        $this->assertTrue($values->contains($match->id));
+        $this->assertFalse($values->contains($other->id));
+    }
+
+    public function test_staff_options_filters_by_staff_number(): void
+    {
+        $person = Person::factory()->create();
+        $person->institution()->attach(Institution::factory()->create()->id, [
+            'staff_number' => 'STAFFUNIQ123',
+            'hire_date' => now()->subYears(2),
+        ]);
+
+        $other = $this->staffPerson();
+
+        $response = $this->actingAs($this->adminUser())
+            ->getJson(route('users.staff-options', ['search' => 'UNIQ123']));
+
+        $response->assertOk();
+        $values = collect($response->json())->pluck('value');
+
+        $this->assertTrue($values->contains($person->id));
+        $this->assertFalse($values->contains($other->id));
+    }
+
+    public function test_staff_options_cache_invalidated_on_associate(): void
+    {
+        $person = $this->staffPerson();
+        $admin = $this->adminUser();
+
+        // Populate the default (no-search) cache while the person is still unlinked.
+        $first = $this->actingAs($admin)->getJson(route('users.staff-options'));
+        $this->assertTrue(collect($first->json())->pluck('value')->contains($person->id));
+
+        $target = User::factory()->create(['person_id' => null]);
+        $this->actingAs($admin)->patch(route('user.associate-staff', ['user' => $target->id]), [
+            'person_id' => $person->id,
+        ]);
+
+        // After association the cache must be invalidated, so the now-linked person is gone.
+        $second = $this->actingAs($admin)->getJson(route('users.staff-options'));
+        $this->assertFalse(collect($second->json())->pluck('value')->contains($person->id));
+    }
+
     public function test_staff_options_requires_permission(): void
     {
         $response = $this->actingAs(User::factory()->create())


### PR DESCRIPTION
## Summary

Two related fixes to the settings/admin area, plus a pre-existing seeder change that was sitting in the working tree.

### 1. Associate-staff picker performance
The `users.staff-options` endpoint loaded **every** unlinked staff person in one unbounded query (no cache), and `SearchSelect` rendered them all as DOM nodes — slow in production with thousands of staff.

- `staffOptions()` now accepts `?search=` (matches name + `staff_number` at the DB level), caps results to 25, and caches the no-search default for 1h (invalidated on associate/dissociate).
- `SearchSelect` gains opt-in `remote` / `loading` / `maxHeight` / `renderLimit` props with a debounced `search` emit — existing static usages are unchanged.
- `AssociateStaff` fetches debounced server results and uses a taller dropdown (`max-h-96`) so 5+ staff show without scrolling.

### 2. Responsive settings pages (User / Role / Permission / Audit-log — Index & Show)
The wide list tables were wrapped in an inner `overflow-hidden` div that **clipped** them, so columns past the first (including **Actions**) were unreachable on any screen narrower than the table.

- Swap the inner table wrapper `overflow-hidden` → `overflow-x-auto` in 7 list partials so wide tables scroll within their bordered card.
- Index headers `w-4/6` → `w-full lg:w-4/6` (full width on mobile/tablet; desktop layout preserved).
- AuditLog filter grid gains `sm:grid-cols-2`; AuditLog/Show timestamps collapse to one column on small screens.

### 3. Seeder (pre-existing change)
Admin user is granted the `super-administrator` role on seed; the three hard-coded demo accounts are removed.

## Testing
- `php artisan test --filter=AssociateUserStaffTest` → **25 passed** (4 new: result limit, name filter, staff-number filter, cache invalidation).
- `vendor/bin/pint` clean; `npm run build` compiles.
- Responsive work verified in a real browser at **360px** and **1440px**: tables scroll, grids collapse, Actions column reachable, no content overflow.

> Note: a pre-existing ~15px horizontal overflow from the app shell's `<body class="w-screen">` affects every page app-wide and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)