### PR TITLE
feat: Rank distribution Excel exports for units and departments

### DIFF
--- a/app/Exports/RankDistribution/DepartmentsRankDistributionExport.php
+++ b/app/Exports/RankDistribution/DepartmentsRankDistributionExport.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Exports\RankDistribution;
+
+use App\Services\RankDistributionService;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class DepartmentsRankDistributionExport implements FromArray, ShouldAutoSize, WithHeadings, WithStyles, WithTitle
+{
+    use Exportable;
+
+    private ?array $matrix = null;
+
+    public function title(): string
+    {
+        return 'Ranks by Department';
+    }
+
+    public function headings(): array
+    {
+        $departmentNames = array_column($this->matrix()['columns'], 'name');
+
+        return array_merge(['Rank'], $departmentNames, ['Total']);
+    }
+
+    public function array(): array
+    {
+        $matrix = $this->matrix();
+
+        $rows = [];
+        foreach ($matrix['rows'] as $rank) {
+            $rows[] = array_merge([$rank['name']], array_values($rank['counts']), [$rank['total']]);
+        }
+
+        $rows[] = array_merge(['Total'], array_values($matrix['column_totals']), [$matrix['grand_total']]);
+
+        return $rows;
+    }
+
+    public function styles(Worksheet $sheet): array
+    {
+        return [1 => ['font' => ['bold' => true]]];
+    }
+
+    private function matrix(): array
+    {
+        return $this->matrix ??= app(RankDistributionService::class)->matrixByDepartments();
+    }
+}

--- a/app/Exports/RankDistribution/ServiceRankDistributionExport.php
+++ b/app/Exports/RankDistribution/ServiceRankDistributionExport.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Exports\RankDistribution;
+
+use App\Services\RankDistributionService;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class ServiceRankDistributionExport implements FromArray, ShouldAutoSize, WithHeadings, WithStyles, WithTitle
+{
+    use Exportable;
+
+    public function title(): string
+    {
+        return 'Service Rank Distribution';
+    }
+
+    public function headings(): array
+    {
+        return ['Rank', 'Staff Count'];
+    }
+
+    public function array(): array
+    {
+        $distribution = app(RankDistributionService::class)->forUnits(null);
+
+        $rows = array_map(fn (array $rank) => [$rank['name'], $rank['count']], $distribution);
+        $rows[] = ['Total', array_sum(array_column($distribution, 'count'))];
+
+        return $rows;
+    }
+
+    public function styles(Worksheet $sheet): array
+    {
+        return [1 => ['font' => ['bold' => true]]];
+    }
+}

--- a/app/Exports/RankDistribution/UnitRankDistributionExport.php
+++ b/app/Exports/RankDistribution/UnitRankDistributionExport.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Exports\RankDistribution;
+
+use App\Models\Unit;
+use App\Services\RankDistributionService;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class UnitRankDistributionExport implements FromArray, ShouldAutoSize, WithHeadings, WithStyles, WithTitle
+{
+    use Exportable;
+
+    private ?array $matrix = null;
+
+    public function __construct(private readonly Unit $unit) {}
+
+    public function title(): string
+    {
+        return 'Rank Distribution';
+    }
+
+    public function headings(): array
+    {
+        $unitNames = array_map(
+            fn (array $column) => str_repeat('  ', $column['depth']) . $column['name'],
+            $this->matrix()['columns']
+        );
+
+        return array_merge(['Rank'], $unitNames, ['Total']);
+    }
+
+    public function array(): array
+    {
+        $matrix = $this->matrix();
+
+        $rows = [];
+        foreach ($matrix['rows'] as $rank) {
+            $rows[] = array_merge([$rank['name']], array_values($rank['counts']), [$rank['total']]);
+        }
+
+        $rows[] = array_merge(['Total'], array_values($matrix['column_totals']), [$matrix['grand_total']]);
+
+        return $rows;
+    }
+
+    public function styles(Worksheet $sheet): array
+    {
+        return [1 => ['font' => ['bold' => true]]];
+    }
+
+    private function matrix(): array
+    {
+        return $this->matrix ??= app(RankDistributionService::class)->matrixForUnit($this->unit);
+    }
+}

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Exports\RankDistribution\DepartmentsRankDistributionExport;
+use App\Exports\RankDistribution\ServiceRankDistributionExport;
+use App\Exports\RankDistribution\UnitRankDistributionExport;
 use App\Exports\UnitStaffExport;
 use App\Http\Requests\StaffDirectoryFilterRequest;
 use App\Http\Requests\StoreUnitRequest;
