### PR TITLE
Index tables: row click opens the show page

### DIFF
--- a/resources/js/Components/Table/MainTable.vue
+++ b/resources/js/Components/Table/MainTable.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import MainTable from "@/Components/MainTable.vue";
+
 export default MainTable;
 </script>

--- a/resources/js/Components/Table/RowHeader.vue
+++ b/resources/js/Components/Table/RowHeader.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import RowHeader from "@/Components/RowHeader.vue";
+
 export default RowHeader;
 </script>

--- a/resources/js/Components/Table/TableBody.vue
+++ b/resources/js/Components/Table/TableBody.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import TableBody from "@/Components/TableBody.vue";
+
 export default TableBody;
 </script>

--- a/resources/js/Components/Table/TableData.vue
+++ b/resources/js/Components/Table/TableData.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import TableData from "@/Components/TableData.vue";
+
 export default TableData;
 </script>

--- a/resources/js/Components/Table/TableHead.vue
+++ b/resources/js/Components/Table/TableHead.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import TableHead from "@/Components/TableHead.vue";
+
 export default TableHead;
 </script>

--- a/resources/js/Components/Table/TableRow.vue
+++ b/resources/js/Components/Table/TableRow.vue
@@ -1,7 +1,6 @@
-<script setup>
-// Re-export from parent directory for backwards compatibility
-</script>
 <script>
+// Re-export from parent directory for backwards compatibility
 import TableRow from "@/Components/TableRow.vue";
+
 export default TableRow;
 </script>

--- a/resources/js/Pages/AuditLog/partials/ActivityList.vue
+++ b/resources/js/Pages/AuditLog/partials/ActivityList.vue
@@ -57,7 +57,7 @@ const getEventBadgeClass = (event) => {
 				</TableHead>
 				<TableBody>
 					<template v-for="activity in activities" :key="activity.id">
-						<TableRow>
+						<TableRow @click="emit('viewActivity', activity)">
 							<TableData>
 								<span class="text-sm text-gray-600 dark:text-gray-400">
 									{{ activity.created_at }}
@@ -93,7 +93,7 @@ const getEventBadgeClass = (event) => {
 								</span>
 								<span v-else class="text-sm text-gray-400">-</span>
 							</TableData>
-							<TableData>
+							<TableData @click.stop>
 								<SubMenu
 									:items="['View', 'Delete']"
 									:can-edit="permissions?.includes('view user activity')"

--- a/resources/js/Pages/User/partials/UserList.vue
+++ b/resources/js/Pages/User/partials/UserList.vue
@@ -70,7 +70,7 @@ const tableCols = [
 					</TableHead>
 					<TableBody>
 						<template v-for="user in users" :key="user.id">
-							<TableRow>
+							<TableRow @click="emit('openUser', user.id)">
 								<TableData>
 									{{ user.name }}
 								</TableData>
@@ -86,7 +86,7 @@ const tableCols = [
 								<TableData>
 									{{ user.permissions_count }}
 								</TableData>
-								<TableData class="flex justify-end items-center gap-2">
+								<TableData class="flex justify-end items-center gap-2" @click.stop>
 									<button
 										v-if="canAssociateStaff"
 										type="button"


### PR DESCRIPTION
## Summary

Clicking a row in the **User** and **Audit-log** index tables now opens that record's show page, matching the behaviour the **Role** and **Permission** tables already had. All four settings index tables are now consistent.

| Page | Before | After |
|------|--------|-------|
| User | submenu "Open" only | row click → `user.show` |
| Audit-log | submenu "View" only | row click → `audit-log.show` |
| Role | row click (already) | unchanged |
| Permission | row click (already) | unchanged |

## Changes
- `UserList` / `ActivityList`: emit `openUser` / `viewActivity` on the `TableRow` `@click`, and add `@click.stop` on the actions cell so the submenu and the associate-staff button don't trigger navigation.
- **Bug fix** — the `@/Components/Table/*` components were broken re-exports: an empty `<script setup>` was merged over `export default <Component>`, clobbering the real component's `setup` so its `emit` was `undefined` (`$setup.emit is not a function` on row click). Rewritten as clean re-exports, which also repairs the **Document** and **Notes** lists that import the same shims.

## Testing
Verified in-browser at the running app:
- Each of the four index tables navigates to the correct show page on row click (`/user/2`, `/role/1`, `/permission/1`, `/audit-log/40276`).
- Clicking the actions submenu / "Change staff" button does **not** navigate — the associate-staff modal still opens.
- `npm run build` compiles cleanly; no new ESLint issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)