### PR TITLE
Fix: admins who are also staff can view other staff details

### DIFF
--- a/app/Http/Controllers/InstitutionPersonController.php
+++ b/app/Http/Controllers/InstitutionPersonController.php
@@ -169,7 +169,7 @@ class InstitutionPersonController extends Controller
             return redirect()->route('dashboard')->with('error', 'You do not have permission to view staff details');
         }
 
-        if (request()->user()->isStaff()) {
+        if (request()->user()->isStaff() && Gate::denies('view all staff')) {
             if (request()->user()->person->institution->first()->staff->id != $staffId) {
                 return redirect()->route('dashboard')->with('error', 'You do not have permission to view details of this staff');
             }

--- a/tests/Feature/StaffShowAuthorizationTest.php
+++ b/tests/Feature/StaffShowAuthorizationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Institution;
+use App\Models\InstitutionPerson;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffShowAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Create a Person that is an active staff member. */
+    protected function staffPerson(): Person
+    {
+        $institution = Institution::factory()->create();
+        $person = Person::factory()->create();
+        $person->institution()->attach($institution->id, [
+            'staff_number' => 'STAFF' . fake()->unique()->numerify('#####'),
+            'hire_date' => now()->subYears(3),
+        ]);
+
+        $staff = InstitutionPerson::query()
+            ->where('person_id', $person->id)
+            ->where('institution_id', $institution->id)
+            ->firstOrFail();
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $institution->id,
+        ]);
+
+        return $person;
+    }
+
+    protected function staffId(Person $person): int
+    {
+        return $person->institution->first()->staff->id;
+    }
+
+    public function test_admin_who_is_also_staff_can_view_another_staff_details(): void
+    {
+        $adminPerson = $this->staffPerson();
+        $admin = User::factory()->create(['person_id' => $adminPerson->id]);
+        $admin->givePermissionTo(['view staff', 'view all staff']);
+
+        $otherStaff = $this->staffPerson();
+
+        $response = $this->actingAs($admin)
+            ->get(route('staff.show', ['staff' => $this->staffId($otherStaff)]));
+
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionMissing('error');
+    }
+
+    public function test_self_service_staff_cannot_view_another_staff_details(): void
+    {
+        $staffPerson = $this->staffPerson();
+        $staff = User::factory()->create(['person_id' => $staffPerson->id]);
+        $staff->givePermissionTo('view staff');
+
+        $otherStaff = $this->staffPerson();
+
+        $response = $this->actingAs($staff)
+            ->get(route('staff.show', ['staff' => $this->staffId($otherStaff)]));
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('error', 'You do not have permission to view details of this staff');
+    }
+
+    public function test_self_service_staff_can_view_their_own_details(): void
+    {
+        $staffPerson = $this->staffPerson();
+        $staff = User::factory()->create(['person_id' => $staffPerson->id]);
+        $staff->givePermissionTo('view staff');
+
+        $response = $this->actingAs($staff)
+            ->get(route('staff.show', ['staff' => $this->staffId($staffPerson)]));
+
+        $response->assertSessionMissing('error');
+    }
+}


### PR DESCRIPTION
## Problem

In production, an administrator who is **also** an employee could open the staff index but got **"You do not have permission to view details of this staff"** when opening any staff's detail page.

The `show()` ownership guard keyed off `isStaff()`, which resolves to `Person::isStaff()` — simply *"has an institution record" = is an employee*. So every administrator who is also a staff member was trapped into viewing only their own profile.

**Dev vs prod:** in dev, admin accounts aren't linked to staff records, so `isStaff()` is `false` and the guard never fires. In production, real administrators are employees, so it triggers. The error message comes solely from this guard — it was never a permissions/seeding issue.

## Fix

Skip the self-service ownership guard for anyone who can `view all staff`, mirroring how `index()` already gates access:

```php
if (request()->user()->isStaff() && Gate::denies('view all staff')) {
```

- Admins / HR / super-admins (have `view all staff`) → can view any staff's details.
- Self-service staff (no `view all staff`) → still restricted to their own profile.

## Tests

Added `tests/Feature/StaffShowAuthorizationTest.php`:
- ✅ admin-who-is-also-staff can view another staff's details
- ✅ self-service staff cannot view another staff's details (restriction preserved)
- ✅ self-service staff can view their own details

All pass; related suites (Authorization, StaffCreation, AssociateUserStaff) green — 65 tests, no regressions.

## Deploy

Code-only change — ships with the normal deploy, no seeder needed. Clear caches if route/config caching is enabled:

```bash
php artisan optimize:clear
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)