### PR TITLE
fix: gate staff show page on 'view all staff' permission

### DIFF
--- a/app/Http/Controllers/InstitutionPersonController.php
+++ b/app/Http/Controllers/InstitutionPersonController.php
@@ -66,35 +66,35 @@ class InstitutionPersonController extends Controller
             ->with('person')
             ->currentUnit()
             ->currentRank()
-            ->when($request->rank_id, fn ($q, $rankId) => $q->filterByRank($rankId))
-            ->when($request->job_category_id, fn ($q, $categoryId) => $q->filterByJobCategory($categoryId))
-            ->when($request->unit_id, fn ($q, $unitId) => $q->filterByUnit($unitId))
-            ->when($request->department_id, fn ($q, $deptId) => $q->filterByDepartment($deptId))
-            ->when($request->gender, fn ($q, $gender) => $q->filterByGender($gender))
-            ->when($request->status, fn ($q, $status) => $q->filterByStatus($status))
+            ->when($request->rank_id, fn($q, $rankId) => $q->filterByRank($rankId))
+            ->when($request->job_category_id, fn($q, $categoryId) => $q->filterByJobCategory($categoryId))
+            ->when($request->unit_id, fn($q, $unitId) => $q->filterByUnit($unitId))
+            ->when($request->department_id, fn($q, $deptId) => $q->filterByDepartment($deptId))
+            ->when($request->gender, fn($q, $gender) => $q->filterByGender($gender))
+            ->when($request->status, fn($q, $status) => $q->filterByStatus($status))
             ->when(
                 $request->hire_date_from && $request->hire_date_to,
-                fn ($q) => $q->filterByHireDateRange($request->hire_date_from, $request->hire_date_to)
+                fn($q) => $q->filterByHireDateRange($request->hire_date_from, $request->hire_date_to)
             )
             ->when(
                 $request->hire_date_from && ! $request->hire_date_to,
-                fn ($q) => $q->filterByHireDateFrom($request->hire_date_from)
+                fn($q) => $q->filterByHireDateFrom($request->hire_date_from)
             )
             ->when(
                 $request->hire_date_to && ! $request->hire_date_from,
-                fn ($q) => $q->filterByHireDateTo($request->hire_date_to)
+                fn($q) => $q->filterByHireDateTo($request->hire_date_to)
             )
             ->when(
                 $request->age_from && $request->age_to,
-                fn ($q) => $q->filterByAgeRange($request->age_from, $request->age_to)
+                fn($q) => $q->filterByAgeRange($request->age_from, $request->age_to)
             )
             ->when(
                 $request->age_from && ! $request->age_to,
-                fn ($q) => $q->filterByAgeFrom($request->age_from)
+                fn($q) => $q->filterByAgeFrom($request->age_from)
             )
             ->when(
                 $request->age_to && ! $request->age_from,
-                fn ($q) => $q->filterByAgeTo($request->age_to)
+                fn($q) => $q->filterByAgeTo($request->age_to)
             )
             ->search($request->search)
             ->paginate(per_page())
