### PR TITLE
feat: add app:create-service-account command

### DIFF
--- a/app/Console/Commands/CreateServiceAccount.php
+++ b/app/Console/Commands/CreateServiceAccount.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+class CreateServiceAccount extends Command
+{
+    protected $signature = 'app:create-service-account
+        {email : Email for the service account}
+        {--name= : Display name (defaults to the title-cased email local-part)}';
+
+    protected $description = 'Create a locked, non-human user intended solely to own external API tokens.';
+
+    public function handle(): int
+    {
+        $email = $this->argument('email');
+
+        if (Validator::make(['email' => $email], ['email' => 'email'])->fails()) {
+            $this->error("'{$email}' is not a valid email address.");
+
+            return self::FAILURE;
+        }
+
+        if (User::where('email', $email)->exists()) {
+            $this->error("A user with email {$email} already exists.");
+
+            return self::FAILURE;
+        }
+
+        $user = User::create([
+            'name' => $this->option('name') ?: $this->deriveName($email),
+            'email' => $email,
+            'password' => Hash::make(Str::random(48)),
+            'password_change_at' => now(),
+            'is_service' => true,
+        ]);
+
+        $this->info("Service account created (id={$user->id}, email={$user->email}).");
+        $this->line("Issue a token for it with: php artisan app:issue-api-token {$user->email}");
+
+        return self::SUCCESS;
+    }
+
+    private function deriveName(string $email): string
+    {
+        return Str::of($email)->before('@')->replace(['.', '_', '-'], ' ')->title()->toString();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ class User extends Authenticatable
         'email',
         'password',
         'password_change_at',
+        'is_service',
         'deleted_at',
     ];
 
@@ -51,6 +52,7 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'is_service' => 'boolean',
     ];
 
     /**

--- a/database/migrations/2026_07_06_215129_add_is_service_to_users_table.php
+++ b/database/migrations/2026_07_06_215129_add_is_service_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_service')->default(false)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_service');
+        });
+    }
+};

--- a/tests/Feature/CreateServiceAccountCommandTest.php
+++ b/tests/Feature/CreateServiceAccountCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CreateServiceAccountCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_locked_service_account(): void
+    {
+        $this->artisan('app:create-service-account', ['email' => 'audit@service.local'])
+            ->assertExitCode(0);
+
+        $user = User::where('email', 'audit@service.local')->first();
+
+        $this->assertNotNull($user);
+        $this->assertTrue($user->is_service);
+        $this->assertNotNull($user->password_change_at);
+        $this->assertCount(0, $user->roles);
+    }
+
+    public function test_it_defaults_the_name_to_the_titlecased_email_local_part(): void
+    {
+        $this->artisan('app:create-service-account', ['email' => 'audit-service@service.local'])
+            ->assertExitCode(0);
+
+        $user = User::where('email', 'audit-service@service.local')->first();
+
+        $this->assertSame('Audit Service', $user->name);
+    }
+
+    public function test_it_respects_a_custom_name_option(): void
+    {
+        $this->artisan('app:create-service-account', [
+            'email' => 'svc@service.local',
+            '--name' => 'Reporting Bot',
+        ])->assertExitCode(0);
+
+        $this->assertSame('Reporting Bot', User::where('email', 'svc@service.local')->first()->name);
+    }
+
+    public function test_it_fails_when_the_email_already_exists(): void
+    {
+        User::factory()->create(['email' => 'taken@service.local']);
+
+        $this->artisan('app:create-service-account', ['email' => 'taken@service.local'])
+            ->assertExitCode(1);
+
+        $this->assertSame(1, User::where('email', 'taken@service.local')->count());
+    }
+
+    public function test_it_fails_for_an_invalid_email(): void
+    {
+        $this->artisan('app:create-service-account', ['email' => 'not-an-email'])
+            ->assertExitCode(1);
+
+        $this->assertSame(0, User::where('email', 'not-an-email')->count());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an artisan command to create locked, non-human **service accounts** whose sole purpose is to own external API tokens (issued separately via `app:issue-api-token`). This formalizes the manual process previously done via tinker.

```bash
php artisan app:create-service-account audit@service.local
php artisan app:create-service-account audit@service.local --name="Reporting Bot"
```

## What it does

- Validates the email and refuses duplicates (both exit `1`).
- Creates a locked user: random 48-char hashed password (no interactive login), `password_change_at` set so the `PasswordChanged` middleware isn't tripped, `is_service = true`, and **no role** (API access is scoped by token abilities, not roles).
- `--name` defaults to the title-cased email local-part (`audit-service` → "Audit Service").
- Prints the new id plus the follow-up `app:issue-api-token` hint.

## Changes

| File | Change |
|------|--------|
| `app/Console/Commands/CreateServiceAccount.php` | New command |
| `database/migrations/..._add_is_service_to_users_table.php` | Adds `is_service` boolean (default `false`) |
| `app/Models/User.php` | `is_service` fillable + boolean cast |
| `tests/Feature/CreateServiceAccountCommandTest.php` | 5 tests / 13 assertions |

## Out of scope

The `is_service` flag is stored but not yet used to hide service accounts from the human-user index — a deliberate follow-up.

## Testing

- New feature tests: **5 passed** (written test-first; RED verified before implementation).
- Related token-command tests: **16 passed**, no regression.
- Pint clean.

> Note: new databases need `php artisan migrate` for the `is_service` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)