### PR TITLE
Add app:list-api-tokens and app:revoke-api-token commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,26 @@ php artisan db:seed --class=AllPermissionsSeeder --force   # syncs all permissio
 - Tests pass without this because the test database re-seeds before every test (`$seed = true`), masking the gap.
 - The `super-administrator` `Gate::before` override (`app/Providers/AuthServiceProvider.php`) makes `can()` return `true` for any ability, so backend checks can appear to work even when the permission row is missing. **UI that gates on `$page.props.auth.permissions` (the explicit assigned list) will still be hidden** until the permission is actually seeded and assigned — so the feature looks broken/invisible in the browser even for super admins.
 
+#### E. External API Access Tokens (Sanctum)
+
+External apps reach the `/api/*` endpoints (e.g. `GET /api/staff-statistics`) with **Sanctum personal access tokens** scoped by ability — `auth:sanctum` validates the token, `abilities:<name>` enforces the scope (a token lacking it gets 403). Tokens are issued manually by an operator, never seeded or committed. The token lifecycle is managed entirely by three auto-discovered artisan commands:
+
+```bash
+# Issue — prints the plaintext token ONCE (not recoverable afterward)
+php artisan app:issue-api-token user@example.test --name="Audit Service" --ability=staff-statistics:read
+
+# List — audit issued tokens (ID, owner, name, abilities, last used); secrets never shown
+php artisan app:list-api-tokens
+php artisan app:list-api-tokens user@example.test   # filter to one user
+
+# Revoke — by id (ID from the list) or all for a user; effective immediately (next request 401)
+php artisan app:revoke-api-token <id>                       # prompts to confirm
+php artisan app:revoke-api-token --all-for=user@example.test --force
+```
+
+- The `personal_access_tokens.token` column stores only a SHA-256 hash, so a token can be listed/revoked but never re-displayed. Rotate by revoking + re-issuing (there is no rotation endpoint).
+- Design/operational details: `docs/superpowers/specs/2026-06-01-audit-service-api-access-design.md`.
+
 ### 5. Testing
 
 #### A. Create Tests