@@ -165,12 +165,16 @@ class InstitutionPersonController extends Controller
      */
     public function show($staffId)
     {
-        if (request()->user()->cannot('view staff')) {
+        $user = request()->user();
+
+        if ($user->cannot('view staff')) {
             return redirect()->route('dashboard')->with('error', 'You do not have permission to view staff details');
         }
 
-        if (request()->user()->isStaff()) {
-            if (request()->user()->person->institution->first()->staff->id != $staffId) {
+        if ($user->cannot('view all staff')) {
+            $ownStaffId = $user->person?->institution->first()?->staff->id;
+
+            if ($ownStaffId != $staffId) {
                 return redirect()->route('dashboard')->with('error', 'You do not have permission to view details of this staff');
             }
         }
@@ -230,7 +234,7 @@ class InstitutionPersonController extends Controller
             'hire_date' => $staff->hire_date?->displayDate(),
             'retirement_date' => $staff->retirement_date_formatted,
             'start_date' => $staff->start_date,
-            'promotions' => $staff->ranks ? $staff->ranks->map(fn ($rank) => [
+            'promotions' => $staff->ranks ? $staff->ranks->map(fn($rank) => [
                 'id' => $rank->id,
                 'name' => $rank->name,
                 'start_date' => $rank->pivot->start_date?->displayDate(),

--- a/tests/Feature/StaffShowAuthorizationTest.php
+++ b/tests/Feature/StaffShowAuthorizationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Institution;
+use App\Models\InstitutionPerson;
+use App\Models\Person;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StaffShowAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Institution $institution;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->institution = Institution::factory()->create();
+    }
+
+    private function makeActiveStaff(): InstitutionPerson
+    {
+        $staff = InstitutionPerson::factory()->create([
+            'institution_id' => $this->institution->id,
+            'person_id' => Person::factory()->create()->id,
+        ]);
+
+        $staff->statuses()->create([
+            'status' => 'A',
+            'start_date' => now()->subYear(),
+            'institution_id' => $this->institution->id,
+        ]);
+
+        return $staff;
+    }
+
+    /**
+     * @param  array<string>  $permissions
+     */
+    private function userFor(InstitutionPerson $staff, array $permissions): User
+    {
+        $user = User::factory()->create(['person_id' => $staff->person_id]);
+
+        if ($permissions) {
+            $user->givePermissionTo($permissions);
+        }
+
+        return $user;
+    }
+
+    public function test_user_with_view_all_staff_who_is_also_employee_can_view_other_staff(): void
+    {
+        $adminStaff = $this->makeActiveStaff();
+        $admin = $this->userFor($adminStaff, ['view staff', 'view all staff']);
+
+        $otherStaff = $this->makeActiveStaff();
+
+        $response = $this->actingAs($admin)
+            ->get(route('staff.show', ['staff' => $otherStaff->id]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_staff_only_user_can_view_their_own_record(): void
+    {
+        $staff = $this->makeActiveStaff();
+        $user = $this->userFor($staff, ['view staff']);
+
+        $response = $this->actingAs($user)
+            ->get(route('staff.show', ['staff' => $staff->id]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_staff_only_user_cannot_view_another_staff(): void
+    {
+        $staff = $this->makeActiveStaff();
+        $user = $this->userFor($staff, ['view staff']);
+
+        $otherStaff = $this->makeActiveStaff();
+
+        $response = $this->actingAs($user)
+            ->get(route('staff.show', ['staff' => $otherStaff->id]));
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('error', 'You do not have permission to view details of this staff');
+    }
+
+    public function test_user_without_view_staff_permission_is_forbidden(): void
+    {
+        $staff = $this->makeActiveStaff();
+        $user = $this->userFor($staff, []);
+
+        $response = $this->actingAs($user)
+            ->get(route('staff.show', ['staff' => $staff->id]));
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Problem

`InstitutionPersonController::show()` restricted *any* user for whom `isStaff()` returns true to viewing only their own staff record. But `isStaff()` resolves to `Person::institution()->exists()` — i.e. **"is this person an employee of any institution"**, not **"has the staff role"**. As a result, an admin/HR user who is *also* an employee got locked out of every other staff's show page, despite holding the broad `view all staff` permission.

## Fix

Swap the ownership-gate discriminator from `isStaff()` to the existing **`view all staff`** permission — the same gate `index()` already uses for the full listing.

- Roles with `view all staff` (admin-user, aag-admin, hr-user, personel-user, general-admin-user, internal-audit-user, super-administrator) can view any staff page, whether or not they are themselves employees.
- The `staff` role — seeded with `view staff` but **not** `view all staff` — remains restricted to its own record.

The self-lookup chain is preserved but made null-safe (`?->`), since the block can now run for a `view staff`-only user without a linked person; they fall through to the denied redirect rather than erroring.

No new permission or migration needed — this just applies a distinction the seeders already define.

## Tests

New `tests/Feature/StaffShowAuthorizationTest.php` (4 passing):
- Employee-admin with `view all staff` can view **another** staff (the bug fix)
- Staff-only user can view **their own** record
- Staff-only user is redirected when requesting **another** staff
- User without `view staff` is `403` (route middleware `can:view staff`)

Adjacent `StaffCreationTest` (12) remains green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)