@@ -10,10 +13,10 @@ use App\Models\InstitutionPerson;
 use App\Models\Job;
 use App\Models\JobCategory;
 use App\Models\Unit;
+use App\Services\RankDistributionService;
 use App\Services\UnitHierarchy;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Maatwebsite\Excel\Facades\Excel;
@@ -185,7 +188,7 @@ class UnitController extends Controller
         ]);
     }
 
-    public function show(StaffDirectoryFilterRequest $request, $unit, UnitHierarchy $hierarchy)
+    public function show(StaffDirectoryFilterRequest $request, $unit, UnitHierarchy $hierarchy, RankDistributionService $rankDistribution)
     {
         $unit = Unit::query()
             ->with([
@@ -208,7 +211,7 @@ class UnitController extends Controller
 
         $stats = $this->buildRootStats($unit, $allIds);
         $subs = $this->buildSubUnitCards($unit, $childIdMap);
-        $rankDistribution = $this->buildRankDistribution($allIds);
+        $rankDistribution = $rankDistribution->forUnits($allIds);
 
         return Inertia::render('Unit/Show', [
             'unit' => [
@@ -301,52 +304,6 @@ class UnitController extends Controller
                 'female_staff' => (int) ($totals->female ?? 0),
             ];
         })->values()->all();
-    }
-
-    /**
-     * @param  int[]  $allIds
-     * @return array<int, array<string, mixed>>
-     */
-    private function buildRankDistribution(array $allIds): array
-    {
-        return Job::query()
-            ->select('jobs.id', 'jobs.name')
-            ->selectRaw('COUNT(DISTINCT institution_person.id) as staff_count')
-            ->join('job_staff', function ($join) {
-                $join->on('jobs.id', '=', 'job_staff.job_id')
-                    ->whereNull('job_staff.end_date')
-                    ->whereNull('job_staff.deleted_at');
-            })
-            ->join('institution_person', 'institution_person.id', '=', 'job_staff.staff_id')
-            ->join('staff_unit', function ($join) use ($allIds) {
-                $join->on('staff_unit.staff_id', '=', 'institution_person.id')
-                    ->whereIn('staff_unit.unit_id', $allIds)
-                    ->whereNull('staff_unit.end_date')
-                    ->whereNull('staff_unit.deleted_at');
-            })
-            ->join('job_categories', 'jobs.job_category_id', '=', 'job_categories.id')
-            ->whereExists(function ($query) {
-                $query->select(DB::raw(1))
-                    ->from('status')
-                    ->whereColumn('status.staff_id', 'institution_person.id')
-                    ->whereNull('status.deleted_at')
-                    ->where('status.status', 'A')
-                    ->where(function ($inner) {
-                        $inner->whereNull('status.end_date')
-                            ->orWhere('status.end_date', '>', now());
-                    });
-            })
-            ->groupBy('jobs.id', 'jobs.name', 'job_categories.level')
-            ->orderBy('job_categories.level')
-            ->get()
-            ->map(fn ($job) => [
-                'id' => $job->id,
-                'name' => $job->name,
-                'full_name' => $job->name,
-                'count' => (int) $job->staff_count,
-            ])
-            ->values()
-            ->all();
     }
 
     public function staff(StaffDirectoryFilterRequest $request, Unit $unit, UnitHierarchy $hierarchy)
@@ -617,5 +574,27 @@ class UnitController extends Controller
                 // str_replace(array("/", "\\"), '-', $unit->name)
                 . ' staff.xlsx'
         );
+    }
+
+    public function downloadRankDistribution(Unit $unit)
+    {
+        return Excel::download(
+            new UnitRankDistributionExport($unit),
+            Str::of($unit->name)
+                ->title()
+                ->replaceMatches('/[^A-Za-z0-9]++/', '-')
+                ->__toString()
+                . ' rank distribution.xlsx'
+        );
+    }
+
+    public function downloadDepartmentsRankDistribution()
+    {
+        return Excel::download(new DepartmentsRankDistributionExport, 'departments-rank-distribution.xlsx');
+    }
+
+    public function downloadServiceRankDistribution()
+    {
+        return Excel::download(new ServiceRankDistributionExport, 'audit-service-rank-distribution.xlsx');
     }
 }