--- a/app/Console/Commands/ListApiTokens.php
+++ b/app/Console/Commands/ListApiTokens.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ListApiTokens extends Command
+{
+    protected $signature = 'app:list-api-tokens
+        {email? : Optional user email to filter tokens by}';
+
+    protected $description = 'List issued Sanctum personal access tokens and their abilities (secrets are never shown).';
+
+    public function handle(): int
+    {
+        $query = PersonalAccessToken::query()->with('tokenable')->latest('id');
+
+        if ($this->argument('email') !== null) {
+            $user = User::where('email', $this->argument('email'))->first();
+
+            if ($user === null) {
+                $this->error("No user found with email {$this->argument('email')}.");
+
+                return self::FAILURE;
+            }
+
+            $query->where('tokenable_id', $user->getKey())
+                ->where('tokenable_type', $user->getMorphClass());
+        }
+
+        $tokens = $query->get();
+
+        if ($tokens->isEmpty()) {
+            $this->info('No API tokens issued.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'Owner', 'Name', 'Abilities', 'Last used', 'Created'],
+            $tokens->map(fn (PersonalAccessToken $token): array => [
+                $token->getKey(),
+                $token->tokenable?->email ?? '—',
+                $token->name,
+                implode(', ', $token->abilities ?? []),
+                $token->last_used_at?->diffForHumans() ?? 'never',
+                $token->created_at->toDateString(),
+            ])->all(),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RevokeApiToken.php
+++ b/app/Console/Commands/RevokeApiToken.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class RevokeApiToken extends Command
+{
+    protected $signature = 'app:revoke-api-token
+        {id? : The token id to revoke (see app:list-api-tokens)}
+        {--all-for= : Revoke ALL tokens for the user with this email}
+        {--force : Skip the confirmation prompt}';
+
+    protected $description = 'Revoke a Sanctum personal access token by id, or all tokens for a user.';
+
+    public function handle(): int
+    {
+        $id = $this->argument('id');
+        $email = $this->option('all-for');
+
+        if (($id === null) === ($email === null)) {
+            $this->error('Provide either a token id or --all-for=email, not both.');
+
+            return self::FAILURE;
+        }
+
+        return $email !== null
+            ? $this->revokeAllForUser($email)
+            : $this->revokeById($id);
+    }
+
+    protected function revokeAllForUser(string $email): int
+    {
+        $user = User::where('email', $email)->first();
+
+        if ($user === null) {
+            $this->error("No user found with email {$email}.");
+
+            return self::FAILURE;
+        }
+
+        $count = $user->tokens()->count();
+
+        if ($count === 0) {
+            $this->info("No tokens to revoke for {$email}.");
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->option('force') && ! $this->confirm("Revoke all {$count} token(s) for {$email}?")) {
+            $this->info('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $user->tokens()->delete();
+
+        $this->info("Revoked {$count} token(s) for {$email}.");
+
+        return self::SUCCESS;
+    }
+
+    protected function revokeById(string $id): int
+    {
+        $token = PersonalAccessToken::with('tokenable')->find($id);
+
+        if ($token === null) {
+            $this->error("No token found with id {$id}.");
+
+            return self::FAILURE;
+        }
+
+        $owner = $token->tokenable?->email ?? '—';
+        $abilities = implode(', ', $token->abilities ?? []);
+        $this->line("Token #{$token->getKey()} — {$owner} — {$token->name} — [{$abilities}]");
+
+        if (! $this->option('force') && ! $this->confirm("Revoke token #{$token->getKey()}?")) {
+            $this->info('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $token->delete();
+
+        $this->info("Revoked token #{$id}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/docs/superpowers/plans/2026-06-01-audit-service-api-access.md
+++ b/docs/superpowers/plans/2026-06-01-audit-service-api-access.md
@@ -686,3 +686,17 @@ GET /api/staff-statistics
 Authorization: Bearer <token>
 Accept: application/json
 ```
+
+To audit or revoke tokens later:
+
+```bash
+# List issued tokens (no secrets shown); ID column is the revoke handle
+php artisan app:list-api-tokens
+php artisan app:list-api-tokens audit-service@audit.gov.gh   # filter to one user
+
+# Revoke a leaked/retired token — effective immediately (next request gets 401)
+php artisan app:revoke-api-token <id>                        # prompts to confirm
+php artisan app:revoke-api-token --all-for=audit-service@audit.gov.gh --force
+```
+
+There is no rotation endpoint: rotate by revoking the old token and issuing a new one.

--- a/docs/superpowers/specs/2026-06-01-audit-service-api-access-design.md
+++ b/docs/superpowers/specs/2026-06-01-audit-service-api-access-design.md
@@ -36,9 +36,14 @@ attached — access is governed entirely by the token ability. This is acceptabl
 because `StaffStatisticsController::index` performs no `Gate` check; the ability
 is the sole authorization gate, which gives least privilege.
 
-### 2. Token issuance command
+### 2. Token management commands
 
-New command `App\Console\Commands\IssueApiToken`, signature:
+The token lifecycle (issue → list → revoke) is operated entirely from artisan;
+all three commands are auto-discovered from `app/Console/Commands`.
+
+#### 2.1 Issue — `App\Console\Commands\IssueApiToken`
+
+Signature:
 
 ```
 app:issue-api-token {email} {--name=Audit Service Website} {--ability=staff-statistics:read}
@@ -53,6 +58,45 @@ Behavior:
 
 Tokens are issued manually by an operator and handed to the Audit team
 out-of-band. **Tokens are never seeded or committed.**
+
+#### 2.2 List — `App\Console\Commands\ListApiTokens`
+
+Signature:
+
+```
+app:list-api-tokens {email? : optional user email to filter by}
+```
+
+Behavior:
+- Renders a table of issued tokens: **ID, Owner, Name, Abilities, Last used, Created**.
+- Optional `email` argument scopes the list to one user's tokens; an unknown
+  email fails with a clear message and a non-zero exit.
+- Eager-loads `tokenable` to avoid N+1 when resolving owner emails.
+- **Never selects or prints the token hash** — only metadata is shown, so the
+  output is safe to read for auditing. The `ID` column is the handle passed to
+  the revoke command.
+
+#### 2.3 Revoke — `App\Console\Commands\RevokeApiToken`
+
+Signature:
+
+```
+app:revoke-api-token {id? : token id to revoke} {--all-for= : revoke ALL tokens for this user email} {--force}
+```
+
+Behavior:
+- Targets **exactly one** of: a single token by `id`, or every token for a user
+  via `--all-for=email`. Supplying both or neither fails with a non-zero exit.
+- Before deleting, prints a one-line summary of what will be revoked and prompts
+  for confirmation. `--force` skips the prompt for non-interactive use (CI/scripts).
+- Declining the prompt aborts cleanly (exit 0, nothing deleted).
+- Deletes the row(s) from `personal_access_tokens` (`$token->delete()` /
+  `$user->tokens()->delete()`); revocation takes effect immediately on the next
+  request, which then receives **401**.
+
+Revocation is the supported way to disable a leaked or retired token. Because the
+table stores only a SHA-256 hash of the secret, a token can be revoked but never
+re-displayed.
 
 ### 3. Ability enforcement on the route
 
@@ -181,11 +225,27 @@ External Audit app
 6. Command creates a token with the requested ability for the user.
 7. Command with an unknown email fails gracefully (non-zero exit, no token created).
 
+`tests/Feature/ListApiTokensCommandTest.php`:
+8. Lists issued tokens (name + abilities visible); filters by email; empty state;
+   unknown email fails (non-zero exit).
+
+`tests/Feature/RevokeApiTokenCommandTest.php`:
+9. Revokes by id (with `--force` and via confirmation); declining keeps the token;
+   `--all-for` revokes one user's tokens without touching another's; unknown id /
+   unknown email / ambiguous (both) / missing (neither) target all fail.
+
 Tests rely on the existing per-test reseed and model factories.
+
+> Note: content assertions on the `app:list-api-tokens` table use
+> `Artisan::call()` + `Artisan::output()` rather than
+> `$this->artisan()->expectsOutputToContain()`. The latter buffers the table at an
+> 80-column width and wraps the rightmost cells, splitting ability strings and
+> producing false negatives; `Artisan::call()` renders at the table's natural width.
 
 ## Out of scope (YAGNI)
 
-- Login/token-rotation endpoint.
+- Login/token-rotation **endpoint** (HTTP). CLI revocation is provided by
+  `app:revoke-api-token`; rotation is revoke + re-issue.
 - Broad (unrestricted) tokens.
 - Log pruning command / scheduled cleanup.
 - In-app UI for viewing `api_logs`.

--- a/tests/Feature/ListApiTokensCommandTest.php
+++ b/tests/Feature/ListApiTokensCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class ListApiTokensCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_issued_tokens(): void
+    {
+        $user = User::factory()->create(['email' => 'svc@example.test']);
+        $user->createToken('Audit Service Website', ['staff-statistics:read']);
+
+        $exitCode = Artisan::call('app:list-api-tokens');
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Audit Service Website', $output);
+        $this->assertStringContainsString('staff-statistics:read', $output);
+    }
+
+    public function test_it_filters_tokens_by_email(): void
+    {
+        $alice = User::factory()->create(['email' => 'alice@example.test']);
+        $bob = User::factory()->create(['email' => 'bob@example.test']);
+        $alice->createToken('Alice Token', ['staff-statistics:read']);
+        $bob->createToken('Bob Token', ['staff-statistics:read']);
+
+        $exitCode = Artisan::call('app:list-api-tokens', ['email' => 'alice@example.test']);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Alice Token', $output);
+        $this->assertStringNotContainsString('Bob Token', $output);
+    }
+
+    public function test_it_reports_empty_state_when_no_tokens_exist(): void
+    {
+        $this->artisan('app:list-api-tokens')
+            ->expectsOutput('No API tokens issued.')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_fails_for_unknown_email(): void
+    {
+        $this->artisan('app:list-api-tokens', ['email' => 'nobody@example.test'])
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Feature/RevokeApiTokenCommandTest.php
+++ b/tests/Feature/RevokeApiTokenCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\PersonalAccessToken;
+use Tests\TestCase;
+
+class RevokeApiTokenCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_revokes_a_token_by_id_with_force(): void
+    {
+        $user = User::factory()->create();
+        $keep = $user->createToken('Keep', ['staff-statistics:read'])->accessToken;
+        $revoke = $user->createToken('Revoke', ['staff-statistics:read'])->accessToken;
+
+        $this->artisan('app:revoke-api-token', ['id' => $revoke->getKey(), '--force' => true])
+            ->assertExitCode(0);
+
+        $this->assertNull(PersonalAccessToken::find($revoke->getKey()));
+        $this->assertNotNull(PersonalAccessToken::find($keep->getKey()));
+    }
+
+    public function test_it_revokes_a_token_by_id_after_confirmation(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('Revoke', ['staff-statistics:read'])->accessToken;
+
+        $this->artisan('app:revoke-api-token', ['id' => $token->getKey()])
+            ->expectsConfirmation("Revoke token #{$token->getKey()}?", 'yes')
+            ->assertExitCode(0);
+
+        $this->assertNull(PersonalAccessToken::find($token->getKey()));
+    }
+
+    public function test_it_keeps_the_token_when_confirmation_declined(): void
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('Keep', ['staff-statistics:read'])->accessToken;
+
+        $this->artisan('app:revoke-api-token', ['id' => $token->getKey()])
+            ->expectsConfirmation("Revoke token #{$token->getKey()}?", 'no')
+            ->expectsOutput('Aborted.')
+            ->assertExitCode(0);
+
+        $this->assertNotNull(PersonalAccessToken::find($token->getKey()));
+    }
+
+    public function test_it_revokes_all_tokens_for_a_user(): void
+    {
+        $target = User::factory()->create(['email' => 'target@example.test']);
+        $other = User::factory()->create(['email' => 'other@example.test']);
+        $target->createToken('A', ['staff-statistics:read']);
+        $target->createToken('B', ['staff-statistics:read']);
+        $other->createToken('C', ['staff-statistics:read']);
+
+        $this->artisan('app:revoke-api-token', ['--all-for' => 'target@example.test', '--force' => true])
+            ->assertExitCode(0);
+
+        $this->assertSame(0, $target->fresh()->tokens()->count());
+        $this->assertSame(1, $other->fresh()->tokens()->count());
+    }
+
+    public function test_it_reports_when_user_has_no_tokens_to_revoke(): void
+    {
+        User::factory()->create(['email' => 'empty@example.test']);
+
+        $this->artisan('app:revoke-api-token', ['--all-for' => 'empty@example.test', '--force' => true])
+            ->expectsOutput('No tokens to revoke for empty@example.test.')
+            ->assertExitCode(0);
+    }
+
+    public function test_it_fails_for_unknown_id(): void
+    {
+        $this->artisan('app:revoke-api-token', ['id' => 999, '--force' => true])
+            ->assertExitCode(1);
+    }
+
+    public function test_it_fails_for_unknown_all_for_email(): void
+    {
+        $this->artisan('app:revoke-api-token', ['--all-for' => 'nobody@example.test', '--force' => true])
+            ->assertExitCode(1);
+    }
+
+    public function test_it_fails_when_both_id_and_all_for_supplied(): void
+    {
+        $this->artisan('app:revoke-api-token', ['id' => 1, '--all-for' => 'someone@example.test'])
+            ->assertExitCode(1);
+    }
+
+    public function test_it_fails_when_neither_id_nor_all_for_supplied(): void
+    {
+        $this->artisan('app:revoke-api-token')
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
## Summary

Completes the Sanctum API token lifecycle (**issue → list → revoke**). Previously only `app:issue-api-token` existed, so auditing or disabling a token meant dropping into `tinker` or running raw SQL against `personal_access_tokens` — and there was no supported revocation path at all.

## What's added

- **`app:list-api-tokens [email?]`** — tabular audit of issued tokens (ID, Owner, Name, Abilities, Last used, Created). Optional email filter; eager-loads `tokenable` to avoid N+1. **Never prints the token hash** — safe for auditing. The ID column is the revoke handle.
- **`app:revoke-api-token [id?] [--all-for=email] [--force]`** — revoke a single token by id, or every token for a user via `--all-for`. Shows what will be deleted and prompts y/N; `--force` skips for CI/scripts. Rejects ambiguous (both) or missing (neither) targets. Revocation is effective immediately — the next request gets 401.

Both commands auto-discover from `app/Console/Commands` (no registration needed) and follow the existing `IssueApiToken` conventions.

## Tests

`tests/Feature/ListApiTokensCommandTest.php` (4) and `RevokeApiTokenCommandTest.php` (9) — **13 cases, all passing**. Cover happy paths, email filtering, empty states, unknown id/email, declined confirmation, and the target-validation guards.

> Note: list-content assertions use `Artisan::call()` + `Artisan::output()` rather than `$this->artisan()->expectsOutputToContain()`, which buffers the table at 80 cols and wraps cells (splitting ability strings into false negatives).

## Docs

Documented the full token workflow in `CLAUDE.md` (new "External API Access Tokens" subsection) and the audit-service API spec + plan.

## Verification

- `php artisan test tests/Feature/ListApiTokensCommandTest.php tests/Feature/RevokeApiTokenCommandTest.php` → 13 passed
- `vendor/bin/pint --dirty` → clean
- `php artisan list` → both commands registered

No migrations, routes, or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)