--- a/app/Services/RankDistributionService.php
+++ b/app/Services/RankDistributionService.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Job;
+use App\Models\Unit;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class RankDistributionService
+{
+    public function __construct(private readonly UnitHierarchy $hierarchy) {}
+
+    /**
+     * Count active staff per rank across the given unit ids.
+     * Pass null to count across every unit (service-wide).
+     *
+     * @param  int[]|null  $unitIds
+     * @return array<int, array{id: int, name: string, full_name: string, count: int}>
+     */
+    public function forUnits(?array $unitIds): array
+    {
+        return $this->baseQuery($unitIds)
+            ->select('jobs.id', 'jobs.name')
+            ->selectRaw('COUNT(DISTINCT institution_person.id) as staff_count')
+            ->groupBy('jobs.id', 'jobs.name', 'job_categories.level')
+            ->orderBy('job_categories.level')
+            ->orderBy('jobs.name')
+            ->get()
+            ->map(fn ($job) => [
+                'id' => $job->id,
+                'name' => $job->name,
+                'full_name' => $job->name,
+                'count' => (int) $job->staff_count,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Rank rows against every unit in the given unit's subtree as columns,
+     * depth-first order, the unit itself first.
+     *
+     * @return array{
+     *   columns: array<int, array{id: int, name: string, depth: int}>,
+     *   rows: array<int, array{id: int, name: string, counts: array<int, int>, total: int}>,
+     *   column_totals: array<int, int>,
+     *   grand_total: int
+     * }
+     */
+    public function matrixForUnit(Unit $unit): array
+    {
+        $columns = $this->hierarchy->orderedSubtree($unit);
+        $allIds = array_column($columns, 'id');
+
+        return $this->buildMatrix($columns, $this->cellCounts($allIds), $this->forUnits($allIds));
+    }
+
+    /**
+     * Rank rows against every department as columns (alphabetical), each
+     * department's counts aggregated over its entire subtree.
+     *
+     * @return array{
+     *   columns: array<int, array{id: int, name: string, depth: int}>,
+     *   rows: array<int, array{id: int, name: string, counts: array<int, int>, total: int}>,
+     *   column_totals: array<int, int>,
+     *   grand_total: int
+     * }
+     */
+    public function matrixByDepartments(): array
+    {
+        $departments = Unit::query()->departments()->orderBy('name')->get(['id', 'name']);
+
+        $columns = [];
+        $cells = [];
+        $allIds = [];
+        foreach ($departments as $department) {
+            $columns[] = ['id' => $department->id, 'name' => $department->name, 'depth' => 0];
+
+            $subtreeIds = $this->hierarchy->descendantIds($department);
+            $allIds = array_merge($allIds, $subtreeIds);
+
+            foreach ($this->forUnits($subtreeIds) as $rank) {
+                $cells[$rank['id']][$department->id] = $rank['count'];
+            }
+        }
+
+        return $this->buildMatrix($columns, $cells, $this->forUnits(array_values(array_unique($allIds))));
+    }
+
+    /**
+     * Distinct staff count per rank per unit for the given unit ids.
+     *
+     * @param  int[]  $unitIds
+     * @return array<int, array<int, int>> keyed by rank id, then unit id
+     */
+    private function cellCounts(array $unitIds): array
+    {
+        $rows = $this->baseQuery($unitIds)
+            ->select('jobs.id as rank_id', 'staff_unit.unit_id')
+            ->selectRaw('COUNT(DISTINCT institution_person.id) as staff_count')
+            ->groupBy('jobs.id', 'staff_unit.unit_id')
+            ->get();
+
+        $cells = [];
+        foreach ($rows as $row) {
+            $cells[(int) $row->rank_id][(int) $row->unit_id] = (int) $row->staff_count;
+        }
+
+        return $cells;
+    }
+
+    /**
+     * Rank totals come from an aggregate DISTINCT count over the full id set,
+     * not a row sum, so they reconcile with the counts shown on the unit page
+     * even when a staff member holds active assignments in several units.
+     *
+     * @param  array<int, array{id: int, name: string, depth: int}>  $columns
+     * @param  array<int, array<int, int>>  $cells
+     * @param  array<int, array{id: int, name: string, full_name: string, count: int}>  $rankTotals
+     * @return array{
+     *   columns: array<int, array{id: int, name: string, depth: int}>,
+     *   rows: array<int, array{id: int, name: string, counts: array<int, int>, total: int}>,
+     *   column_totals: array<int, int>,
+     *   grand_total: int
+     * }
+     */
+    private function buildMatrix(array $columns, array $cells, array $rankTotals): array
+    {
+        $columnTotals = array_fill_keys(array_column($columns, 'id'), 0);
+        $grandTotal = 0;
+        $rows = [];
+
+        foreach ($rankTotals as $rank) {
+            $counts = [];
+            foreach ($columns as $column) {
+                $count = $cells[$rank['id']][$column['id']] ?? 0;
+                $counts[$column['id']] = $count;
+                $columnTotals[$column['id']] += $count;
+            }
+
+            $grandTotal += $rank['count'];
+            $rows[] = [
+                'id' => $rank['id'],
+                'name' => $rank['name'],
+                'counts' => $counts,
+                'total' => $rank['count'],
+            ];
+        }
+
+        return [
+            'columns' => $columns,
+            'rows' => $rows,
+            'column_totals' => $columnTotals,
+            'grand_total' => $grandTotal,
+        ];
+    }
+
+    /**
+     * Active staff joined to their current rank and current unit assignment,
+     * optionally restricted to the given unit ids.
+     *
+     * @param  int[]|null  $unitIds
+     */
+    private function baseQuery(?array $unitIds): Builder
+    {
+        return Job::query()
+            ->join('job_staff', function ($join) {
+                $join->on('jobs.id', '=', 'job_staff.job_id')
+                    ->whereNull('job_staff.end_date')
+                    ->whereNull('job_staff.deleted_at');
+            })
+            ->join('institution_person', 'institution_person.id', '=', 'job_staff.staff_id')
+            ->join('staff_unit', function ($join) use ($unitIds) {
+                $join->on('staff_unit.staff_id', '=', 'institution_person.id')
+                    ->whereNull('staff_unit.end_date')
+                    ->whereNull('staff_unit.deleted_at');
+
+                if ($unitIds !== null) {
+                    $join->whereIn('staff_unit.unit_id', $unitIds);
+                }
+            })
+            ->join('job_categories', 'jobs.job_category_id', '=', 'job_categories.id')
+            ->whereExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('status')
+                    ->whereColumn('status.staff_id', 'institution_person.id')
+                    ->whereNull('status.deleted_at')
+                    ->where('status.status', 'A')
+                    ->where(function ($inner) {
+                        $inner->whereNull('status.end_date')
+                            ->orWhere('status.end_date', '>', now());
+                    });
+            });
+    }
+}

--- a/app/Services/UnitHierarchy.php
+++ b/app/Services/UnitHierarchy.php
@@ -40,6 +40,41 @@ class UnitHierarchy
     }
 
     /**
+     * Depth-first ordered subtree: the unit itself first, then every active
+     * descendant, siblings ordered by name. Same active-unit filters as
+     * descendantIds() (end_date and deleted_at must be null).
+     *
+     * @return array<int, array{id: int, name: string, depth: int}>
+     */
+    public function orderedSubtree(Unit $unit): array
+    {
+        $records = DB::table('units')
+            ->whereIn('id', $this->descendantIdsFromId($unit->id))
+            ->orderBy('name')
+            ->get(['id', 'name', 'unit_id']);
+
+        $childrenByParent = [];
+        foreach ($records as $record) {
+            $childrenByParent[$record->unit_id][] = $record;
+        }
+
+        $ordered = [];
+        $visit = function (object $record, int $depth) use (&$visit, &$ordered, $childrenByParent): void {
+            $ordered[] = ['id' => (int) $record->id, 'name' => $record->name, 'depth' => $depth];
+            foreach ($childrenByParent[$record->id] ?? [] as $child) {
+                $visit($child, $depth + 1);
+            }
+        };
+
+        $root = $records->firstWhere('id', $unit->id);
+        if ($root !== null) {
+            $visit($root, 0);
+        }
+
+        return $ordered;
+    }
+
+    /**
      * BFS over the active unit tree starting from $id, returning $id plus all descendant IDs.
      *
      * @return int[]

--- a/resources/js/Pages/Unit/Index.vue
+++ b/resources/js/Pages/Unit/Index.vue
@@ -1,6 +1,6 @@
 <script setup>
 import MainLayout from "@/Layouts/NewAuthenticated.vue";
-import { Head } from "@inertiajs/vue3";
+import { Head, usePage } from "@inertiajs/vue3";
 import { ref, computed, onMounted } from "vue";
 import { router } from "@inertiajs/vue3";
 import Pagination from "../../Components/Pagination.vue";
@@ -13,6 +13,7 @@ import UnitsList from "./partials/UnitsList.vue";
 import { useNavigation } from "@/Composables/navigation";
 import { useSearch } from "@/Composables/search";
 import {
+	ArrowDownTrayIcon,
 	ChevronLeftIcon,
 	ChevronRightIcon,
 	PlusIcon,
@@ -72,16 +73,37 @@ const breadCrumbLinks = [
 				: "/institution",
 	},
 ];
-const pageActions = [
-	{
+const canDownload = computed(() =>
+	usePage().props?.auth.permissions?.includes("download unit staff"),
+);
+const pageActions = computed(() => {
+	const actions = [];
+	if (canDownload.value) {
+		actions.push(
+			{
+				name: "Export by Department",
+				icon: ArrowDownTrayIcon,
+			},
+			{
+				name: "Export Service Ranks",
+				icon: ArrowDownTrayIcon,
+			},
+		);
+	}
+	actions.push({
 		name: "Add Unit",
 		color: "primary",
 		icon: PlusIcon,
-	},
-];
+	});
+	return actions;
+});
 const buttonClicked = (text) => {
 	if (text === "Add Unit") {
 		toggle();
+	} else if (text === "Export by Department") {
+		window.location = route("export.units.rank-distribution.departments");
+	} else if (text === "Export Service Ranks") {
+		window.location = route("export.units.rank-distribution.service");
 	}
 };
 const stats = ref([]);

--- a/resources/js/Pages/Unit/Show.vue
+++ b/resources/js/Pages/Unit/Show.vue
@@ -108,6 +108,8 @@ const handleUnitDeleted = () => {
 				<RankDistributionSection
 					v-if="props.rank_distribution?.length > 0"
 					:distribution="props.rank_distribution"
+					:unit-id="props.unit?.id"
+					:can-download="permissions?.includes('download unit staff')"
 				/>
 
 				<!-- Staff Directory -->

--- a/resources/js/Pages/Unit/partials/RankDistributionSection.vue
+++ b/resources/js/Pages/Unit/partials/RankDistributionSection.vue
@@ -10,6 +10,7 @@ import RankDistributionChart from "@/Components/Charts/RankDistributionChart.vue
 import {
 	ChevronDownIcon,
 	ArrowsPointingOutIcon,
+	ArrowDownTrayIcon,
 	XMarkIcon,
 } from "@heroicons/vue/24/outline";
 
@@ -17,6 +18,14 @@ const props = defineProps({
 	distribution: {
 		type: Array,
 		required: true,
+	},
+	unitId: {
+		type: Number,
+		default: null,
+	},
+	canDownload: {
+		type: Boolean,
+		default: false,
 	},
 });
 
@@ -42,22 +51,32 @@ const closeFullScreen = () => {
 <template>
 	<section v-if="distribution && distribution.length > 0">
 		<!-- Collapsible Header -->
-		<button
-			type="button"
-			class="flex items-center justify-between w-full mb-4 group"
-			@click="toggleCollapse"
-		>
-			<h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-				Rank Distribution
-				<span class="text-sm font-normal text-gray-500 dark:text-gray-400">
-					({{ distribution.length }} ranks)
-				</span>
-			</h2>
-			<ChevronDownIcon
-				class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform duration-200 group-hover:text-gray-700 dark:group-hover:text-gray-300"
-				:class="{ '-rotate-180': !isCollapsed }"
-			/>
-		</button>
+		<div class="flex items-center justify-between gap-4 mb-4">
+			<button
+				type="button"
+				class="flex items-center justify-between flex-1 group"
+				@click="toggleCollapse"
+			>
+				<h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+					Rank Distribution
+					<span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+						({{ distribution.length }} ranks)
+					</span>
+				</h2>
+				<ChevronDownIcon
+					class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform duration-200 group-hover:text-gray-700 dark:group-hover:text-gray-300"
+					:class="{ '-rotate-180': !isCollapsed }"
+				/>
+			</button>
+			<a
+				v-if="canDownload && unitId"
+				class="inline-flex items-center gap-x-1.5 rounded-md bg-white dark:bg-gray-800 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 whitespace-nowrap"
+				:href="route('export.unit.rank-distribution', { unit: unitId })"
+			>
+				<ArrowDownTrayIcon class="-ml-0.5 h-5 w-5 text-gray-400" />
+				Export to Excel
+			</a>
+		</div>
 
 		<!-- Collapsible Content -->
 		<transition

--- a/routes/web.php
+++ b/routes/web.php
@@ -256,6 +256,9 @@ Route::controller(UnitController::class)->middleware(['auth', 'password_changed'
     Route::get('/unit/{unit}/details', 'details')->middleware('can:view unit')->name('unit.details');
     Route::post('/unit/{unit}/details', 'addSub')->middleware('can:create unit')->name('unit.add-sub');
     Route::get('/unit/{unit}/download', 'download')->middleware('can:download unit staff')->name('export.unit.staff');
+    Route::get('/unit/{unit}/rank-distribution/download', 'downloadRankDistribution')->middleware('can:download unit staff')->name('export.unit.rank-distribution');
+    Route::get('/units/rank-distribution/departments/download', 'downloadDepartmentsRankDistribution')->middleware('can:download unit staff')->name('export.units.rank-distribution.departments');
+    Route::get('/units/rank-distribution/service/download', 'downloadServiceRankDistribution')->middleware('can:download unit staff')->name('export.units.rank-distribution.service');
 });
 
 // Unit Office Management

--- a/tests/Feature/Unit/RankDistributionExportTest.php
+++ b/tests/Feature/Unit/RankDistributionExportTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature\Unit;
+
+use App\Exports\RankDistribution\DepartmentsRankDistributionExport;
+use App\Exports\RankDistribution\ServiceRankDistributionExport;
+use App\Exports\RankDistribution\UnitRankDistributionExport;
+use App\Models\InstitutionPerson;
+use App\Models\Job;
+use App\Models\JobCategory;
+use App\Models\Person;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Maatwebsite\Excel\Facades\Excel;
+use Tests\TestCase;
+
+class RankDistributionExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->user->givePermissionTo('download unit staff');
+    }
+
+    private function makeActiveStaff(Unit $unit, ?Job $rank = null): InstitutionPerson
+    {
+        $person = Person::factory()->create();
+        $staff = InstitutionPerson::factory()->create([
+            'institution_id' => $unit->institution_id,
+            'person_id' => $person->id,
+        ]);
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $unit->institution_id,
+        ]);
+        $staff->units()->attach($unit->id, ['start_date' => now()->subYear()]);
+        if ($rank) {
+            $staff->ranks()->attach($rank->id, ['start_date' => now()->subYear()]);
+        }
+
+        return $staff;
+    }
+
+    private function makeRank(string $name, int $level): Job
+    {
+        return Job::factory()->create([
+            'name' => $name,
+            'job_category_id' => JobCategory::factory()->create(['level' => $level])->id,
+        ]);
+    }
+
+    public function test_unit_export_route_downloads_file(): void
+    {
+        Excel::fake();
+
+        $root = Unit::factory()->create(['unit_id' => null, 'name' => 'Finance']);
+
+        $this->actingAs($this->user)
+            ->get(route('export.unit.rank-distribution', ['unit' => $root->id]))
+            ->assertOk();
+
+        Excel::assertDownloaded('Finance rank distribution.xlsx');
+    }
+
+    public function test_unit_matrix_headings_list_units_depth_first_with_zero_staff_columns(): void
+    {
+        $root = Unit::factory()->create(['unit_id' => null, 'name' => 'Audit Department']);
+        $childB = Unit::factory()->create(['unit_id' => $root->id, 'institution_id' => $root->institution_id, 'name' => 'Beta Division']);
+        Unit::factory()->create(['unit_id' => $root->id, 'institution_id' => $root->institution_id, 'name' => 'Alpha Division']);
+        Unit::factory()->create(['unit_id' => $childB->id, 'institution_id' => $root->institution_id, 'name' => 'Beta Unit One']);
+
+        $export = new UnitRankDistributionExport($root);
+
+        $this->assertSame(
+            [
+                'Rank',
+                'Audit Department',
+                '  Alpha Division',
+                '  Beta Division',
+                '    Beta Unit One',
+                'Total',
+            ],
+            $export->headings()
+        );
+    }
+
+    public function test_unit_matrix_counts_and_totals(): void
+    {
+        $root = Unit::factory()->create(['unit_id' => null, 'name' => 'Audit Department']);
+        $child = Unit::factory()->create(['unit_id' => $root->id, 'institution_id' => $root->institution_id, 'name' => 'Alpha Division']);
+        $grand = Unit::factory()->create(['unit_id' => $child->id, 'institution_id' => $root->institution_id, 'name' => 'Alpha Unit']);
+
+        $director = $this->makeRank('Director', 1);
+        $officer = $this->makeRank('Officer', 2);
+
+        $this->makeActiveStaff($root, $director);
+        $this->makeActiveStaff($child, $officer);
+        $this->makeActiveStaff($grand, $officer);
+        $this->makeActiveStaff($grand, $officer);
+
+        $export = new UnitRankDistributionExport($root);
+
+        $this->assertSame(
+            [
+                ['Director', 1, 0, 0, 1],
+                ['Officer', 0, 1, 2, 3],
+                ['Total', 1, 1, 2, 4],
+            ],
+            $export->array()
+        );
+    }
+
+    public function test_departments_export_aggregates_each_department_subtree(): void
+    {
+        $alpha = Unit::factory()->department()->create(['name' => 'Alpha Department']);
+        $beta = Unit::factory()->department()->create(['name' => 'Beta Department']);
+        $alphaSub = Unit::factory()->create(['unit_id' => $alpha->id, 'institution_id' => $alpha->institution_id, 'name' => 'Alpha Division']);
+
+        $officer = $this->makeRank('Officer', 1);
+
+        $this->makeActiveStaff($alphaSub, $officer);
+        $this->makeActiveStaff($alphaSub, $officer);
+        $this->makeActiveStaff($beta, $officer);
+
+        $export = new DepartmentsRankDistributionExport;
+
+        $this->assertSame(['Rank', 'Alpha Department', 'Beta Department', 'Total'], $export->headings());
+        $this->assertSame(
+            [
+                ['Officer', 2, 1, 3],
+                ['Total', 2, 1, 3],
+            ],
+            $export->array()
+        );
+    }
+
+    public function test_service_export_lists_ranks_ordered_by_level_with_total(): void
+    {
+        $unitA = Unit::factory()->create(['unit_id' => null]);
+        $unitB = Unit::factory()->create(['unit_id' => null]);
+
+        $director = $this->makeRank('Director', 1);
+        $officer = $this->makeRank('Officer', 2);
+
+        $this->makeActiveStaff($unitA, $officer);
+        $this->makeActiveStaff($unitB, $officer);
+        $this->makeActiveStaff($unitB, $director);
+
+        $export = new ServiceRankDistributionExport;
+
+        $this->assertSame(['Rank', 'Staff Count'], $export->headings());
+        $this->assertSame(
+            [
+                ['Director', 1],
+                ['Officer', 2],
+                ['Total', 3],
+            ],
+            $export->array()
+        );
+    }
+
+    public function test_export_routes_require_download_unit_staff_permission(): void
+    {
+        $unit = Unit::factory()->create(['unit_id' => null]);
+        $userWithoutPermission = User::factory()->create();
+
+        $this->actingAs($userWithoutPermission)
+            ->get(route('export.unit.rank-distribution', ['unit' => $unit->id]))
+            ->assertForbidden();
+
+        $this->actingAs($userWithoutPermission)
+            ->get(route('export.units.rank-distribution.departments'))
+            ->assertForbidden();
+
+        $this->actingAs($userWithoutPermission)
+            ->get(route('export.units.rank-distribution.service'))
+            ->assertForbidden();
+    }
+
+    public function test_index_export_routes_download_files(): void
+    {
+        Excel::fake();
+
+        $this->actingAs($this->user)
+            ->get(route('export.units.rank-distribution.departments'))
+            ->assertOk();
+        $this->actingAs($this->user)
+            ->get(route('export.units.rank-distribution.service'))
+            ->assertOk();
+
+        Excel::assertDownloaded('departments-rank-distribution.xlsx');
+        Excel::assertDownloaded('audit-service-rank-distribution.xlsx');
+    }
+}


### PR DESCRIPTION
## Summary

Adds three Excel exports for staff rank distribution, surfaced with permission-gated download buttons in the Unit UI:

- **Per-unit matrix** — ranks × every unit in the subtree (depth-first, indented), from a unit's Show page.
- **By-department matrix** — ranks × each department (alphabetical), each column aggregated over the department's whole subtree. From the Unit index.
- **Service-wide** — ranks × total staff count across all units. From the Unit index.

### Implementation
- New `RankDistributionService` centralizes the active-staff-per-rank query (active status, current rank, current unit assignment) and builds the matrices. Replaces the inline `buildRankDistribution` previously in `UnitController`.
- New `UnitHierarchy::orderedSubtree()` produces the depth-first, name-ordered column list.
- Three `App\Exports\RankDistribution\*` export classes (`FromArray` + headings/styles/auto-size).
- Three routes gated on the `download unit staff` permission; UI buttons gated on the same permission via `auth.permissions`.
- Rank/column totals use an aggregate `DISTINCT` count (not a row-sum) so they reconcile with the unit page even when a staff member holds active assignments in several units.

## Testing

**Automated** — `tests/Feature/Unit/RankDistributionExportTest.php`: 7 tests / 18 assertions passing, including 403 gating when the permission is absent.

**End-to-end (manual)** — Verified in a browser against seeded data (24 staff, 2 departments, 8 units) logged in as a super-admin:
- Both index export buttons and the per-unit Export-to-Excel button render (permission-gated) and download their `.xlsx`.
- Parsed all three files; every count and total reconciles:
  - Service-wide: ranks ordered by category level, grand total 24.
  - By department: alphabetical columns, column totals 12 / 12 = 24, zero cells filled.
  - Per-unit (Finance): depth-first indented columns, column totals 1/2/4/5 = 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXvbygRoMxjPsJxTdsH86p